### PR TITLE
Successful Generic ClaimWithdraw Test

### DIFF
--- a/contracts/Merkle.sol
+++ b/contracts/Merkle.sol
@@ -30,9 +30,9 @@ library Merkle {
             }
             /* solhint-enable no-inline-assembly */
             if (index % 2 == 0) {
-                computedHash = keccak256(abi.encodePacked(computedHash, proofElement));
+                computedHash = sha256(abi.encodePacked(computedHash, proofElement));
             } else {
-                computedHash = keccak256(abi.encodePacked(proofElement, computedHash));
+                computedHash = sha256(abi.encodePacked(proofElement, computedHash));
             }
             index = index / 2;
         }

--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -249,9 +249,7 @@ contract SnappBase is Ownable {
         uint128 amount,
         bytes memory proof
     ) public {
-        // No need to check token because wouldn't pass Merkle proof if unregistered
-        // require(tokenIdToAddressMap[tokenId] != address(0), "Requested token is not registered");
-
+        // No need to check tokenId or accountId (wouldn't pass merkle proof if unregistered).
         require(
             pendingWithdraws[withdrawSlot].appliedAccountStateIndex > 0,
             "Requested slot has not been processed"

--- a/test/merkle.js
+++ b/test/merkle.js
@@ -1,7 +1,7 @@
 const MerkleWrapper = artifacts.require("MerkleWrapper")
 
 const MerkleTree = require("merkletreejs")
-const { keccak256 } = require("ethereumjs-util")
+const { sha256 } = require("ethereumjs-util")
 
 const {
   assertRejects,
@@ -12,8 +12,8 @@ const {
 contract("Merkle", () => {
 
   describe("Height 2 \"all\" permutations", function () {
-    const leaves = ["0", "1", "2", "3"].map(x => keccak256(x))
-    const tree = new MerkleTree(leaves, keccak256)
+    const leaves = ["0", "1", "2", "3"].map(x => sha256(x))
+    const tree = new MerkleTree(leaves, sha256)
     const proofs = leaves.map(x => tree.getProof(x))
     
     const concatenated_proofs = proofs.map(pf => Buffer.concat(pf.map(x => x.data)))

--- a/test/snapp_base.js
+++ b/test/snapp_base.js
@@ -53,10 +53,9 @@ contract("SnappBase", async (accounts) => {
       assert.equal((await instance.getDepositCreationBlock.call(0)).toNumber(), tx.blockNumber)
     })
 
-    it("getDepositHash(slot)", async () => {
+    it.only("getDepositHash(slot)", async () => {
       const instance = await SnappBase.new()
-      const deposit_init = "0x0000000000000000000000000000000000000000000000000000000000000000"
-      assert.equal(await instance.getDepositHash.call(0), deposit_init)
+      assert.equal(await instance.getDepositHash.call(0), 0x0)
     })
 
   })

--- a/test/snapp_base.js
+++ b/test/snapp_base.js
@@ -53,7 +53,7 @@ contract("SnappBase", async (accounts) => {
       assert.equal((await instance.getDepositCreationBlock.call(0)).toNumber(), tx.blockNumber)
     })
 
-    it.only("getDepositHash(slot)", async () => {
+    it("getDepositHash(slot)", async () => {
       const instance = await SnappBase.new()
       assert.equal(await instance.getDepositHash.call(0), 0x0)
     })

--- a/test/snapp_utils.js
+++ b/test/snapp_utils.js
@@ -25,8 +25,33 @@ const stateHash = async function(contract) {
   return state_root
 }
 
+// returns byte string of hexed-sliced-padded int
+const uint8 = function(num) {
+  assert(num < 2**8)
+  return web3.utils.toHex(num).slice(2).padStart(2, "0")
+
+}
+
+// returns byte string of hexed-sliced-padded int
+const uint16 = function(num) {
+  assert(num < 2**16)
+  return web3.utils.toHex(num).slice(2).padStart(4, "0")
+}
+
+// returns byte string of hexed-sliced-padded int
+const uint128 = function(num) {
+  assert(num < 2**128)
+  return web3.utils.toHex(num).slice(2).padStart(32, "0")
+}
+
+// returns equivalent to Soliditiy's abi.encodePacked(uint16 a, uint8 b, uint128 c)
+const encodePacked_16_8_128 = function(a, b, c) {
+  return "0x" + uint16(a) + uint8(b) + uint128(c)
+}
+
 module.exports = {
   falseArray,
   isActive,
-  stateHash
+  stateHash,
+  encodePacked_16_8_128
 }

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -118,7 +118,6 @@ const countDuplicates = function(obj, num) {
   return obj
 }
 
-
 /**
  * Given a sequence of index1, elements1, ..., indexN elementN this function returns 
  * the corresponding MerkleTree of height 7.
@@ -134,18 +133,6 @@ const generateMerkleTree = memoize(_generateMerkleTree, {
   strategy: memoize.strategies.variadic
 })
 
-// returns byte string of hexed-sliced-padded int
-const encode_as_uint8 = function(num) {
-  assert(num < 2**8)
-  return web3.utils.toHex(num).slice(2).padStart(2, "0")
-}
-
-// returns byte string of hexed-sliced-padded int
-const encode_as_uint16 = function(num) {
-  assert(num < 2**16)
-  return web3.utils.toHex(num).slice(2).padStart(4, "0")
-}
-
 module.exports = {
   assertRejects,
   waitForNBlocks,
@@ -157,6 +144,4 @@ module.exports = {
   toHex,
   countDuplicates,
   generateMerkleTree,
-  encode_as_uint8,
-  encode_as_uint16,
 }


### PR DESCRIPTION
- Merkle to use sha256. 

- Simulate Solidity's abi.encodePacked for our particular use case. 

Closes #28 & #29 