### PR TITLE
remove bitmap from applyWithdrawal

### DIFF
--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -45,7 +45,7 @@ contract SnappBase is Ownable {
 
     struct ClaimableWithdrawState {
         bytes32 merkleRoot;            // Merkle root of claimable withdraws in this block
-        bool[100] claimedBitmap;       // Bitmap signalling which withdraws have been claimed
+        bool[] claimedBitmap;          // Bitmap signalling which withdraws have been claimed
         uint appliedAccountStateIndex; // AccountState when this state was created (for rollback)
     }
 
@@ -247,12 +247,10 @@ contract SnappBase is Ownable {
         // Update account states
         stateRoots.push(_newStateRoot);
         pendingWithdraws[slot].appliedAccountStateIndex = stateIndex();
-        
-        bool[MAX_WITHDRAW_BATCH_SIZE] memory nullArray;
 
         claimableWithdraws[slot] = ClaimableWithdrawState({
             merkleRoot: _merkleRoot,
-            claimedBitmap: nullArray,
+            claimedBitmap: new bool[](MAX_WITHDRAW_BATCH_SIZE),
             appliedAccountStateIndex: stateIndex()
         });
 

--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -43,8 +43,6 @@ contract SnappBase is Ownable {
     uint public withdrawIndex;
     mapping (uint => PendingFlux) public pendingWithdraws;
 
-    bool[100] private nullArray;
-
     struct ClaimableWithdrawState {
         bytes32 merkleRoot;            // Merkle root of claimable withdraws in this block
         bool[100] claimedBitmap;       // Bitmap signalling which withdraws have been claimed
@@ -250,6 +248,8 @@ contract SnappBase is Ownable {
         stateRoots.push(_newStateRoot);
         pendingWithdraws[slot].appliedAccountStateIndex = stateIndex();
         
+        bool[MAX_WITHDRAW_BATCH_SIZE] memory nullArray;
+
         claimableWithdraws[slot] = ClaimableWithdrawState({
             merkleRoot: _merkleRoot,
             claimedBitmap: nullArray,

--- a/scripts/apply_withdrawals.js
+++ b/scripts/apply_withdrawals.js
@@ -4,19 +4,12 @@ const getArgumentsHelper = require("./script_utilities.js")
 module.exports = async (callback) => {
   try {
     const arguments = getArgumentsHelper()
-    if (arguments.length != 4) {
-      callback("Error: This script requires arguments - <slot> <inclusionBitmap> <merkleRoot> <newStateRoot>")
+    if (arguments.length != 3) {
+      callback("Error: This script requires arguments - <slot> <merkleRoot> <newStateRoot>")
     }
     const [slot, bitmap, merkle_root, new_state] = arguments
     
     const instance = await SnappBase.deployed()
-
-    // Check bitMap is of correct length
-    const expectedBitmapLength = (await instance.MAX_WITHDRAW_BATCH_SIZE.call()).toNumber()
-    if (bitmap.length != expectedBitmapLength) {
-      const msg = "Error: Bitmap must be boolean array of length " + expectedBitmapLength
-      callback(msg)
-    }
 
     const state_index = (await instance.stateIndex.call()).toNumber()
     const curr_state = await instance.stateRoots.call(state_index)

--- a/scripts/apply_withdrawals.js
+++ b/scripts/apply_withdrawals.js
@@ -7,7 +7,7 @@ module.exports = async (callback) => {
     if (arguments.length != 3) {
       callback("Error: This script requires arguments - <slot> <merkleRoot> <newStateRoot>")
     }
-    const [slot, bitmap, merkle_root, new_state] = arguments
+    const [slot, merkle_root, new_state] = arguments
     
     const instance = await SnappBase.deployed()
 
@@ -20,7 +20,7 @@ module.exports = async (callback) => {
     }
 
     console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
-    await instance.applyWithdrawals(slot, bitmap, merkle_root, curr_state, new_state, withdraw_state.shaHash)
+    await instance.applyWithdrawals(slot, merkle_root, curr_state, new_state, withdraw_state.shaHash)
     const updated_state = await instance.pendingWithdraws.call(slot)
     console.log("Successfully applied Withdrawals!")
     console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex.toNumber())


### PR DESCRIPTION
Solves #40 

No need to pass bitmap into `applyWithdrawals`, now it is defaulted to false and set to true when a successful claim is made. 