### PR TITLE
Using bytes orderData instead of array of order inputs

### DIFF
--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -120,25 +120,7 @@ contract SnappAuction is SnappBase {
         bytes32 orderHash;
         bytes memory orderData;
         for (uint i = 0; i < numOrders; i++) {
-            orderData = packedOrders.slice(26*i, 26);
-
-            uint8 buyToken = BytesLib.toUint8(orderData, 0);
-            uint8 sellToken = BytesLib.toUint8(orderData, 1);
-
-            uint96 buyAmount;
-            assembly {  // solhint-disable no-inline-assembly
-                buyAmount := mload(add(add(orderData, 0xc), 2))
-            }
-            uint96 sellAmount;
-            assembly {  // solhint-disable no-inline-assembly
-                sellAmount := mload(add(add(orderData, 0xc), 14))
-            }
-            orderHash = sha256(
-                abi.encodePacked(
-                    orderHash,
-                    encodeOrder(accountId, buyToken, sellToken, buyAmount, sellAmount)
-                )
-            );
+            orderhash = calculateNextOrderHashIteration(packedOrders.slice(26*i, 26), orderhash);
         }
         uint currentBatchIndex = standingOrders[accountId].currentBatchIndex;
         StandingOrderBatch memory currentOrderBatch = standingOrders[accountId].reservedAccountOrders[currentBatchIndex];
@@ -176,27 +158,8 @@ contract SnappAuction is SnappBase {
         bytes memory orderData;
 
         for (uint i = 0; i < packedOrders.length / 26; i++) {
-            orderData = packedOrders.slice(26*i, 26);
-
-            uint96 buyAmount;
-            assembly {  // solhint-disable no-inline-assembly
-                buyAmount := mload(add(add(orderData, 0xc), 0))
-            }
-            uint96 sellAmount;
-            assembly {  // solhint-disable no-inline-assembly
-                sellAmount := mload(add(add(orderData, 0xc), 12))
-            }
-
-            uint8 sellToken = BytesLib.toUint8(orderData, 24);
-            uint8 buyToken = BytesLib.toUint8(orderData, 25);
-
             createNewPendingBatchIfNecessary();
-            bytes32 nextAuctionHash = sha256(
-                abi.encodePacked(
-                    auctions[auctionIndex].shaHash,  // TODO - Below todo will affect this.
-                    encodeOrder(accountId, buyToken, sellToken, buyAmount, sellAmount)
-                )
-            );
+            bytes32 nextAuctionHash = calculateNextOrderHashIteration(packedOrders.slice(26*i, 26), auctions[auctionIndex].shaHash);
             // TODO - auctions.shaHash should only need to be updated once (per index) on the outside of this loop
             auctions[auctionIndex].shaHash = nextAuctionHash;
             
@@ -261,6 +224,27 @@ contract SnappAuction is SnappBase {
 
         // solhint-disable-next-line max-line-length
         return bytes32(uint(accountId) + (uint(buyToken) << 16) + (uint(sellToken) << 24) + (uint(sellAmount) << 32) + (uint(buyAmount) << 128));
+    }
+    function calculateNextOrderHashIteration(bytes orderData, bytes32 previousHash) internal
+        returns(bytes32)
+    {
+        buyToken = BytesLib.toUint8(orderData, 0);
+        sellToken = BytesLib.toUint8(orderData, 1);
+
+        buyAmount;
+        assembly {  // solhint-disable no-inline-assembly
+            buyAmount := mload(add(add(orderData, 0xc), 2))
+        }
+        sellAmount;
+        assembly {  // solhint-disable no-inline-assembly
+            sellAmount := mload(add(add(orderData, 0xc), 14))
+        }
+        return nextHash = sha256(
+                abi.encodePacked(
+                    previousHash,  // TODO - Below todo will affect this.
+                    encodeOrder(accountId, buyToken, sellToken, buyAmount, sellAmount)
+                )
+            );
     }
 
     function createNewPendingBatch() internal {

--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -30,7 +30,7 @@ contract SnappAuction is SnappBase {
 
     event SellOrder(
         uint auctionId,
-        uint16 slotStartIndex,
+        uint16 slotIndex,
         uint16 accountId,
         bytes packedOrder
     );
@@ -241,10 +241,10 @@ contract SnappAuction is SnappBase {
 
         return sha256(
             abi.encodePacked(
-                    previousHash,
-                    encodeOrder(accountId, buyToken, sellToken, buyAmount, sellAmount)
-                )
-            );
+                previousHash,
+                encodeOrder(accountId, buyToken, sellToken, buyAmount, sellAmount)
+            )
+        );
     }
 
     function createNewPendingBatch() internal {

--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -157,22 +157,10 @@ contract SnappAuction is SnappBase {
         uint8 sellToken,
         uint96 buyAmount,
         uint96 sellAmount
-    ) public onlyRegistered() {
-        createNewPendingBatchIfNecessary();
-
-        // Update Auction Hash based on request
-        uint16 accountId = publicKeyToAccountMap(msg.sender);
-        bytes32 nextAuctionHash = sha256(
-            abi.encodePacked(
-                auctions[auctionIndex].shaHash,
-                encodeOrder(accountId, buyToken, sellToken, buyAmount, sellAmount)
-            )
-        );
-        auctions[auctionIndex].shaHash = nextAuctionHash;
-
-        emit SellOrder(auctionIndex, auctions[auctionIndex].size, accountId, buyToken, sellToken, buyAmount, sellAmount);
-        // Only increment size after event (so it is emitted as an index)
-        auctions[auctionIndex].size++;
+    ) public {
+        // Ignore first 4 bytes padding and last two bytes accountId
+        bytes memory packed = abi.encodePacked(encodeOrder(0, buyToken, sellToken, buyAmount, sellAmount));
+        placeSellOrders(BytesLib.slice(packed, 4, 26));
     }
 
     function placeSellOrders(bytes memory packedOrders) public onlyRegistered() {
@@ -185,17 +173,18 @@ contract SnappAuction is SnappBase {
         for (uint i = 0; i < packedOrders.length / 26; i++) {
             orderData = packedOrders.slice(26*i, 26);
 
-            uint8 buyToken = BytesLib.toUint8(orderData, 0);
-            uint8 sellToken = BytesLib.toUint8(orderData, 1);
-
             uint96 buyAmount;
             assembly {  // solhint-disable no-inline-assembly
-                buyAmount := mload(add(add(orderData, 0xc), 2))
+                buyAmount := mload(add(add(orderData, 0xc), 0))
             }
             uint96 sellAmount;
             assembly {  // solhint-disable no-inline-assembly
-                sellAmount := mload(add(add(orderData, 0xc), 14))
+                sellAmount := mload(add(add(orderData, 0xc), 12))
             }
+
+            uint8 sellToken = BytesLib.toUint8(orderData, 24);
+            uint8 buyToken = BytesLib.toUint8(orderData, 25);
+
             createNewPendingBatchIfNecessary();
             bytes32 nextAuctionHash = sha256(
                 abi.encodePacked(

--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -118,7 +118,6 @@ contract SnappAuction is SnappBase {
             createNewPendingBatch();
         }
         bytes32 orderHash;
-        bytes memory orderData;
         for (uint i = 0; i < numOrders; i++) {
             orderhash = calculateNextOrderHashIteration(packedOrders.slice(26*i, 26), orderhash);
         }
@@ -155,11 +154,13 @@ contract SnappAuction is SnappBase {
         require(packedOrders.length % 26 == 0, "Each order should be packed in 26 bytes!");
         // TODO - use ECRecover from signature contained in first 65 bytes of packedOrder
         uint16 accountId = publicKeyToAccountMap(msg.sender);
-        bytes memory orderData;
 
         for (uint i = 0; i < packedOrders.length / 26; i++) {
             createNewPendingBatchIfNecessary();
-            bytes32 nextAuctionHash = calculateNextOrderHashIteration(packedOrders.slice(26*i, 26), auctions[auctionIndex].shaHash);
+            bytes32 nextAuctionHash = calculateNextOrderHashIteration(
+                packedOrders.slice(26*i, 26),
+                auctions[auctionIndex].shaHash
+            );
             // TODO - auctions.shaHash should only need to be updated once (per index) on the outside of this loop
             auctions[auctionIndex].shaHash = nextAuctionHash;
             
@@ -225,6 +226,7 @@ contract SnappAuction is SnappBase {
         // solhint-disable-next-line max-line-length
         return bytes32(uint(accountId) + (uint(buyToken) << 16) + (uint(sellToken) << 24) + (uint(sellAmount) << 32) + (uint(buyAmount) << 128));
     }
+
     function calculateNextOrderHashIteration(bytes orderData, bytes32 previousHash) internal
         returns(bytes32)
     {
@@ -240,7 +242,7 @@ contract SnappAuction is SnappBase {
             sellAmount := mload(add(add(orderData, 0xc), 14))
         }
         return nextHash = sha256(
-                abi.encodePacked(
+            abi.encodePacked(
                     previousHash,  // TODO - Below todo will affect this.
                     encodeOrder(accountId, buyToken, sellToken, buyAmount, sellAmount)
                 )

--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -30,7 +30,7 @@ contract SnappAuction is SnappBase {
 
     event SellOrder(
         uint auctionId,
-        uint16 slotIndex,
+        uint16 slotStartIndex,
         uint16 accountId,
         bytes packedOrder
     );
@@ -164,7 +164,7 @@ contract SnappAuction is SnappBase {
             );
             // TODO - auctions.shaHash should only need to be updated once (per index) on the outside of this loop
             auctions[auctionIndex].shaHash = nextAuctionHash;
-            
+
             // Only increment size after event (so it is emitted as an index)
             auctions[auctionIndex].size++;
         }
@@ -205,7 +205,7 @@ contract SnappAuction is SnappBase {
     function maxUnreservedOrderCount() public pure returns (uint16) {
         return AUCTION_BATCH_SIZE - (AUCTION_RESERVED_ACCOUNTS * AUCTION_RESERVED_ACCOUNT_BATCH_SIZE);
     }
-    
+
     function encodeOrder(
         uint16 accountId,
         uint8 buyToken,

--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -241,7 +241,7 @@ contract SnappAuction is SnappBase {
 
         return sha256(
             abi.encodePacked(
-                    previousHash,  // TODO - Below todo will affect this.
+                    previousHash,
                     encodeOrder(accountId, buyToken, sellToken, buyAmount, sellAmount)
                 )
             );

--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -32,19 +32,13 @@ contract SnappAuction is SnappBase {
         uint auctionId,
         uint16 slotIndex,
         uint16 accountId,
-        uint8 buyToken,
-        uint8 sellToken,
-        uint96 buyAmount,
-        uint96 sellAmount
+        bytes packedOrders
     );
 
     event StandingSellOrderBatch(
         uint currentBatchIndex,
         uint16 accountId,
-        uint8[] buyToken,
-        uint8[] sellToken,
-        uint96[] buyAmount,
-        uint96[] sellAmount
+        bytes packedOrders
     );
 
     event AuctionSettlement(
@@ -106,18 +100,15 @@ contract SnappAuction is SnappBase {
      * Auction Functionality
      */
     function placeStandingSellOrder(
-        uint8[] memory buyTokens,
-        uint8[] memory sellTokens,
-        uint96[] memory buyAmounts,
-        uint96[] memory sellAmounts
+        bytes memory packedOrders
     ) public onlyRegistered() {
 
         // Update Auction Hash based on request
         uint16 accountId = publicKeyToAccountMap(msg.sender);
         require(accountId <= AUCTION_RESERVED_ACCOUNTS, "Accout is not a reserved account");
 
-        bytes32 orderHash;
-        uint numOrders = buyTokens.length;
+        require(packedOrders.length % 26 == 0, "Each order should be packed in 26 bytes!");
+        uint numOrders = packedOrders.length / 26;
         require(numOrders <= AUCTION_RESERVED_ACCOUNT_BATCH_SIZE, "Too many orders for reserved batch");
 
         if (
@@ -126,12 +117,26 @@ contract SnappAuction is SnappBase {
         ) {
             createNewPendingBatch();
         }
-
+        bytes32 orderHash;
+        bytes memory orderData;
         for (uint i = 0; i < numOrders; i++) {
+            orderData = packedOrders.slice(26*i, 26);
+
+            uint8 buyToken = BytesLib.toUint8(orderData, 0);
+            uint8 sellToken = BytesLib.toUint8(orderData, 1);
+
+            uint96 buyAmount;
+            assembly {  // solhint-disable no-inline-assembly
+                buyAmount := mload(add(add(orderData, 0xc), 2))
+            }
+            uint96 sellAmount;
+            assembly {  // solhint-disable no-inline-assembly
+                sellAmount := mload(add(add(orderData, 0xc), 14))
+            }
             orderHash = sha256(
                 abi.encodePacked(
                     orderHash,
-                    encodeOrder(accountId, buyTokens[i], sellTokens[i], buyAmounts[i], sellAmounts[i])
+                    encodeOrder(accountId, buyToken, sellToken, buyAmount, sellAmount)
                 )
             );
         }
@@ -149,7 +154,7 @@ contract SnappAuction is SnappBase {
         //TODO: The case auctionIndex < currentOrderBatch.validFromIndex can happen once roll-backs are implemented
         //Then we have to revert the orderplacement
         standingOrders[accountId].reservedAccountOrders[currentBatchIndex] = currentOrderBatch;
-        emit StandingSellOrderBatch(currentBatchIndex, accountId, buyTokens, sellTokens, buyAmounts, sellAmounts);
+        emit StandingSellOrderBatch(currentBatchIndex, accountId, packedOrders);
     }
 
     function placeSellOrder(
@@ -170,7 +175,10 @@ contract SnappAuction is SnappBase {
         );
         auctions[auctionIndex].shaHash = nextAuctionHash;
 
-        emit SellOrder(auctionIndex, auctions[auctionIndex].size, accountId, buyToken, sellToken, buyAmount, sellAmount);
+        emit SellOrder(
+            auctionIndex, auctions[auctionIndex].size, accountId,
+            abi.encode((uint(buyToken) << 16) + (uint(sellToken) << 24) + (uint(sellAmount) << 32) + (uint(buyAmount) << 128))
+        );
         // Only increment size after event (so it is emitted as an index)
         auctions[auctionIndex].size++;
     }
@@ -205,12 +213,13 @@ contract SnappAuction is SnappBase {
             );
             // TODO - auctions.shaHash should only need to be updated once (per index) on the outside of this loop
             auctions[auctionIndex].shaHash = nextAuctionHash;
-            emit SellOrder(
-                auctionIndex, auctions[auctionIndex].size, accountId, buyToken, sellToken, buyAmount, sellAmount
-            );
+            
             // Only increment size after event (so it is emitted as an index)
             auctions[auctionIndex].size++;
         }
+        emit SellOrder(
+            auctionIndex, auctions[auctionIndex].size, accountId, packedOrders
+            );
     }
 
     function applyAuction(

--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -32,7 +32,7 @@ contract SnappAuction is SnappBase {
         uint auctionId,
         uint16 slotIndex,
         uint16 accountId,
-        bytes packedOrders
+        bytes packedOrder
     );
 
     event StandingSellOrderBatch(

--- a/test/snapp_auction.js
+++ b/test/snapp_auction.js
@@ -538,7 +538,7 @@ contract("SnappAuction", async (accounts) => {
       assert.equal(currentAuction.size, 2)
     })
 
-    it.only("Encodes order information in emitted event", async () => {
+    it("Encodes order information in emitted event", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
       const order = encodeOrder(0, 1, 2, 3)

--- a/test/snapp_utils.js
+++ b/test/snapp_utils.js
@@ -53,7 +53,7 @@ const encodePacked_16_8_128 = function(a, b, c) {
 }
 
 const encodeOrder = function(buyToken, sellToken, buyAmount, sellAmount) {
-  return Buffer.from(uint8(buyToken) + uint8(sellToken) +  uint96(buyAmount) + uint96(sellAmount), "hex")
+  return Buffer.from(uint96(buyAmount) + uint96(sellAmount) + uint8(sellToken) + uint8(buyToken) , "hex")
 }
 
 module.exports = {

--- a/test/snapp_utils.js
+++ b/test/snapp_utils.js
@@ -60,5 +60,5 @@ module.exports = {
   falseArray,
   isActive,
   encodePacked_16_8_128,
-  encodeOrder  
+  encodeOrder
 }

--- a/test/snapp_utils.js
+++ b/test/snapp_utils.js
@@ -60,5 +60,5 @@ module.exports = {
   falseArray,
   isActive,
   encodePacked_16_8_128,
-  encodeOrder
+  encodeOrder  
 }


### PR DESCRIPTION
This PR is making sure that the orders are no longer emitted with separate variables buyToken, sellToken, buyAmounts, sellAmount
but instead, are just emitted as one order blob
```
event SellOrder(
        uint auctionId,
        uint16 slotIndex,
        uint16 accountId,
        uint8 buyToken,
        uint8 sellToken,
        uint96 buyAmount,
        uint96 sellAmount
    );
to
event SellOrder(
        uint auctionId,
        uint16 slotStartIndex,
        uint16 accountId,
        bytes orderData
    );
```
it also makes sure that placing order is done with packedOrderdata as well.

testplan:
unit tests only

