### PR TITLE
Apply Withdraw Script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "setup": "npx truffle exec scripts/setup_environment.js",
     "deposit": "npx truffle exec scripts/deposit.js",
     "apply-deposits": "npx truffle exec scripts/apply_deposits.js",
-    "mine-blocks": "npx truffle exec scripts/mine_blocks.js"
+    "mine-blocks": "npx truffle exec scripts/mine_blocks.js",
+    "withdraw-request": "npx truffle exec scripts/request_withdraw.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "deposit": "npx truffle exec scripts/deposit.js",
     "apply-deposits": "npx truffle exec scripts/apply_deposits.js",
     "mine-blocks": "npx truffle exec scripts/mine_blocks.js",
-    "withdraw-request": "npx truffle exec scripts/request_withdraw.js"
+    "request-withdraw": "npx truffle exec scripts/request_withdraw.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "deposit": "npx truffle exec scripts/deposit.js",
     "apply-deposits": "npx truffle exec scripts/apply_deposits.js",
     "mine-blocks": "npx truffle exec scripts/mine_blocks.js",
-    "request-withdraw": "npx truffle exec scripts/request_withdraw.js"
+    "request-withdraw": "npx truffle exec scripts/request_withdraw.js",
+    "apply-withdrawals": "npx truffle exec scripts/apply_withdrawals.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/apply_deposits.js
+++ b/scripts/apply_deposits.js
@@ -18,10 +18,10 @@ module.exports = async (callback) => {
       callback("Error: Requested deposit slot has already been applied")
     }
 
-    console.log("Current slot for :", slot , " with curr_state", curr_state, " and new_state", new_state)
+    console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
     await instance.applyDeposits(slot, curr_state, new_state, deposit_state.shaHash)
-    const deposit_state2 = await instance.deposits.call(slot)
-    console.log("New appliedAccountStateIndex is:",deposit_state2.appliedAccountStateIndex )
+    const updated_state = await instance.deposits.call(slot)
+    console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex )
     callback()
   } catch (error) {
     callback(error)

--- a/scripts/apply_deposits.js
+++ b/scripts/apply_deposits.js
@@ -21,7 +21,7 @@ module.exports = async (callback) => {
     console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
     await instance.applyDeposits(slot, curr_state, new_state, deposit_state.shaHash)
     const updated_state = await instance.deposits.call(slot)
-    console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex )
+    console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex.toNumber())
     callback()
   } catch (error) {
     callback(error)

--- a/scripts/apply_deposits.js
+++ b/scripts/apply_deposits.js
@@ -20,7 +20,7 @@ module.exports = async (callback) => {
     console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
     await instance.applyDeposits(slot, curr_state, new_state, deposit_state.shaHash)
     const updated_state = await instance.deposits.call(slot)
-    console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex )
+    console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex.toNumber())
     callback()
   } catch (error) {
     callback(error)

--- a/scripts/apply_deposits.js
+++ b/scripts/apply_deposits.js
@@ -21,6 +21,7 @@ module.exports = async (callback) => {
     console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
     await instance.applyDeposits(slot, curr_state, new_state, deposit_state.shaHash)
     const updated_state = await instance.deposits.call(slot)
+    console.log("Successfully applied Deposits!")
     console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex.toNumber())
     callback()
   } catch (error) {

--- a/scripts/apply_deposits.js
+++ b/scripts/apply_deposits.js
@@ -20,6 +20,7 @@ module.exports = async (callback) => {
     console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
     await instance.applyDeposits(slot, curr_state, new_state, deposit_state.shaHash)
     const updated_state = await instance.deposits.call(slot)
+    console.log("Successfully applied Deposits!")
     console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex.toNumber())
     callback()
   } catch (error) {

--- a/scripts/apply_withdrawals.js
+++ b/scripts/apply_withdrawals.js
@@ -1,0 +1,28 @@
+const SnappBase = artifacts.require("SnappBase")
+
+module.exports = async (callback) => {
+  try {
+    const arguments = await process.argv.slice(4)
+    if (arguments.length != 4) {
+      callback("Error: This script requires arguments - <slot> <inclusion bitMap> <merkle root> <new state root>")
+    }
+    const [slot, bitmap, merkle_root, new_state] = arguments
+    
+    const instance = await SnappBase.deployed()
+    const state_index = (await instance.stateIndex.call()).toNumber()
+    const curr_state = await instance.stateRoots.call(state_index)
+
+    const withdraw_state = await instance.pendingWithdraws.call(slot)
+    if (withdraw_state.appliedAccountStateIndex != 0) {
+      callback("Error: Requested withdraw slot has already been applied")
+    }
+
+    console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
+    await instance.applyWithdrawals(slot, bitmap, merkle_root, curr_state, new_state, withdraw_state.shaHash)
+    const updated_state = await instance.pendingWithdraws.call(slot)
+    console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex )
+    callback()
+  } catch (error) {
+    callback(error)
+  }
+}

--- a/scripts/apply_withdrawals.js
+++ b/scripts/apply_withdrawals.js
@@ -10,6 +10,14 @@ module.exports = async (callback) => {
     const [slot, bitmap, merkle_root, new_state] = arguments
     
     const instance = await SnappBase.deployed()
+
+    // Check bitMap is of correct length
+    const expectedBitmapLength = (await instance.MAX_WITHDRAW_BATCH_SIZE.call()).toNumber()
+    if (bitmap.length != expectedBitmapLength) {
+      const msg = "Error: Bitmap must be boolean array of length " + expectedBitmapLength
+      callback(msg)
+    }
+
     const state_index = (await instance.stateIndex.call()).toNumber()
     const curr_state = await instance.stateRoots.call(state_index)
 

--- a/scripts/apply_withdrawals.js
+++ b/scripts/apply_withdrawals.js
@@ -1,13 +1,11 @@
 const SnappBase = artifacts.require("SnappBase")
-
-// TODO - may adjust inclusion bitmap to expect shorter input
-// const { falseArray }  = require("../test/snapp_utils.js")
+const getArgumentsHelper = require("./script_utilities.js")
 
 module.exports = async (callback) => {
   try {
-    const arguments = await process.argv.slice(4)
+    const arguments = getArgumentsHelper()
     if (arguments.length != 4) {
-      callback("Error: This script requires arguments - <slot> <inclusion bitMap> <merkle root> <new state root>")
+      callback("Error: This script requires arguments - <slot> <inclusionBitmap> <merkleRoot> <newStateRoot>")
     }
     const [slot, bitmap, merkle_root, new_state] = arguments
     

--- a/scripts/apply_withdrawals.js
+++ b/scripts/apply_withdrawals.js
@@ -1,5 +1,8 @@
 const SnappBase = artifacts.require("SnappBase")
 
+// TODO - may adjust inclusion bitmap to expect shorter input
+// const { falseArray }  = require("../test/snapp_utils.js")
+
 module.exports = async (callback) => {
   try {
     const arguments = await process.argv.slice(4)
@@ -20,6 +23,7 @@ module.exports = async (callback) => {
     console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
     await instance.applyWithdrawals(slot, bitmap, merkle_root, curr_state, new_state, withdraw_state.shaHash)
     const updated_state = await instance.pendingWithdraws.call(slot)
+    console.log("Successfully applied Withdrawals!")
     console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex.toNumber())
     callback()
   } catch (error) {

--- a/scripts/apply_withdrawals.js
+++ b/scripts/apply_withdrawals.js
@@ -20,7 +20,7 @@ module.exports = async (callback) => {
     console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
     await instance.applyWithdrawals(slot, bitmap, merkle_root, curr_state, new_state, withdraw_state.shaHash)
     const updated_state = await instance.pendingWithdraws.call(slot)
-    console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex )
+    console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex.toNumber())
     callback()
   } catch (error) {
     callback(error)

--- a/scripts/apply_withdrawals.js
+++ b/scripts/apply_withdrawals.js
@@ -3,23 +3,23 @@ const SnappBase = artifacts.require("SnappBase")
 module.exports = async (callback) => {
   try {
     const arguments = await process.argv.slice(4)
-    if (arguments.length != 2) {
-      callback("Error: This script requires arguments - <slot> <new state root>")
+    if (arguments.length != 4) {
+      callback("Error: This script requires arguments - <slot> <inclusion bitMap> <merkle root> <new state root>")
     }
-    const [slot, new_state] = arguments
+    const [slot, bitmap, merkle_root, new_state] = arguments
     
     const instance = await SnappBase.deployed()
     const state_index = (await instance.stateIndex.call()).toNumber()
     const curr_state = await instance.stateRoots.call(state_index)
 
-    const deposit_state = await instance.deposits.call(slot)
-    if (deposit_state.appliedAccountStateIndex != 0) {
-      callback("Error: Requested deposit slot has already been applied")
+    const withdraw_state = await instance.pendingWithdraws.call(slot)
+    if (withdraw_state.appliedAccountStateIndex != 0) {
+      callback("Error: Requested withdraw slot has already been applied")
     }
 
     console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
-    await instance.applyDeposits(slot, curr_state, new_state, deposit_state.shaHash)
-    const updated_state = await instance.deposits.call(slot)
+    await instance.applyWithdrawals(slot, bitmap, merkle_root, curr_state, new_state, withdraw_state.shaHash)
+    const updated_state = await instance.pendingWithdraws.call(slot)
     console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex )
     callback()
   } catch (error) {

--- a/scripts/request_withdraw.js
+++ b/scripts/request_withdraw.js
@@ -1,0 +1,33 @@
+const SnappBase = artifacts.require("SnappBase")
+const zero_address = 0x0
+
+module.exports = async (callback) => {
+  try {
+    const arguments = await process.argv.slice(4)
+    if (arguments.length != 3) {
+      callback("Error: This script requires arguments - <accountId> <tokenId> <withdraw amount>")
+    }
+    const [accountId, tokenId, amount] = arguments
+    
+    const instance = await SnappBase.deployed()
+    const depositor = await instance.accountToPublicKeyMap.call(accountId)
+    if (depositor == zero_address) {
+      callback(`Error: No account registerd at index ${accountId}`)
+    }
+  
+    const token_address = await instance.tokenIdToAddressMap.call(tokenId)
+    if (token_address == zero_address) {
+      callback(`Error: No token registered at index ${tokenId}`)
+    }
+  
+    const tx = await instance.requestWithdrawal(tokenId, amount, {from: depositor})
+    const slot = tx.logs[0].args.slot.toNumber()
+    const slot_index = tx.logs[0].args.slotIndex.toNumber()
+  
+    const withdraw_hash = (await instance.pendingWithdraws(slot)).shaHash
+    console.log("Withdraw Request successful: Slot %s - Index %s - Hash %s", slot, slot_index, withdraw_hash)
+    callback()
+  } catch(error) {
+    callback(error)
+  }
+}

--- a/scripts/request_withdraw.js
+++ b/scripts/request_withdraw.js
@@ -1,11 +1,12 @@
 const SnappBase = artifacts.require("SnappBase")
 const zero_address = 0x0
+const getArgumentsHelper = require("./script_utilities.js")
 
 module.exports = async (callback) => {
   try {
-    const arguments = await process.argv.slice(4)
+    const arguments = getArgumentsHelper()
     if (arguments.length != 3) {
-      callback("Error: This script requires arguments - <accountId> <tokenId> <withdraw amount>")
+      callback("Error: This script requires arguments - <accountId> <tokenId> <withdrawAmount>")
     }
     const [accountId, tokenId, amount] = arguments
     


### PR DESCRIPTION
This is version is currently working, but the bitmap requirement as an argument is going to be annoying. Some ways that might make it easier is to pass one of the following flags

- "FullBitMap" - an array of all `true`
- "NullBitMap" - an array of all `false`
- "ExclusionIndices" - a list of indices for which the withdraw was excluded
- "InclusionIndices" - a list of indices for which the withdraw was included

Currently this can be tested as follows, 

```
npm run apply-withdrawals <slot: int> <bitmap: bool[100]> <merkleRoot: bytes32> <newState: bytes32>

I still want to include some assertions on the contents of the bitmap here. However, it is working in its current state.


