### PR TITLE
[Easy] Make coverage work with Truffle v5.0.21

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -51,15 +51,22 @@ module.exports = {
     // options below to some value.
     //
     development: {
-     host: "127.0.0.1",     // Localhost (default: none)
-     port: 8545,            // Standard Ethereum port (default: none)
-     network_id: "*",       // Any network (default: none)
+      host: "127.0.0.1",     // Localhost (default: none)
+      port: 8545,            // Standard Ethereum port (default: none)
+      network_id: "*",       // Any network (default: none)
     },
 
     developmentdocker: {
-     host: "ganache-cli",     // Localhost (default: none)
-     port: 8545,            // Standard Ethereum port (default: none)
-     network_id: "*",       // Any network (default: none)
+      host: "ganache-cli",     // Localhost (default: none)
+      port: 8545,            // Standard Ethereum port (default: none)
+      network_id: "*",       // Any network (default: none)
+    },
+    coverage: {
+      host: "localhost",
+      network_id: "*",
+      port: 8555,         // <-- If you change this, also set the port option in .solcover.js.
+      gas: 0xfffffffffff, // <-- Use this high gas value
+      gasPrice: 0x01      // <-- Use this low gas price
     },
 
     // Another network with more advanced options...
@@ -104,7 +111,7 @@ module.exports = {
   // Configure your compilers
   compilers: {
     solc: {
-      // version: "0.5.1",    // Fetch exact version from solc-bin (default: truffle's version)
+      version: "<0.5.5",    // Fetch exact version from solc-bin (default: truffle's version)
       // docker: true,        // Use "0.5.1" you've installed locally with docker (default: false)
       // settings: {          // See the solidity docs for advice about optimization and evmVersion
       //  optimizer: {


### PR DESCRIPTION
Truffle v5.0.21 requires an explicit entry for coverage networks in the `truffle-config.js`. This is because solidity-coverage writes the required network information (using ridiculously high gas limit) into a temporary `truffle.js` which in the newest version of truffle is ignored over the `truffle-config.js`

Moreover, coverage only works until solc v0.5.4. Thus it is not compatible with the latest truffle either.

This diff makes it so that coverage works with the newest version of truffle.

It's really annoying that coverage uses the global truffle instead of the one locally installed under `node_modules`.