### PR TITLE
Deals with reorgs in deposits by throwing in apply deposit

### DIFF
--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -119,13 +119,13 @@ contract SnappBase is Ownable {
         uint slot,
         bytes32 _currStateRoot,
         bytes32 _newStateRoot,
-        bytes32 _depositHash,
+        bytes32 _depositHash
     )
         public onlyOwner()
     {   
         require(slot <= depositIndex, "Requested deposit slot does not exist");
         require(slot == 0 || deposits[slot-1].appliedAccountStateIndex != 0, "Must apply deposit slots in order!");
-        require(deposits[slot].depositHash == depositHash, "Deposits have been reorged");
+        require(deposits[slot].shaHash == _depositHash, "Deposits have been reorged");
         require(deposits[slot].appliedAccountStateIndex == 0, "Deposits already processed");
         require(block.number > deposits[slot].creationBlock + 20, "Requested deposit slot is still active");
         require(stateRoots[stateIndex()] == _currStateRoot, "Incorrect State Root");

--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -118,13 +118,14 @@ contract SnappBase is Ownable {
     function applyDeposits(
         uint slot,
         bytes32 _currStateRoot,
-        bytes32 _newStateRoot
+        bytes32 _newStateRoot,
+        bytes32 _depositHash,
     )
         public onlyOwner()
     {   
         require(slot <= depositIndex, "Requested deposit slot does not exist");
-
         require(slot == 0 || deposits[slot-1].appliedAccountStateIndex != 0, "Must apply deposit slots in order!");
+        require(deposits[slot].depositHash == depositHash, "Deposits have been reorged");
         require(deposits[slot].appliedAccountStateIndex == 0, "Deposits already processed");
         require(block.number > deposits[slot].creationBlock + 20, "Requested deposit slot is still active");
         require(stateRoots[stateIndex()] == _currStateRoot, "Incorrect State Root");

--- a/scripts/apply_deposits.js
+++ b/scripts/apply_deposits.js
@@ -15,6 +15,9 @@ module.exports = async (callback) => {
         console.log("Warning: Requested deposit slot has already been applied")
         callback()
     }
+    console.log("Current slot for :", slot , " with curr_state", curr_state, " and new_state", new_state)
     const tx = await instance.applyDeposits(slot, curr_state, new_state)
+    const deposit_state2 = await instance.deposits.call(slot)
+    console.log("New appliedAccountStateIndex is:",deposit_state2.appliedAccountStateIndex )
     callback()
 }

--- a/scripts/apply_deposits.js
+++ b/scripts/apply_deposits.js
@@ -15,8 +15,9 @@ module.exports = async (callback) => {
         console.log("Warning: Requested deposit slot has already been applied")
         callback()
     }
+
     console.log("Current slot for :", slot , " with curr_state", curr_state, " and new_state", new_state)
-    const tx = await instance.applyDeposits(slot, curr_state, new_state)
+    const tx = await instance.applyDeposits(slot, curr_state, new_state, deposit_state.shaHash)
     const deposit_state2 = await instance.deposits.call(slot)
     console.log("New appliedAccountStateIndex is:",deposit_state2.appliedAccountStateIndex )
     callback()

--- a/scripts/mineBlocks.js
+++ b/scripts/mineBlocks.js
@@ -1,0 +1,15 @@
+module.exports = async () => {
+  const [times] = await process.argv.slice(4)
+
+  const mineOneBlock = async (id) => web3.currentProvider.send({
+    jsonrpc: "2.0",
+    method: "evm_mine",
+    params: [],
+    id,
+  }, (err, res) => !err ? console.log(res) : err )
+
+  for (let i = 0; i < times; ++i) {
+    await mineOneBlock(i)
+  }
+  console.log("mined", times, "blocks")
+}


### PR DESCRIPTION
We need to have the deposithash in the applyDeposit function as a parameter to make sure that if a reorg happens and the depositHash is different, the drivers applyDeposit transaction is not going through.

Cherry on top: 
mine several blocks with truffle script