### PR TITLE
Move SnappBase logic into SnappBaseCore library

### DIFF
--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -1,186 +1,117 @@
 pragma solidity ^0.5.0;
 
-import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "./libraries/Merkle.sol";
+import "./libraries/SnappBaseCore.sol";
 import "./libraries/IdToAddressBiMap.sol";
 
 
 contract SnappBase is Ownable {
-    using Merkle for bytes32;
-
-    uint public constant MAX_UINT = 2**256 - 1;
-    uint8 public constant MAX_ACCOUNT_ID = 100;
-    uint8 public constant MAX_TOKENS = 30;
-    uint8 public constant DEPOSIT_BATCH_SIZE = 100;
-    uint8 public constant WITHDRAW_BATCH_SIZE = 100;
-
-    bytes32[] public stateRoots;  // Pedersen Hash
-
-    enum TransitionType {
-        Deposit,
-        Withdraw
-    }
-
-    IdToAddressBiMap.Data private registeredAccounts;
-    IdToAddressBiMap.Data private registeredTokens;
-    uint8 public numTokens;
-
-    struct PendingBatch {
-        uint16 size;                   // Number of deposits in this batch
-        bytes32 shaHash;               // Rolling shaHash of all deposits
-        uint creationTimestamp;        // Timestamp of batch creation
-        uint appliedAccountStateIndex; // accountState index when batch applied (for rollback), 0 implies not applied.
-    }
-
-    uint public depositIndex = MAX_UINT;
-    mapping (uint => PendingBatch) public deposits;
-
-    uint public withdrawIndex = MAX_UINT;
-    mapping (uint => PendingBatch) public pendingWithdraws;
-
-    struct ClaimableWithdrawState {
-        bytes32 merkleRoot;                      // Merkle root of claimable withdraws in this block
-        bool[WITHDRAW_BATCH_SIZE] claimedBitmap; // Bitmap signalling which withdraws have been claimed
-        uint appliedAccountStateIndex;           // AccountState when this state was created (for rollback)
-    }
-
-    mapping (uint => ClaimableWithdrawState) public claimableWithdraws;
-
-    event WithdrawRequest(uint16 accountId, uint8 tokenId, uint128 amount, uint slot, uint16 slotIndex);
-    event Deposit(uint16 accountId, uint8 tokenId, uint128 amount, uint slot, uint16 slotIndex);
-    event StateTransition(TransitionType transitionType, uint stateIndex, bytes32 stateHash, uint slot);
-    event SnappInitialization(bytes32 stateHash, uint8 maxTokens, uint16 maxAccounts);
+    using SnappBaseCore for SnappBaseCore.Data;
+    SnappBaseCore.Data internal coreData;
 
     constructor () public {
-        // The initial state should be Pederson hash of an empty balance tree
-        bytes32 stateInit = bytes32(0);
-        stateRoots.push(stateInit);
-
-        emit SnappInitialization(stateInit, MAX_TOKENS, MAX_ACCOUNT_ID);
-    }
-
-    /**
-     * Public View Methods
-     */
-    function stateIndex() public view returns (uint) {
-        return stateRoots.length - 1;
-    }
-
-    function getCurrentStateRoot() public view returns (bytes32) {
-        return stateRoots[stateIndex()];
-    }
-
-    function hasDepositBeenApplied(uint index) public view returns (bool) {
-        return deposits[index].appliedAccountStateIndex != 0;
-    }
-
-    function getDepositCreationTimestamp(uint slot) public view returns (uint) {
-        return deposits[slot].creationTimestamp;
-    }
-
-    function getDepositHash(uint slot) public view returns (bytes32) {
-        return deposits[slot].shaHash;
-    }
-
-    function hasWithdrawBeenApplied(uint index) public view returns (bool) {
-        return pendingWithdraws[index].appliedAccountStateIndex != 0;
-    }
-
-    function getWithdrawCreationTimestamp(uint slot) public view returns (uint) {
-        return pendingWithdraws[slot].creationTimestamp;
-    }
-
-    function getWithdrawHash(uint slot) public view returns (bytes32) {
-        return pendingWithdraws[slot].shaHash;
-    }
-
-    function hasWithdrawBeenClaimed(uint slot, uint16 index) public view returns (bool) {
-        return claimableWithdraws[slot].claimedBitmap[index];
-    }
-
-    function publicKeyToAccountMap(address addr) public view returns (uint16) {
-        return IdToAddressBiMap.getId(registeredAccounts, addr);
-    }
-
-    function accountToPublicKeyMap(uint16 id) public view returns (address) {
-        return IdToAddressBiMap.getAddressAt(registeredAccounts, id);
-    }
-
-    function tokenAddresToIdMap(address addr) public view returns (uint16) {
-        return IdToAddressBiMap.getId(registeredTokens, addr);
-    }
-
-    function tokenIdToAddressMap(uint16 id) public view returns (address) {
-        return IdToAddressBiMap.getAddressAt(registeredTokens, id);
-    }
-
-    function hasAccount(uint16 accountId) public view returns (bool) {
-        return IdToAddressBiMap.hasId(registeredAccounts, accountId);
+        coreData.init();
     }
 
     /**
      * Modifiers
      */
     modifier onlyRegistered() {
-        require(IdToAddressBiMap.hasAddress(registeredAccounts, msg.sender), "Must have registered account");
+        require(IdToAddressBiMap.hasAddress(coreData.registeredAccounts, msg.sender), "Must have registered account");
         _;
+    }
+
+    /**
+     * Public View Methods
+     */
+    function numTokens() public view returns (uint8) {
+        return coreData.numTokens;
+    }
+
+    function stateIndex() public view returns (uint) {
+        return coreData.stateIndex();
+    }
+
+    function getCurrentStateRoot() public view returns (bytes32) {
+        return coreData.stateRoots[stateIndex()];
+    }
+
+    function getCurrentDepositIndex() public view returns (uint) {
+        return coreData.depositIndex;
+    }
+
+    function hasDepositBeenApplied(uint index) public view returns (bool) {
+        return coreData.deposits[index].appliedAccountStateIndex != 0;
+    }
+
+    function getDepositCreationTimestamp(uint slot) public view returns (uint) {
+        return coreData.deposits[slot].creationTimestamp;
+    }
+
+    function getDepositHash(uint slot) public view returns (bytes32) {
+        return coreData.deposits[slot].shaHash;
+    }
+
+    function getCurrentWithdrawIndex() public view returns (uint) {
+        return coreData.withdrawIndex;
+    }
+
+    function hasWithdrawBeenApplied(uint index) public view returns (bool) {
+        return coreData.pendingWithdraws[index].appliedAccountStateIndex != 0;
+    }
+
+    function getWithdrawCreationTimestamp(uint slot) public view returns (uint) {
+        return coreData.pendingWithdraws[slot].creationTimestamp;
+    }
+
+    function getWithdrawHash(uint slot) public view returns (bytes32) {
+        return coreData.pendingWithdraws[slot].shaHash;
+    }
+
+    function hasWithdrawBeenClaimed(uint slot, uint16 index) public view returns (bool) {
+        return coreData.claimableWithdraws[slot].claimedBitmap[index];
+    }
+
+    function isPendingWithdrawActive(uint slot) public view returns (bool) {
+        return block.timestamp <= coreData.deposits[slot].creationTimestamp + 3 minutes;
+    }
+
+    function publicKeyToAccountMap(address addr) public view returns (uint16) {
+        return coreData.publicKeyToAccountMap(addr);
+    }
+
+    function accountToPublicKeyMap(uint16 id) public view returns (address) {
+        return coreData.accountToPublicKeyMap(id);
+    }
+
+    function tokenAddresToIdMap(address addr) public view returns (uint16) {
+        return IdToAddressBiMap.getId(coreData.registeredTokens, addr);
+    }
+
+    function tokenIdToAddressMap(uint16 id) public view returns (address) {
+        return coreData.tokenIdToAddressMap(id);
+    }
+
+    function hasAccount(uint16 accountId) public view returns (bool) {
+        return IdToAddressBiMap.hasId(coreData.registeredAccounts, accountId);
     }
 
     /**
      * General Snapp Functionality
      */
     function openAccount(uint16 accountId) public {
-        require(accountId < MAX_ACCOUNT_ID, "Account index exceeds max");
-        require(
-            IdToAddressBiMap.insert(registeredAccounts, accountId, msg.sender),
-            "Address occupies slot or requested slot already taken"
-        );
+        coreData.openAccount(accountId);
     }
 
     function addToken(address _tokenAddress) public onlyOwner() {
-        require(numTokens + 1 <= MAX_TOKENS, "Max tokens reached");
-        require(
-            IdToAddressBiMap.insert(registeredTokens, numTokens, _tokenAddress),
-            "Token already registered"
-        );
-        numTokens++;
+        coreData.addToken(_tokenAddress);
     }
 
     /**
      * Deposits
      */
     function deposit(uint8 tokenId, uint128 amount) public onlyRegistered() {
-        require(amount != 0, "Must deposit positive amount");
-        require(IdToAddressBiMap.hasId(registeredTokens, tokenId), "Requested token is not registered");
-        require(
-            ERC20(tokenIdToAddressMap(tokenId)).transferFrom(msg.sender, address(this), amount),
-            "Unsuccessful transfer"
-        );
-
-        if (depositIndex == MAX_UINT ||
-            deposits[depositIndex].size == DEPOSIT_BATCH_SIZE ||
-            block.timestamp > deposits[depositIndex].creationTimestamp + 3 minutes
-        ) {
-            depositIndex++;
-            deposits[depositIndex] = PendingBatch({
-                size: 0,
-                shaHash: bytes32(0),
-                creationTimestamp: block.timestamp,
-                appliedAccountStateIndex: 0
-            });
-        }
-
-        // Update Deposit Hash based on request
-        uint16 accountId = publicKeyToAccountMap(msg.sender);
-        bytes32 nextDepositHash = sha256(
-            abi.encodePacked(deposits[depositIndex].shaHash, encodeFlux(accountId, tokenId, amount))
-        );
-        deposits[depositIndex].shaHash = nextDepositHash;
-
-        emit Deposit(accountId, tokenId, amount, depositIndex, deposits[depositIndex].size);
-        // Only increment size after event (so it is emitted as an index)
-        deposits[depositIndex].size++;
+        coreData.deposit(tokenId, amount);
     }
 
     function applyDeposits(
@@ -191,65 +122,14 @@ contract SnappBase is Ownable {
     )
         public onlyOwner()
     {
-        require(slot != MAX_UINT && slot <= depositIndex, "Requested deposit slot does not exist");
-        require(slot == 0 || deposits[slot-1].appliedAccountStateIndex != 0, "Must apply deposit slots in order!");
-        require(deposits[slot].shaHash == _depositHash, "Deposits have been reorged");
-        require(deposits[slot].appliedAccountStateIndex == 0, "Deposits already processed");
-        require(
-            block.timestamp > deposits[slot].creationTimestamp + 3 minutes,
-            "Requested deposit slot is still active"
-        );
-        require(stateRoots[stateIndex()] == _currStateRoot, "Incorrect State Root");
-
-        // Note that the only slot that can ever be empty is the first (at index zero)
-        // This occurs when no deposits are made within the first 20 blocks of the contract's deployment
-        // This code allows for the processing of the empty block and since it will only happen once
-        // No, additional verification is necessary.
-
-        stateRoots.push(_newStateRoot);
-        deposits[slot].appliedAccountStateIndex = stateIndex();
-
-        emit StateTransition(TransitionType.Deposit, stateIndex(), _newStateRoot, slot);
+        coreData.applyDeposits(slot, _currStateRoot, _newStateRoot, _depositHash);
     }
 
     /**
      * Withdraws
      */
     function requestWithdrawal(uint8 tokenId, uint128 amount) public onlyRegistered() {
-        require(amount != 0, "Must request positive amount");
-        require(IdToAddressBiMap.hasId(registeredTokens, tokenId), "Requested token is not registered");
-        require(
-            ERC20(tokenIdToAddressMap(tokenId)).balanceOf(address(this)) >= amount,
-            "Requested amount exceeds contract's balance"
-        );
-
-        // Determine or construct correct current withdraw state.
-        // This is governed by WITHDRAW_BATCH_SIZE and creationTimestamp
-        if (
-            withdrawIndex == MAX_UINT ||
-            pendingWithdraws[withdrawIndex].size == WITHDRAW_BATCH_SIZE ||
-            block.timestamp > pendingWithdraws[withdrawIndex].creationTimestamp + 3 minutes
-        ) {
-            withdrawIndex++;
-            pendingWithdraws[withdrawIndex] = PendingBatch({
-                size: 0,
-                shaHash: bytes32(0),
-                creationTimestamp: block.timestamp,
-                appliedAccountStateIndex: 0
-            });
-        }
-
-        // Update Withdraw Hash based on request
-        uint16 accountId = publicKeyToAccountMap(msg.sender);
-        bytes32 nextWithdrawHash = sha256(
-            abi.encodePacked(pendingWithdraws[withdrawIndex].shaHash, encodeFlux(accountId, tokenId, amount))
-        );
-
-        pendingWithdraws[withdrawIndex].shaHash = nextWithdrawHash;
-
-        emit WithdrawRequest(accountId, tokenId, amount, withdrawIndex, pendingWithdraws[withdrawIndex].size);
-        // Only increment size after event (so it is emitted as an index)
-        pendingWithdraws[withdrawIndex].size++;
+        coreData.requestWithdrawal(tokenId, amount);
     }
 
     function applyWithdrawals(
@@ -261,30 +141,7 @@ contract SnappBase is Ownable {
     )
         public onlyOwner()
     {
-        require(slot != MAX_UINT && slot <= withdrawIndex, "Requested withdrawal slot does not exist");
-        require(
-            slot == 0 || pendingWithdraws[slot-1].appliedAccountStateIndex != 0,
-            "Previous withdraw slot not processed!"
-        );
-        require(pendingWithdraws[slot].shaHash == _withdrawHash, "Withdraws have been reorged");
-        require(pendingWithdraws[slot].appliedAccountStateIndex == 0, "Withdraws already processed");
-        require(
-            block.timestamp > pendingWithdraws[slot].creationTimestamp + 3 minutes,
-            "Requested withdraw slot is still active");
-        require(stateRoots[stateIndex()] == _currStateRoot, "Incorrect State Root");
-
-        // Update account states
-        stateRoots.push(_newStateRoot);
-        pendingWithdraws[slot].appliedAccountStateIndex = stateIndex();
-
-        bool[WITHDRAW_BATCH_SIZE] memory nullArray;
-        claimableWithdraws[slot] = ClaimableWithdrawState({
-            merkleRoot: _merkleRoot,
-            claimedBitmap: nullArray,
-            appliedAccountStateIndex: stateIndex()
-        });
-
-        emit StateTransition(TransitionType.Withdraw, stateIndex(), _newStateRoot, slot);
+        coreData.applyWithdrawals(slot, _merkleRoot, _currStateRoot, _newStateRoot, _withdrawHash);
     }
 
     function claimWithdrawal(
@@ -295,24 +152,6 @@ contract SnappBase is Ownable {
         uint128 amount,
         bytes memory proof
     ) public {
-        // No need to check tokenId or accountId (wouldn't pass merkle proof if unregistered).
-        require(pendingWithdraws[slot].appliedAccountStateIndex > 0, "Requested slot has not been processed");
-        require(claimableWithdraws[slot].claimedBitmap[inclusionIndex] == false, "Already claimed");
-
-        bytes32 leaf = encodeFlux(accountId, tokenId, amount);
-        require(
-            leaf.checkMembership(inclusionIndex, claimableWithdraws[slot].merkleRoot, proof, 7),
-            "Failed Merkle membership check."
-        );
-
-        // Set claim bitmap to true (indicating that funds have been claimed).
-        claimableWithdraws[slot].claimedBitmap[inclusionIndex] = true;
-
-        // There is no situation where contract balance can't afford the upcoming transfer.
-        ERC20(tokenIdToAddressMap(tokenId)).transfer(accountToPublicKeyMap(accountId), amount);
-    }
-
-    function encodeFlux(uint16 accountId, uint8 tokenId, uint128 amount) internal pure returns (bytes32) {
-        return bytes32(uint(amount) + (uint(tokenId) << 128) + (uint(accountId) << 136));
+        coreData.claimWithdrawal(slot, inclusionIndex, accountId, tokenId, amount, proof);
     }
 }

--- a/contracts/libraries/SnappBaseCore.sol
+++ b/contracts/libraries/SnappBaseCore.sol
@@ -1,0 +1,269 @@
+pragma solidity ^0.5.0;
+
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "./IdToAddressBiMap.sol";
+import "./Merkle.sol";
+import "../SnappBase.sol";
+
+
+library SnappBaseCore {
+    using Merkle for bytes32;
+
+    uint public constant MAX_UINT = 2**256 - 1;
+    uint8 public constant MAX_ACCOUNT_ID = 100;
+    uint8 public constant MAX_TOKENS = 30;
+    uint8 public constant DEPOSIT_BATCH_SIZE = 100;
+    uint8 public constant WITHDRAW_BATCH_SIZE = 100;
+
+    event WithdrawRequest(uint16 accountId, uint8 tokenId, uint128 amount, uint slot, uint16 slotIndex);
+    event Deposit(uint16 accountId, uint8 tokenId, uint128 amount, uint slot, uint16 slotIndex);
+    event StateTransition(TransitionType transitionType, uint stateIndex, bytes32 stateHash, uint slot);
+    event SnappInitialization(bytes32 stateHash, uint8 maxTokens, uint16 maxAccounts);
+
+    enum TransitionType {
+        Deposit,
+        Withdraw
+    }
+
+    struct PendingBatch {
+        uint16 size;                   // Number of deposits in this batch
+        bytes32 shaHash;               // Rolling shaHash of all deposits
+        uint creationTimestamp;        // Timestamp of batch creation
+        uint appliedAccountStateIndex; // accountState index when batch applied (for rollback), 0 implies not applied.
+    }
+
+    struct ClaimableWithdrawState {
+        bytes32 merkleRoot;                      // Merkle root of claimable withdraws in this block
+        bool[WITHDRAW_BATCH_SIZE] claimedBitmap; // Bitmap signalling which withdraws have been claimed
+        uint appliedAccountStateIndex;           // AccountState when this state was created (for rollback)
+    }
+
+    struct Data {
+        bytes32[] stateRoots;
+        IdToAddressBiMap.Data registeredAccounts;
+        IdToAddressBiMap.Data registeredTokens;
+        uint8 numTokens;
+        uint depositIndex;
+        mapping (uint => PendingBatch) deposits;
+        uint withdrawIndex;
+        mapping (uint => PendingBatch) pendingWithdraws;
+        mapping (uint => ClaimableWithdrawState) claimableWithdraws;
+    }
+
+    function init(Data storage data) public {
+        // The initial state should be Pederson hash of an empty balance tree
+        bytes32 stateInit = bytes32(0);
+        data.stateRoots.push(stateInit);
+        data.depositIndex = MAX_UINT;
+        data.withdrawIndex = MAX_UINT;
+
+        emit SnappInitialization(stateInit, MAX_TOKENS, MAX_ACCOUNT_ID);
+    }
+
+    /**
+     * Public View Methods
+     */
+    function stateIndex(Data storage data) public view returns (uint) {
+        return data.stateRoots.length - 1;
+    }
+
+    function publicKeyToAccountMap(Data storage data, address addr) public view returns (uint16) {
+        return IdToAddressBiMap.getId(data.registeredAccounts, addr);
+    }
+
+    function accountToPublicKeyMap(Data storage data, uint16 id) public view returns (address) {
+        return IdToAddressBiMap.getAddressAt(data.registeredAccounts, id);
+    }
+
+    function tokenIdToAddressMap(Data storage data, uint16 id) public view returns (address) {
+        return IdToAddressBiMap.getAddressAt(data.registeredTokens, id);
+    }
+
+    /**
+     * General Snapp Functionality
+     */
+    function openAccount(Data storage data, uint16 accountId) public {
+        require(accountId < MAX_ACCOUNT_ID, "Account index exceeds max");
+        require(
+            IdToAddressBiMap.insert(data.registeredAccounts, accountId, msg.sender),
+            "Address occupies slot or requested slot already taken"
+        );
+    }
+
+    function addToken(Data storage data, address _tokenAddress) public {
+        require(data.numTokens + 1 <= MAX_TOKENS, "Max tokens reached");
+        require(
+            IdToAddressBiMap.insert(data.registeredTokens, data.numTokens, _tokenAddress),
+            "Token already registered"
+        );
+        data.numTokens++;
+    }
+
+    /**
+     * Deposits
+     */
+    function deposit(Data storage data, uint8 tokenId, uint128 amount) public {
+        require(amount != 0, "Must deposit positive amount");
+        require(IdToAddressBiMap.hasId(data.registeredTokens, tokenId), "Requested token is not registered");
+        require(
+            ERC20(tokenIdToAddressMap(data, tokenId)).transferFrom(msg.sender, address(this), amount),
+            "Unsuccessful transfer"
+        );
+
+        if (data.depositIndex == MAX_UINT ||
+            data.deposits[data.depositIndex].size == DEPOSIT_BATCH_SIZE ||
+            block.timestamp > data.deposits[data.depositIndex].creationTimestamp + 3 minutes
+        ) {
+            data.depositIndex++;
+            data.deposits[data.depositIndex] = PendingBatch({
+                size: 0,
+                shaHash: bytes32(0),
+                creationTimestamp: block.timestamp,
+                appliedAccountStateIndex: 0
+            });
+        }
+
+        // Update Deposit Hash based on request
+        uint16 accountId = publicKeyToAccountMap(data, msg.sender);
+        bytes32 nextDepositHash = sha256(
+            abi.encodePacked(data.deposits[data.depositIndex].shaHash, encodeFlux(accountId, tokenId, amount))
+        );
+        data.deposits[data.depositIndex].shaHash = nextDepositHash;
+
+        emit Deposit(accountId, tokenId, amount, data.depositIndex, data.deposits[data.depositIndex].size);
+        // Only increment size after event (so it is emitted as an index)
+        data.deposits[data.depositIndex].size++;
+    }
+
+    function applyDeposits(
+        Data storage data,
+        uint slot,
+        bytes32 _currStateRoot,
+        bytes32 _newStateRoot,
+        bytes32 _depositHash
+    ) public {
+        require(slot != MAX_UINT && slot <= data.depositIndex, "Requested deposit slot does not exist");
+        require(slot == 0 || data.deposits[slot-1].appliedAccountStateIndex != 0, "Must apply deposit slots in order!");
+        require(data.deposits[slot].shaHash == _depositHash, "Deposits have been reorged");
+        require(data.deposits[slot].appliedAccountStateIndex == 0, "Deposits already processed");
+        require(
+            block.timestamp > data.deposits[slot].creationTimestamp + 3 minutes,
+            "Requested deposit slot is still active"
+        );
+        require(data.stateRoots[stateIndex(data)] == _currStateRoot, "Incorrect State Root");
+
+        // Note that the only slot that can ever be empty is the first (at index zero)
+        // This occurs when no deposits are made within the first 20 blocks of the contract's deployment
+        // This code allows for the processing of the empty block and since it will only happen once
+        // No, additional verification is necessary.
+
+        data.stateRoots.push(_newStateRoot);
+        data.deposits[slot].appliedAccountStateIndex = stateIndex(data);
+
+        emit StateTransition(TransitionType.Deposit, stateIndex(data), _newStateRoot, slot);
+    }
+
+    /**
+     * Withdraws
+     */
+    function requestWithdrawal(Data storage data, uint8 tokenId, uint128 amount) public {
+        require(amount != 0, "Must request positive amount");
+        require(IdToAddressBiMap.hasId(data.registeredTokens, tokenId), "Requested token is not registered");
+        require(
+            ERC20(tokenIdToAddressMap(data, tokenId)).balanceOf(address(this)) >= amount,
+            "Requested amount exceeds contract's balance"
+        );
+
+        // Determine or construct correct current withdraw state.
+        // This is governed by WITHDRAW_BATCH_SIZE and creationTimestamp
+        if (
+            data.withdrawIndex == MAX_UINT ||
+            data.pendingWithdraws[data.withdrawIndex].size == WITHDRAW_BATCH_SIZE ||
+            block.timestamp > data.pendingWithdraws[data.withdrawIndex].creationTimestamp + 3 minutes
+        ) {
+            data.withdrawIndex++;
+            data.pendingWithdraws[data.withdrawIndex] = PendingBatch({
+                size: 0,
+                shaHash: bytes32(0),
+                creationTimestamp: block.timestamp,
+                appliedAccountStateIndex: 0
+            });
+        }
+
+        // Update Withdraw Hash based on request
+        uint16 accountId = publicKeyToAccountMap(data, msg.sender);
+        bytes32 nextWithdrawHash = sha256(
+            abi.encodePacked(data.pendingWithdraws[data.withdrawIndex].shaHash, encodeFlux(accountId, tokenId, amount))
+        );
+
+        data.pendingWithdraws[data.withdrawIndex].shaHash = nextWithdrawHash;
+
+        emit WithdrawRequest(accountId, tokenId, amount, data.withdrawIndex, data.pendingWithdraws[data.withdrawIndex].size);
+        // Only increment size after event (so it is emitted as an index)
+        data.pendingWithdraws[data.withdrawIndex].size++;
+    }
+
+    function applyWithdrawals(
+        Data storage data,
+        uint slot,
+        bytes32 _merkleRoot,
+        bytes32 _currStateRoot,
+        bytes32 _newStateRoot,
+        bytes32 _withdrawHash
+    ) public {
+        require(slot != MAX_UINT && slot <= data.withdrawIndex, "Requested withdrawal slot does not exist");
+        require(
+            slot == 0 || data.pendingWithdraws[slot-1].appliedAccountStateIndex != 0,
+            "Previous withdraw slot not processed!"
+        );
+        require(data.pendingWithdraws[slot].shaHash == _withdrawHash, "Withdraws have been reorged");
+        require(data.pendingWithdraws[slot].appliedAccountStateIndex == 0, "Withdraws already processed");
+        require(
+            block.timestamp > data.pendingWithdraws[slot].creationTimestamp + 3 minutes,
+            "Requested withdraw slot is still active");
+        require(data.stateRoots[stateIndex(data)] == _currStateRoot, "Incorrect State Root");
+
+        // Update account states
+        data.stateRoots.push(_newStateRoot);
+        data.pendingWithdraws[slot].appliedAccountStateIndex = stateIndex(data);
+
+        bool[WITHDRAW_BATCH_SIZE] memory nullArray;
+        data.claimableWithdraws[slot] = ClaimableWithdrawState({
+            merkleRoot: _merkleRoot,
+            claimedBitmap: nullArray,
+            appliedAccountStateIndex: stateIndex(data)
+        });
+
+        emit StateTransition(TransitionType.Withdraw, stateIndex(data), _newStateRoot, slot);
+    }
+
+    function claimWithdrawal(
+        Data storage data,
+        uint slot,
+        uint16 inclusionIndex,
+        uint16 accountId,
+        uint8 tokenId,
+        uint128 amount,
+        bytes memory proof
+    ) public {
+        // No need to check tokenId or accountId (wouldn't pass merkle proof if unregistered).
+        require(data.pendingWithdraws[slot].appliedAccountStateIndex > 0, "Requested slot has not been processed");
+        require(data.claimableWithdraws[slot].claimedBitmap[inclusionIndex] == false, "Already claimed");
+
+        bytes32 leaf = encodeFlux(accountId, tokenId, amount);
+        require(
+            leaf.checkMembership(inclusionIndex, data.claimableWithdraws[slot].merkleRoot, proof, 7),
+            "Failed Merkle membership check."
+        );
+
+        // Set claim bitmap to true (indicating that funds have been claimed).
+        data.claimableWithdraws[slot].claimedBitmap[inclusionIndex] = true;
+
+        // There is no situation where contract balance can't afford the upcoming transfer.
+        ERC20(tokenIdToAddressMap(data, tokenId)).transfer(accountToPublicKeyMap(data, accountId), amount);
+    }
+
+    function encodeFlux(uint16 accountId, uint8 tokenId, uint128 amount) internal pure returns (bytes32) {
+        return bytes32(uint(amount) + (uint(tokenId) << 128) + (uint(accountId) << 136));
+    }
+}

--- a/migrations/3_batch_auction.js
+++ b/migrations/3_batch_auction.js
@@ -1,10 +1,16 @@
 /*eslint no-undef: "off"*/
 
 const BiMap = artifacts.require("IdToAddressBiMap.sol")
+const SnappBaseCore = artifacts.require("SnappBaseCore.sol")
 const SnappAuction = artifacts.require("./SnappAuction.sol")
 
 module.exports = async function (deployer) {
   await deployer.deploy(BiMap)
+  
+  await deployer.link(BiMap, SnappBaseCore)
+  await deployer.deploy(SnappBaseCore)
+
   await deployer.link(BiMap, SnappAuction)
+  await deployer.link(SnappBaseCore, SnappAuction)
   await deployer.deploy(SnappAuction)
 }

--- a/test/snapp_auction.js
+++ b/test/snapp_auction.js
@@ -9,7 +9,6 @@ const {
 
 const {
   isActive,
-  stateHash,
   encodeOrder }  = require("./snapp_utils.js")
 
 contract("SnappAuction", async (accounts) => {
@@ -244,8 +243,7 @@ contract("SnappAuction", async (accounts) => {
       await instance.placeSellOrders(order, { from: user_1 })
 
       const slot = (await instance.auctionIndex.call()).toNumber()
-      const state_index = (await instance.stateIndex.call()).toNumber()
-      const state_root = await instance.stateRoots.call(state_index)
+      const state_root = await instance.getCurrentStateRoot()
       const auction_state = await instance.auctions.call(slot)
 
       await truffleAssert.reverts(
@@ -260,8 +258,7 @@ contract("SnappAuction", async (accounts) => {
       await instance.placeSellOrders(order, { from: user_1 })
 
       const slot = (await instance.auctionIndex.call()).toNumber()
-      const state_index = (await instance.stateIndex.call()).toNumber()
-      const state_root = await instance.stateRoots.call(state_index)
+      const state_root = await instance.getCurrentStateRoot()
       const auction_state = await instance.auctions.call(slot)
 
       assert.equal(await isActive(auction_state), true)
@@ -288,7 +285,7 @@ contract("SnappAuction", async (accounts) => {
       assert.equal(await isActive(auction_state), false)
 
       const wrong_state_root = "0x1"
-      assert.notEqual(wrong_state_root, await stateHash(instance))
+      assert.notEqual(wrong_state_root, await instance.getCurrentStateRoot())
 
       await truffleAssert.reverts(
         instance.applyAuction(slot, wrong_state_root, new_state, auction_state.shaHash, auctionSolution),
@@ -311,7 +308,7 @@ contract("SnappAuction", async (accounts) => {
       // Ensure order slot is inactive
       assert.equal(await isActive(auction_state), false)
 
-      const state_root = await stateHash(instance)
+      const state_root = await instance.getCurrentStateRoot()
       const wrong_order_hash = "0x1"
 
       assert.notEqual(wrong_order_hash, auction_state.shaHash)
@@ -337,7 +334,7 @@ contract("SnappAuction", async (accounts) => {
       // Ensure order slot is inactive
       assert.equal(await isActive(auction_state), false)
 
-      const state_root = await stateHash(instance)
+      const state_root = await instance.getCurrentStateRoot()
       const curr_slot = (await instance.auctionIndex.call()).toNumber()
 
       await truffleAssert.reverts(
@@ -361,7 +358,7 @@ contract("SnappAuction", async (accounts) => {
       // Ensure order slot is inactive
       assert.equal(await isActive(auction_state), false)
 
-      const state_root = await stateHash(instance)
+      const state_root = await instance.getCurrentStateRoot()
       
       await instance.applyAuction(slot, state_root, new_state, auction_state.shaHash, auctionSolution)
 
@@ -386,7 +383,7 @@ contract("SnappAuction", async (accounts) => {
       // Ensure order slot is inactive
       assert.equal(await isActive(auction_state), false)
 
-      const state_root = await stateHash(instance)
+      const state_root = await instance.getCurrentStateRoot()
 
       // Apply auction once
       await instance.applyAuction(slot, state_root, new_state, auction_state.shaHash, auctionSolution)
@@ -418,7 +415,7 @@ contract("SnappAuction", async (accounts) => {
       // Wait for second order slot to be inactive
       await waitForNSeconds(181)
 
-      const state_root = await stateHash(instance)
+      const state_root = await instance.getCurrentStateRoot()
 
       await truffleAssert.reverts(
         instance.applyAuction(second_slot, state_root, new_state, second_auction_state.shaHash, auctionSolution),

--- a/test/snapp_utils.js
+++ b/test/snapp_utils.js
@@ -21,13 +21,6 @@ const isActive = async function(object) {
   const timestamp = (await web3.eth.getBlock(block)).timestamp
   return timestamp <= object.creationTimestamp.toNumber() + 180
 }
-
-const stateHash = async function(contract) {
-  const state_index = (await contract.stateIndex.call()).toNumber()
-  const state_root = await contract.stateRoots.call(state_index)
-  return state_root
-}
-
 // returns byte string of hexed-sliced-padded int
 const uint8 = function(num) {
   assert(num < 2**8)
@@ -66,7 +59,6 @@ const encodeOrder = function(buyToken, sellToken, buyAmount, sellAmount) {
 module.exports = {
   falseArray,
   isActive,
-  stateHash,
   encodePacked_16_8_128,
   encodeOrder
 }


### PR DESCRIPTION
This PR moves all logic of the current SnapBase contract into a library, turning the contract itself into a thin wrapper and storage holder. For more information on solidity libraries check [here](https://solidity.readthedocs.io/en/v0.5.3/contracts.html#libraries).

This leads to a gas reduction for `SnappAuction.sol` deployment from 4.76M to 3.29M gas.

Unfortunately, I had to create a bunch of new view functions, since we cannot expose the library internal state as public (solidity won't let us). Otherwise the reduction would have been roughly twice as big. 
Nonetheless, this should give us some breathing room and we should probably do something similar for `SnappAuction.sol`

I realize and apologize that this change is quite large. It is copying a large chunk of contract code from one file into another and adjusts the tests at the same time. 
Please give it a careful review despite that, since it's easy to make a copy paste error on my side.

🤙 