### PR TITLE
Adjusting applyauction with new logic #94

### DIFF
--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -193,7 +193,10 @@ contract SnappAuction is SnappBase {
         require(slot != MAX_UINT && slot <= auctionIndex, "Requested order slot does not exist");
         require(slot == 0 || auctions[slot-1].appliedAccountStateIndex != 0, "Must apply auction slots in order!");
         require(auctions[slot].appliedAccountStateIndex == 0, "Auction already applied");
-        require(_transitionBlockHash == bytes32(0) || blockhash(indexTransitionBlock[slot]) == _transitionBlockHash, "Blockhash doesn't agree");
+        require(
+            _transitionBlockHash == bytes32(0) || blockhash(indexTransitionBlock[slot]) == _transitionBlockHash,
+            "Blockhash doesn't agree"
+        );
         require(
             block.timestamp > auctions[slot].creationTimestamp + 3 minutes ||
                 auctions[slot].size == maxUnreservedOrderCount(),

--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -235,17 +235,6 @@ contract SnappAuction is SnappBase {
         return bytes32(uint(accountId) + (uint(buyToken) << 16) + (uint(sellToken) << 24) + (uint(sellAmount) << 32) + (uint(buyAmount) << 128));
     }
 
-    function orderBatchIsValidAtAuctionIndex(uint autionIndex, uint8 userId, uint128 batchIndex) public view returns(bool) {
-        if (
-            auctionIndex >= getStandingOrderValidFrom(userId, batchIndex) 
-            && auctionIndex <= getStandingOrderValidTo(userId, batchIndex)
-        ) {
-            return true;
-        } else { 
-            return false;
-        }
-    }
-
     function maxUnreservedOrderCount() internal pure returns (uint16) {
         return AUCTION_BATCH_SIZE - (AUCTION_RESERVED_ACCOUNTS * AUCTION_RESERVED_ACCOUNT_BATCH_SIZE);
     }

--- a/test/snapp_auction.js
+++ b/test/snapp_auction.js
@@ -445,7 +445,6 @@ contract("SnappAuction", async (accounts) => {
       await instance.placeSellOrder(0, 1, 1, 1, { from: user_1 })
 
       const first_slot = (await instance.auctionIndex.call()).toNumber()
-      const first_auction_state = await instance.auctions.call(first_slot)
 
       // Wait for current order slot to be inactive
       await waitForNSeconds(181)
@@ -453,7 +452,6 @@ contract("SnappAuction", async (accounts) => {
       // Place an order to ensure second order slot is created.
       const order_tx = await instance.placeSellOrder(0, 1, 1, 1, { from: user_1 })
       const second_slot = order_tx.logs[0].args.auctionId.toNumber()
-      const second_auction_state = await instance.auctions(second_slot)
 
       // Wait for second order slot to be inactive
       await waitForNSeconds(181)


### PR DESCRIPTION
This is another proposal for #94.

Idea:
The main reason why we are using the _orderHash submission is to prevent accidental solutions submission, which have been calculated on wrong data. The biggest error factor is a sudden reorg. We can check for reorgs by checking for the ethereum blockhash

test plan:
Unitest + think of impact for backend implementation