### PR TITLE
[Easy] Increase account balance in tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -495,8 +495,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
@@ -1561,7 +1560,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -1810,7 +1809,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "dev": true,
       "requires": {
@@ -2758,7 +2757,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
       "requires": {

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -91,7 +91,7 @@ const registerTokens = async function(token_artifact, contract, token_owner, num
  */
 const setupEnvironment = async function(token_artifact, contract, token_owner, accounts, numTokens) {
   const tokens = await registerTokens(token_artifact, contract, token_owner, numTokens)
-  const amount = "100000000000000000000"
+  const amount = "300000000000000000000"
   for (let i = 0; i < tokens.length; i++) {openAccounts
     await fundAccounts(token_owner, accounts, tokens[i], amount)
     await approveContract(contract, accounts, tokens[i], amount)


### PR DESCRIPTION
Needed to support the Retreth example in the unit tests where we transact more than 100ETH worth of tokens.