### PR TITLE
[easy] Small reorg of SnappBase code

### DIFF
--- a/test/snapp_base.js
+++ b/test/snapp_base.js
@@ -41,11 +41,6 @@ contract("SnappBase", async (accounts) => {
       assert.equal(await instance.hasDepositBeenApplied.call(0), false)
     })
 
-    it("isDepositSlotEmpty(slot)", async () => {
-      const instance = await SnappBase.new()
-      assert.equal(await instance.isDepositSlotEmpty.call(0), true)
-    })
-
     it("getDepositCreationBlock(slot)", async () => {
       const instance = await SnappBase.new()
       const tx = await web3.eth.getTransaction(instance.transactionHash)


### PR DESCRIPTION
1) Putting all view methods together (removing `isDepositSlotEmpty`, since it can be derived from `getDepositHash`)
2) Small changes to comments