### PR TITLE
#11 emit event on contract deploy.

### DIFF
--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -34,6 +34,7 @@ contract SnappBase is Ownable {
 
     event Deposit(uint16 accountId, uint8 tokenId, uint amount, uint slot, uint16 slotIndex);
     event StateTransition(TransitionType transitionType, bytes32 from, bytes32 to);
+    event SnappInitialization(bytes32 stateHash, uint8 maxTokens, uint16 maxAccounts);
 
     modifier onlyRegistered() {
         require(publicKeyToAccountMap[msg.sender] != 0, "Must have registered account");
@@ -42,7 +43,9 @@ contract SnappBase is Ownable {
 
     constructor () public {
         // The initial state should be Pederson hash of an empty balance tree
-        stateRoots.push(0);
+        bytes32 stateInit = bytes32(0);  // TODO
+        stateRoots.push(stateInit);
+        emit SnappInitialization(stateInit, MAX_TOKENS, MAX_ACCOUNT_ID);
     }
 
     function openAccount(uint16 accountId) public {


### PR DESCRIPTION
This enables the event listener to initialize account balances according to the initial state hash with the values for max accounts and max tokens.