### PR TITLE
[Easy] Fix applyWithdraw script

### DIFF
--- a/scripts/apply_withdrawals.js
+++ b/scripts/apply_withdrawals.js
@@ -27,7 +27,7 @@ module.exports = async (callback) => {
     }
 
     console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
-    await instance.applyWithdrawals(slot, bitmap, merkle_root, curr_state, new_state, withdraw_state.shaHash)
+    await instance.applyWithdrawals(slot, Array.from(bitmap).map(b => b == "0"), merkle_root, curr_state, new_state, withdraw_state.shaHash)
     const updated_state = await instance.pendingWithdraws.call(slot)
     console.log("Successfully applied Withdrawals!")
     console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex.toNumber())


### PR DESCRIPTION
It's currently impossible to pass arguments into the script that are accepted by the script as well as by web3.

The script requires the input string to be of length 100 (with 100 elements). Thus the only way to encode a bitmap is as string with 100 characters (each 0 or 1). However, this is not recognised by the web3 library as a valid bit-array.

This PR transforms the input string into a valid bit array.

Test by running:
```
truffle exec scripts/apply_withdrawals.js 1 0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 0x0000000000000000000000000000000000000000000000000000000000000002 0x0000000000000000000000000000000000000000000000000000000000000002
```