### PR TITLE
Register token

### DIFF
--- a/contracts/BatchAuction.sol
+++ b/contracts/BatchAuction.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-// import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 

--- a/contracts/BatchAuction.sol
+++ b/contracts/BatchAuction.sol
@@ -1,12 +1,22 @@
 pragma solidity ^0.5.0;
 
+// import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
-contract BatchAuction {
+
+contract BatchAuction is Ownable {
 
     uint16 public constant MAX_ACCOUNT_ID = 100;
+    uint8 public constant MAX_TOKENS = 30;
 
     mapping (address => uint16) public publicKeyToAccountMap;
     mapping (uint16 => address) public accountToPublicKeyMap;
+
+    uint8 public numTokens;
+    mapping (address => uint8) public tokenAddresToIdMap;
+    mapping (uint8 => address) public tokenIdToAddressMap;
+
+    event RegisteredToken(address tokenAddress, uint8 tokenId);
 
     function openAccount(uint16 accountId) public {
         require(accountId != 0, "Account index must be positive!");
@@ -19,4 +29,16 @@ contract BatchAuction {
         publicKeyToAccountMap[msg.sender] = accountId;
         accountToPublicKeyMap[accountId] = msg.sender;
     }
+
+    function addToken(address _tokenAddress) public onlyOwner() {
+        require(tokenAddresToIdMap[_tokenAddress] == 0, "Token already registered!");
+        require(numTokens + 1 <= MAX_TOKENS, "Token id exceeds max tokens");
+
+        tokenAddresToIdMap[_tokenAddress] = numTokens + 1;
+        tokenIdToAddressMap[numTokens + 1] = _tokenAddress;
+
+        numTokens++;
+        emit RegisteredToken(_tokenAddress, numTokens);
+    }
+
 }

--- a/contracts/BatchAuction.sol
+++ b/contracts/BatchAuction.sol
@@ -16,8 +16,6 @@ contract BatchAuction is Ownable {
     mapping (address => uint8) public tokenAddresToIdMap;
     mapping (uint8 => address) public tokenIdToAddressMap;
 
-    event RegisteredToken(address tokenAddress, uint8 tokenId);
-
     function openAccount(uint16 accountId) public {
         require(accountId != 0, "Account index must be positive!");
         require(accountId <= MAX_ACCOUNT_ID, "Account index exceeds max");
@@ -38,7 +36,6 @@ contract BatchAuction is Ownable {
         tokenIdToAddressMap[numTokens + 1] = _tokenAddress;
 
         numTokens++;
-        emit RegisteredToken(_tokenAddress, numTokens);
     }
 
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1296,6 +1296,11 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "openzeppelin-solidity": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.1.1.tgz",
+      "integrity": "sha512-kvVI/2n3oYfVYP53rUw+q6QNPlorwYRFaGu/Zs+TWFw2tKlnrz7UXh0UTWYd3Sfbq6eOo4XXnGv4bgcKguOrWg=="
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1482,6 +1482,11 @@
         "mimic-fn": "^1.0.0"
       }
     },
+    "openzeppelin-solidity": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.1.1.tgz",
+      "integrity": "sha512-kvVI/2n3oYfVYP53rUw+q6QNPlorwYRFaGu/Zs+TWFw2tKlnrz7UXh0UTWYd3Sfbq6eOo4XXnGv4bgcKguOrWg=="
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
     "url": "https://github.com/gnosis/dex-contracts/issues"
   },
   "homepage": "https://github.com/gnosis/dex-contracts#readme",
-  "dependencies": {},
+  "dependencies": {
+    "openzeppelin-solidity": "2.1.1"
+  },
   "devDependencies": {
     "eslint": "^5.12.0",
     "eslint-plugin-react": "^7.12.3",

--- a/test/auction_accounts.js
+++ b/test/auction_accounts.js
@@ -27,7 +27,7 @@ contract("BatchAuction", async (accounts) => {
     it("Do allow open account at index = maxAccountNumber", async () => {
       const instance = await BatchAuction.new()
       const max_account_id = (await instance.MAX_ACCOUNT_ID.call()).toNumber()
-      instance.openAccount(max_account_id)
+      await instance.openAccount(max_account_id)
       assert.equal(max_account_id, (await instance.publicKeyToAccountMap.call(owner)).toNumber())
     })
 
@@ -49,7 +49,7 @@ contract("BatchAuction", async (accounts) => {
     it("Can't open two accounts at same index", async () => {
       const instance = await BatchAuction.new()
       const account_index = 1
-      instance.openAccount(account_index)
+      await instance.openAccount(account_index)
 
       // Account owner can't open another
       await assertRejects(instance.openAccount(account_index))
@@ -62,7 +62,7 @@ contract("BatchAuction", async (accounts) => {
       const instance = await BatchAuction.new()
       
       for (let i = 0; i < accounts.length; i++) {
-        instance.openAccount(i+1, { from: accounts[i] })
+        await instance.openAccount(i+1, { from: accounts[i] })
 
         assert.equal(i+1, (await instance.publicKeyToAccountMap.call(accounts[i])).toNumber())
         assert.equal(accounts[i], await instance.accountToPublicKeyMap.call(i+1))
@@ -75,13 +75,13 @@ contract("BatchAuction", async (accounts) => {
       const instance = await BatchAuction.new()
 
       const token_1 = await ERC20.new()
-      instance.addToken(token_1.address)
+      await instance.addToken(token_1.address)
 
       assert.equal((await instance.tokenAddresToIdMap.call(token_1.address)).toNumber(), 1)
       assert.equal(await instance.tokenIdToAddressMap.call(1), token_1.address)
 
       const token_2 = await ERC20.new()
-      instance.addToken(token_2.address)
+      await instance.addToken(token_2.address)
 
       assert.equal((await instance.tokenAddresToIdMap.call(token_2.address)).toNumber(), 2)
       assert.equal(await instance.tokenIdToAddressMap.call(2), token_2.address)
@@ -99,7 +99,7 @@ contract("BatchAuction", async (accounts) => {
       const instance = await BatchAuction.new()
       const token = await ERC20.new()
 
-      instance.addToken(token.address)
+      await instance.addToken(token.address)
       await assertRejects(instance.addToken(token.address))
     })
 
@@ -108,7 +108,7 @@ contract("BatchAuction", async (accounts) => {
       const max_tokens = (await instance.MAX_TOKENS.call()).toNumber()
 
       for (let i = 1; i < max_tokens + 1; i++) {
-        instance.addToken((await ERC20.new()).address)
+        await instance.addToken((await ERC20.new()).address)
       }
       // Last token can't be added (exceeds limit)
       await assertRejects(instance.addToken((await ERC20.new()).address))

--- a/test/auction_accounts.js
+++ b/test/auction_accounts.js
@@ -76,7 +76,6 @@ contract("BatchAuction", async (accounts) => {
 
       const token_1 = await ERC20.new()
       await instance.addToken(token_1.address)
-      instance.addToken(token_1.address)
 
       assert.equal((await instance.tokenAddresToIdMap.call(token_1.address)).toNumber(), 1)
       assert.equal(await instance.tokenIdToAddressMap.call(1), token_1.address)


### PR DESCRIPTION
Token addresses and ids are stored analogously to accounts in two mappings, although here, we keep track of the numTokens and increment them on each addition. 

There is no internal check whether the token address being registered actually contains code for an ERC20 token (which could be undesired), but the security is enforced by only allowing contract owner to register tokens.

One will notice that ERC20 token is imported, but not used. This was required to be compiled in the build so that unit tests can use it. 