### PR TITLE
Not hashing the leafs for withdraw inclusion proofs

### DIFF
--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -286,9 +286,9 @@ contract SnappBase is Ownable {
         require(pendingWithdraws[slot].appliedAccountStateIndex > 0, "Requested slot has not been processed");
         require(claimableWithdraws[slot].claimedBitmap[inclusionIndex] == false, "Already claimed");
         
-        bytes32 leaf = sha256(abi.encodePacked(accountId, tokenId, amount));
+        uint leaf = uint(amount) + (uint(tokenId) << 128) + (uint(accountId) << 136);
         require(
-            leaf.checkMembership(inclusionIndex, claimableWithdraws[slot].merkleRoot, proof, 7),
+            bytes32(leaf).checkMembership(inclusionIndex, claimableWithdraws[slot].merkleRoot, proof, 7),
             "Failed Merkle membership check."
         );
         // Set claim bitmap to true (indicating that funds have been claimed).

--- a/package-lock.json
+++ b/package-lock.json
@@ -116,7 +116,8 @@
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
     },
     "astral-regex": {
       "version": "1.0.0",
@@ -494,8 +495,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1554,7 +1554,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -1803,7 +1803,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -2653,6 +2653,7 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/truffle-assertions/-/truffle-assertions-0.8.0.tgz",
       "integrity": "sha512-Yl99rj8s3/9RMvsCtBhrpYk+68tw+rPoGy4PDuI5FJJNpG89boDWS5ybyKSMD+JDTPjXJHwsILo6+OQAwGqYZg==",
+      "dev": true,
       "requires": {
         "assertion-error": "^1.1.0"
       }
@@ -2750,7 +2751,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/scripts/claim_withdraw.js
+++ b/scripts/claim_withdraw.js
@@ -1,4 +1,5 @@
 const SnappBase = artifacts.require("SnappBase")
+const ERC20 = artifacts.require("ERC20")
 const zero_address = 0x0
 const getArgumentsHelper = require("./script_utilities.js")
 
@@ -10,7 +11,7 @@ const { toHex } = require("../test/utilities.js")
 
 const MongoClient = require("mongodb").MongoClient
 const url = process.env.MONGO_URL ||  "mongodb://localhost:27017/"
-const dbName = process.env.DB_NAME || "test_db"
+const dbName = process.env.DB_NAME || "dfusion2"
 
 const withdraw_search = async function(db_name, _slot, valid=null, a_id=null, t_id=null) {
   const db = await MongoClient.connect(url)
@@ -60,15 +61,14 @@ module.exports = async (callback) => {
     if (valid_withdrawals.length == 0) {
       callback(`Error: No valid withdraw found in slot ${slot}`)
     }
-
+    
     console.log("Reconstructing Merkle Tree from leaf nodes")
     const all_withdraws = await withdraw_search(dbName, slot)
-    const withdraw_hashes = Array(2**7).fill(sha256(0x0))
+    const withdraw_hashes = Array(2**7).fill(Buffer.alloc(32))
     for (let i = 0; i < all_withdraws.length; i++) {
       const withdraw = all_withdraws[i]
       if (withdraw.valid) {
-        withdraw_hashes[i] = sha256(
-          encodePacked_16_8_128(withdraw.accountId, withdraw.tokenId, withdraw.amount))
+        withdraw_hashes[i] = encodePacked_16_8_128(withdraw.accountId, withdraw.tokenId, withdraw.amount)
       }
     }
     const tree = new MerkleTree(withdraw_hashes, sha256)
@@ -79,20 +79,25 @@ module.exports = async (callback) => {
 
     for (let i = 0; i < valid_withdrawals.length; i++) {
       const toClaim = valid_withdrawals[i]
-      console.log(toClaim.slotIndex)
       if (await instance.hasWithdrawBeenClaimed.call(slot, toClaim.slotIndex)) {
         console.log("Already claimed:", toClaim)
       } else {
         console.log("Attempting to claim:", toClaim)
-        const leaf = sha256(encodePacked_16_8_128(accountId, tokenId, toClaim.amount))
+        const leaf = encodePacked_16_8_128(accountId, tokenId, toClaim.amount)
         const proof = Buffer.concat(tree.getProof(leaf).map(x => x.data))
 
         // Could also check if leaf if contained in withdraw_hashes
         if (!proof.length) {
-          callback("Proof for not found [likely invalid]")
+          callback("Proof not found [likely invalid]")
         }
+
+        const token = await ERC20.at(token_address)
+        const balance_before = await token.balanceOf(depositor)
+        
         await instance.claimWithdrawal(slot, toClaim.slotIndex, accountId, tokenId, toClaim.amount, proof)
-        console.log("Success!")
+        
+        const balance_after = await token.balanceOf(depositor)
+        console.log(`Success! Token balance before ${balance_before}, after ${balance_after}`)
       }
     }
     callback()

--- a/scripts/claim_withdraw.js
+++ b/scripts/claim_withdraw.js
@@ -97,7 +97,7 @@ module.exports = async (callback) => {
         await instance.claimWithdrawal(slot, toClaim.slotIndex, accountId, tokenId, toClaim.amount, proof)
         
         const balance_after = await token.balanceOf(depositor)
-        console.log(`Success! Token balance before ${balance_before}, after ${balance_after}`)
+        console.log(`Success! Balance of token ${tokenId} before claim: ${balance_before}, after claim: ${balance_after}`)
       }
     }
     callback()

--- a/test/snapp_base.js
+++ b/test/snapp_base.js
@@ -22,8 +22,6 @@ const {
   stateHash,
   encodePacked_16_8_128 }  = require("./snapp_utils.js")
 
-const { sha256 } = require("ethereumjs-util")
-
 contract("SnappBase", async (accounts) => {
   const [owner, token_owner, user_1, user_2] = accounts
 
@@ -814,7 +812,7 @@ contract("SnappBase", async (accounts) => {
       // Need to apply at slot 0 (empty transition)
       await instance.applyWithdrawals(0, "0x0", await stateHash(instance), "0x1", "0x0")
 
-      const leaf = sha256(encodePacked_16_8_128(1, 1, 1))
+      const leaf = encodePacked_16_8_128(1, 1, 1)
       const tree = generateMerkleTree(0, leaf)
       const merkle_root = tree.getRoot()
       const proof = Buffer.concat(tree.getProof(leaf).map(x => x.data))
@@ -855,7 +853,7 @@ contract("SnappBase", async (accounts) => {
       // Need to apply at slot 0 (empty transition)
       await instance.applyWithdrawals(0, "0x0", await stateHash(instance), "0x1", "0x0")
 
-      const leaf = sha256(encodePacked_16_8_128(1, 1, 1))
+      const leaf = encodePacked_16_8_128(1, 1, 1)
       const tree = generateMerkleTree(0, leaf)
       const merkle_root = tree.getRoot()
       const proof = Buffer.concat(tree.getProof(leaf).map(x => x.data))
@@ -896,7 +894,7 @@ contract("SnappBase", async (accounts) => {
       // Need to apply at slot 0 (empty transition)
       await instance.applyWithdrawals(0, "0x0", await stateHash(instance), "0x1", "0x0")
 
-      const leaf = sha256(encodePacked_16_8_128(1, 1, 1))
+      const leaf = encodePacked_16_8_128(1, 1, 1)
       const tree = generateMerkleTree(0, leaf)
       const merkle_root = tree.getRoot()
       const proof = Buffer.concat(tree.getProof(leaf).map(x => x.data))

--- a/test/snapp_utils.js
+++ b/test/snapp_utils.js
@@ -48,7 +48,10 @@ const uint128 = function(num) {
 
 // returns equivalent to Soliditiy's abi.encodePacked(uint16 a, uint8 b, uint128 c)
 const encodePacked_16_8_128 = function(a, b, c) {
-  return "0x" + uint16(a) + uint8(b) + uint128(c)
+  return Buffer.alloc(13)
+    + Buffer.from(uint16(a), "hex")
+    + Buffer.from(uint8(b), "hex")
+    + Buffer.from(uint128(c), "hex")
 }
 
 module.exports = {


### PR DESCRIPTION
As discussed, we don't have to hash the leafs for the claimable withdraw merkle proofs. Instead, we can use the raw bytes (padded to 256 bits) directly.

This should half the amount of hashes needed inside the snark.