### PR TITLE
Reuse code of multiSellOrder to place single order

### DIFF
--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -157,22 +157,10 @@ contract SnappAuction is SnappBase {
         uint8 sellToken,
         uint96 buyAmount,
         uint96 sellAmount
-    ) public onlyRegistered() {
-        createNewPendingBatchIfNecessary();
-
-        // Update Auction Hash based on request
-        uint16 accountId = publicKeyToAccountMap(msg.sender);
-        bytes32 nextAuctionHash = sha256(
-            abi.encodePacked(
-                auctions[auctionIndex].shaHash,
-                encodeOrder(accountId, buyToken, sellToken, buyAmount, sellAmount)
-            )
-        );
-        auctions[auctionIndex].shaHash = nextAuctionHash;
-
-        emit SellOrder(auctionIndex, auctions[auctionIndex].size, accountId, buyToken, sellToken, buyAmount, sellAmount);
-        // Only increment size after event (so it is emitted as an index)
-        auctions[auctionIndex].size++;
+    ) public {
+        // Ignore first 4 bytes padding and last two bytes accountId
+        bytes memory packed = abi.encodePacked(encodeOrder(0, buyToken, sellToken, buyAmount, sellAmount));
+        placeSellOrders(BytesLib.slice(packed, 4, 26));
     }
 
     function placeSellOrders(bytes memory packedOrders) public onlyRegistered() {
@@ -185,17 +173,18 @@ contract SnappAuction is SnappBase {
         for (uint i = 0; i < packedOrders.length / 26; i++) {
             orderData = packedOrders.slice(26*i, 26);
 
-            uint8 buyToken = BytesLib.toUint8(orderData, 0);
-            uint8 sellToken = BytesLib.toUint8(orderData, 1);
-
             uint96 buyAmount;
             assembly {  // solhint-disable no-inline-assembly
-                buyAmount := mload(add(add(orderData, 0xc), 2))
+                buyAmount := mload(add(add(orderData, 0xc), 0))
             }
             uint96 sellAmount;
             assembly {  // solhint-disable no-inline-assembly
-                sellAmount := mload(add(add(orderData, 0xc), 14))
+                sellAmount := mload(add(add(orderData, 0xc), 12))
             }
+
+            uint8 sellToken = BytesLib.toUint8(orderData, 24);
+            uint8 buyToken = BytesLib.toUint8(orderData, 25);
+
             createNewPendingBatchIfNecessary();
             bytes32 nextAuctionHash = sha256(
                 abi.encodePacked(

--- a/test/snapp_auction.js
+++ b/test/snapp_auction.js
@@ -530,10 +530,10 @@ contract("SnappAuction", async (accounts) => {
       const buyAmount = eventLog[0].args.buyAmount
       const sellAmount = eventLog[0].args.sellAmount
 
-      assert.equal(buyToken, 0)
-      assert.equal(sellToken, 1)
-      assert.equal(buyAmount, 2)
-      assert.equal(sellAmount, 3)
+      assert.equal(buyToken, 0, "buyToken not as expected")
+      assert.equal(sellToken, 1, "sellToken not as expected")
+      assert.equal(buyAmount, 2, "buyAmount not as expected")
+      assert.equal(sellAmount, 3, "sellAmount not as expected")
     })
   })
 

--- a/test/snapp_auction.js
+++ b/test/snapp_auction.js
@@ -518,7 +518,7 @@ contract("SnappAuction", async (accounts) => {
       assert.equal(currentAuction.size, 2)
     })
 
-    it("Order Encoding", async () => {
+    it("Encodes order information in emitted event", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
       const order = encodeOrder(0, 1, 2, 3)

--- a/test/snapp_auction.js
+++ b/test/snapp_auction.js
@@ -517,6 +517,24 @@ contract("SnappAuction", async (accounts) => {
 
       assert.equal(currentAuction.size, 2)
     })
+
+    it("Order Encoding", async () => {
+      const instance = await SnappAuction.new()
+      await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
+      const order = encodeOrder(0, 1, 2, 3)
+      const tx = await instance.placeSellOrders(order, { from: user_1 })
+      const eventLog = tx.logs
+
+      const buyToken = eventLog[0].args.buyToken
+      const sellToken = eventLog[0].args.sellToken
+      const buyAmount = eventLog[0].args.buyAmount
+      const sellAmount = eventLog[0].args.sellAmount
+
+      assert.equal(buyToken, 0)
+      assert.equal(sellToken, 1)
+      assert.equal(buyAmount, 2)
+      assert.equal(sellAmount, 3)
+    })
   })
 
   describe("Larger Test Cases", () => {

--- a/test/snapp_utils.js
+++ b/test/snapp_utils.js
@@ -53,7 +53,7 @@ const encodePacked_16_8_128 = function(a, b, c) {
 }
 
 const encodeOrder = function(buyToken, sellToken, buyAmount, sellAmount) {
-  return Buffer.from(uint8(buyToken) + uint8(sellToken) +  uint96(buyAmount) + uint96(sellAmount), "hex")
+  return Buffer.from(uint96(buyAmount) + uint96(sellAmount) + uint8(sellToken) + uint8(buyToken) , "hex")
 }
 
 module.exports = {


### PR DESCRIPTION
This change makes it so that we call into `placeSellOrders` from `placeSellOrder` instead of rewriting the entire logic.

For this, I aligned the way we encode packed orders in the event emission and on order placement to use the same format (buyAmount, sellAmount, sellToken, buyToken)

Test Plan: run unit tests.