### PR TITLE
new getters

### DIFF
--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -112,4 +112,12 @@ contract SnappBase is Ownable {
         depositHashes[slot].applied = true;
         emit StateTransition(TransitionType.Deposit, _currStateRoot, _newStateRoot);
     }
+
+    function hasDepositBeenApplied(uint index) public view returns (bool) {
+        return depositHashes[index].applied;
+    }
+
+    function getCurrentStateRoot() public view returns (bytes32) {
+        return stateRoots[stateIndex()];
+    }
 }

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -46,11 +46,11 @@ module.exports = {
     // tab if you use this network and you must also set the `host`, `port` and `network_id`
     // options below to some value.
     //
-    // development: {
-    //  host: "127.0.0.1",     // Localhost (default: none)
-    //  port: 8545,            // Standard Ethereum port (default: none)
-    //  network_id: "*",       // Any network (default: none)
-    // },
+     development: {
+      host: "127.0.0.1",     // Localhost (default: none)
+      port: 8545,            // Standard Ethereum port (default: none)
+      network_id: "*",       // Any network (default: none)
+     },
 
     // Another network with more advanced options...
     // advanced: {


### PR DESCRIPTION
I need these getters for my driver


Additional to the getter functions I "uncommented" the networksettings for development. This makes the truffle setup easier on my machine. Is this okay? Why don't we have any truffle settings? Or is this just a backup setting file and I should have my config in truffle.js?