### PR TITLE
Redundant Requirement

### DIFF
--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -255,10 +255,6 @@ contract SnappAuction is SnappBase {
     )
         internal view returns (bytes32)
     {
-        // Restrict buy and sell amount to occupy at most 96 bits.
-        require(buyAmount < 0x1000000000000000000000000, "Buy amount too large!");
-        require(sellAmount < 0x1000000000000000000000000, "Sell amount too large!");
-
         // Must have 0 <= tokenId < MAX_TOKENS anyway, so may as well ensure registered.
         require(buyToken < coreData.numTokens, "Buy token is not registered");
         require(sellToken < coreData.numTokens, "Sell token is not registered");


### PR DESCRIPTION
Now that sell and buy Amounts are `uint96` by default no need to check that they are passed with at most 96 bits.