### PR TITLE
New Solidity linter for Whitespace

### DIFF
--- a/.solhintignore
+++ b/.solhintignore
@@ -1,5 +1,7 @@
 contracts/Migrations.sol
 .solhint.json
 .solhintignore
+.soliumignore
+.soliumrc.json
 
 node_modules/

--- a/.soliumignore
+++ b/.soliumignore
@@ -1,0 +1,3 @@
+node_modules
+contracts/Migrations.sol
+contracts/DevDependencies.sol

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,0 +1,20 @@
+{
+  "extends": "solium:recommended",
+  "plugins": [
+    "security"
+  ],
+  "rules": {
+    "quotes": [
+      "error",
+      "double"
+    ],
+    "indentation": [
+      "error",
+      4
+    ],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ]
+  }
+}

--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -4,6 +4,7 @@
     "security"
   ],
   "rules": {
+    "security/no-block-members": "off",
     "quotes": [
       "error",
       "double"

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,4 @@ script:
   - npm test
   - npm run lint
   - npm run solhint
+  - solium -d contracts/

--- a/contracts/DevDependencies.sol
+++ b/contracts/DevDependencies.sol
@@ -5,8 +5,8 @@ pragma solidity ^0.5.0;
 //  contracts during development.
 //
 //  For other environments, only use compiled contracts from the NPM package.
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";
+import "../node_modules/openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";
 
 
-contract DevDependencies { // solhint-disable no-empty-blocks
-}
+// solium-disable no-empty-blocks
+contract DevDependencies {}

--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -1,5 +1,4 @@
 pragma solidity ^0.5.0;
-// solium-disable security/no-block-members
 
 import "./SnappBase.sol";
 

--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.5.0;
+// solium-disable security/no-block-members
 
 import "./SnappBase.sol";
 
@@ -8,7 +9,7 @@ contract SnappAuction is SnappBase {
     uint16 public constant AUCTION_BATCH_SIZE = 1000;
     uint8 public constant AUCTION_RESERVED_ACCOUNTS = 50;
     uint8 public constant AUCTION_RESERVED_ACCOUNT_BATCH_SIZE = 10;
-    
+
     struct StandingOrderBatch {
         bytes32 orderHash;
         uint validFromIndex; // validity is inclusive of the auction index
@@ -36,10 +37,10 @@ contract SnappAuction is SnappBase {
     );
 
     event StandingSellOrderBatch(
-        uint currentBatchIndex, 
-        uint16 accountId, 
-        uint8[] buyToken, 
-        uint8[] sellToken, 
+        uint currentBatchIndex,
+        uint16 accountId,
+        uint8[] buyToken,
+        uint8[] sellToken,
         uint128[] buyAmount,
         uint128[] sellAmount
     );
@@ -56,7 +57,7 @@ contract SnappAuction is SnappBase {
         uint8 numReservedAccounts,
         uint8 ordersPerReservedAccount
     );
-    
+
     constructor () public {
         emit AuctionInitialization(
             AUCTION_BATCH_SIZE, AUCTION_RESERVED_ACCOUNTS, AUCTION_RESERVED_ACCOUNT_BATCH_SIZE
@@ -81,7 +82,7 @@ contract SnappAuction is SnappBase {
     function getStandingOrderHash(uint16 userId, uint128 batchIndex) public view returns (bytes32) {
         return standingOrders[userId].reservedAccountOrders[batchIndex].orderHash;
     }
-    
+
     function getStandingOrderValidFrom(uint16 userId, uint128 batchIndex) public view returns (uint) {
         return standingOrders[userId].reservedAccountOrders[batchIndex].validFromIndex;
     }
@@ -91,7 +92,7 @@ contract SnappAuction is SnappBase {
         if (validTo == 0) {
             return MAX_UINT;
         } else {
-            return validTo - 1; 
+            return validTo - 1;
         }
     }
 
@@ -108,7 +109,7 @@ contract SnappAuction is SnappBase {
         uint128[] memory buyAmounts,
         uint128[] memory sellAmounts
     ) public onlyRegistered() {
-        
+
         // Update Auction Hash based on request
         uint16 accountId = publicKeyToAccountMap(msg.sender);
         require(accountId <= AUCTION_RESERVED_ACCOUNTS, "Accout is not a reserved account");
@@ -116,7 +117,7 @@ contract SnappAuction is SnappBase {
         bytes32 orderHash;
         uint numOrders = buyTokens.length;
         require(numOrders <= AUCTION_RESERVED_ACCOUNT_BATCH_SIZE, "Too many orders for reserved batch");
-        
+
         if (
             auctionIndex == MAX_UINT ||
             block.timestamp > (auctions[auctionIndex].creationTimestamp + 3 minutes)
@@ -131,7 +132,7 @@ contract SnappAuction is SnappBase {
                     encodeOrder(accountId, buyTokens[i], sellTokens[i], buyAmounts[i], sellAmounts[i])
                 )
             );
-        }        
+        }
         uint currentBatchIndex = standingOrders[accountId].currentBatchIndex;
         StandingOrderBatch memory standingOrderBatch = standingOrders[accountId].reservedAccountOrders[currentBatchIndex];
         if (auctionIndex > standingOrderBatch.validFromIndex) {
@@ -214,8 +215,8 @@ contract SnappAuction is SnappBase {
         uint8 sellToken,
         uint128 buyAmount,
         uint128 sellAmount
-    ) 
-        internal view returns (bytes32) 
+    )
+        internal view returns (bytes32)
     {
         // Restrict buy and sell amount to occupy at most 96 bits.
         require(buyAmount < 0x1000000000000000000000000, "Buy amount too large!");
@@ -237,8 +238,8 @@ contract SnappAuction is SnappBase {
 
     function createNewPendingBatch() internal {
         require(
-                auctionIndex == MAX_UINT || auctionIndex < 2 || auctions[auctionIndex - 2].appliedAccountStateIndex != 0,
-                "Too many pending auctions"
+            auctionIndex == MAX_UINT || auctionIndex < 2 || auctions[auctionIndex - 2].appliedAccountStateIndex != 0,
+            "Too many pending auctions"
             );
         auctionIndex++;
         auctions[auctionIndex] = PendingBatch({

--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.0;
 
 // solium-disable security/no-block-members
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
-import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "../node_modules/openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "../node_modules/openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "./libraries/Merkle.sol";
 import "./libraries/IdToAddressBiMap.sol";
 

--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.5.0;
 
-// solium-disable security/no-block-members
 import "../node_modules/openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "../node_modules/openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "./libraries/Merkle.sol";

--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.0;
 
+// solium-disable security/no-block-members
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 import "./libraries/Merkle.sol";

--- a/contracts/libraries/Merkle.sol
+++ b/contracts/libraries/Merkle.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.5.0;
+// solium-disable security/no-inline-assembly
 
 
 /**

--- a/contracts/libraries/wrapppers/IdToAddressBiMapWrapper.sol
+++ b/contracts/libraries/wrapppers/IdToAddressBiMapWrapper.sol
@@ -25,5 +25,4 @@ contract IdToAddressBiMapWrapper {
     function insert(uint16 id, address addr) public returns (bool) {
         return IdToAddressBiMap.insert(map, id, addr);
     }
-    
 }

--- a/contracts/libraries/wrapppers/MerkleWrapper.sol
+++ b/contracts/libraries/wrapppers/MerkleWrapper.sol
@@ -4,12 +4,11 @@ import "../Merkle.sol";
 
 
 contract MerkleWrapper {
-    
     function checkMembership(
-        bytes32 leaf, 
-        uint256 index, 
-        bytes32 rootHash, 
-        bytes memory proof, 
+        bytes32 leaf,
+        uint256 index,
+        bytes32 rootHash,
+        bytes memory proof,
         uint height
     )
         public

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eth-gas-reporter": "^0.2.0",
     "minimist": "^1.2.0",
     "solhint": "^1.5.0",
+    "solium": "^1.2.4",
     "solidity-coverage": "^0.5.11",
     "truffle": "^5.0.0-next.26",
     "truffle-assertions": "^0.8.0"


### PR DESCRIPTION
This `solium` catches whitespace and block-member usage (which we ignore anyway)