### PR TITLE
[HiPri] Multiple small fixes to make current version work for services repo

### DIFF
--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -68,6 +68,10 @@ contract SnappBase is Ownable {
         return coreData.pendingWithdraws[slot].shaHash;
     }
 
+    function getClaimableWithdrawHash(uint slot) public view returns (bytes32) {
+        return coreData.claimableWithdraws[slot].merkleRoot;
+    }
+
     function hasWithdrawBeenClaimed(uint slot, uint16 index) public view returns (bool) {
         return coreData.claimableWithdraws[slot].claimedBitmap[index];
     }

--- a/contracts/libraries/SnappBaseCore.sol
+++ b/contracts/libraries/SnappBaseCore.sol
@@ -17,7 +17,7 @@ library SnappBaseCore {
 
     event WithdrawRequest(uint16 accountId, uint8 tokenId, uint128 amount, uint slot, uint16 slotIndex);
     event Deposit(uint16 accountId, uint8 tokenId, uint128 amount, uint slot, uint16 slotIndex);
-    event StateTransition(TransitionType transitionType, uint stateIndex, bytes32 stateHash, uint slot);
+    event StateTransition(uint8 transitionType, uint stateIndex, bytes32 stateHash, uint slot);
     event SnappInitialization(bytes32 stateHash, uint8 maxTokens, uint16 maxAccounts);
 
     enum TransitionType {
@@ -160,7 +160,7 @@ library SnappBaseCore {
         data.stateRoots.push(_newStateRoot);
         data.deposits[slot].appliedAccountStateIndex = stateIndex(data);
 
-        emit StateTransition(TransitionType.Deposit, stateIndex(data), _newStateRoot, slot);
+        emit StateTransition(uint8(TransitionType.Deposit), stateIndex(data), _newStateRoot, slot);
     }
 
     /**
@@ -234,7 +234,7 @@ library SnappBaseCore {
             appliedAccountStateIndex: stateIndex(data)
         });
 
-        emit StateTransition(TransitionType.Withdraw, stateIndex(data), _newStateRoot, slot);
+        emit StateTransition(uint8(TransitionType.Withdraw), stateIndex(data), _newStateRoot, slot);
     }
 
     function claimWithdrawal(

--- a/package-lock.json
+++ b/package-lock.json
@@ -1057,8 +1057,7 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
       "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "encoding": {
       "version": "0.1.12",
@@ -1892,8 +1891,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1914,14 +1912,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1936,20 +1932,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2066,8 +2059,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2079,7 +2071,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2094,7 +2085,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2102,14 +2092,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2128,7 +2116,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2216,8 +2203,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2229,7 +2215,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2315,8 +2300,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2352,7 +2336,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2372,7 +2355,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2416,14 +2398,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -3660,7 +3640,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -4058,7 +4038,7 @@
     },
     "os-locale": {
       "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "resolved": "http://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
       "requires": {
         "lcid": "^1.0.0"
@@ -6328,7 +6308,7 @@
           "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
           "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
           "requires": {
-            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#master",
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
             "crypto-js": "^3.1.4",
             "utf8": "^2.1.1",
             "xmlhttprequest": "*"
@@ -6368,7 +6348,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/scripts/apply_deposits.js
+++ b/scripts/apply_deposits.js
@@ -10,19 +10,15 @@ module.exports = async (callback) => {
     const [slot, new_state] = arguments
     
     const instance = await SnappAuction.deployed()
-    const state_index = (await instance.stateIndex.call()).toNumber()
-    const curr_state = await instance.stateRoots.call(state_index)
+    const curr_state = await instance.getCurrentStateRoot()
 
-    const deposit_state = await instance.deposits.call(slot)
-    if (deposit_state.appliedAccountStateIndex != 0) {
+    if (await instance.hasDepositBeenApplied(slot)) {
       callback("Error: Requested deposit slot has already been applied")
     }
 
     console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
-    await instance.applyDeposits(slot, curr_state, new_state, deposit_state.shaHash)
-    const updated_state = await instance.deposits.call(slot)
+    await instance.applyDeposits(slot, curr_state, new_state, await instance.getDepositHash(slot))
     console.log("Successfully applied Deposits!")
-    console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex.toNumber())
     callback()
   } catch (error) {
     callback(error)

--- a/scripts/apply_withdrawals.js
+++ b/scripts/apply_withdrawals.js
@@ -14,16 +14,13 @@ module.exports = async (callback) => {
     const state_index = (await instance.stateIndex.call()).toNumber()
     const curr_state = await instance.stateRoots.call(state_index)
 
-    const withdraw_state = await instance.pendingWithdraws.call(slot)
-    if (withdraw_state.appliedAccountStateIndex != 0) {
+    if (await instance.hasWithdrawBeenApplied(slot)) {
       callback("Error: Requested withdraw slot has already been applied")
     }
 
     console.log("Current slot for: %d with curr_state %s and new_state %s", slot, curr_state, new_state)
-    await instance.applyWithdrawals(slot, merkle_root, curr_state, new_state, withdraw_state.shaHash)
-    const updated_state = await instance.pendingWithdraws.call(slot)
+    await instance.applyWithdrawals(slot, merkle_root, curr_state, new_state, await instance.getWithdrawHash(slot))
     console.log("Successfully applied Withdrawals!")
-    console.log("New appliedAccountStateIndex is:", updated_state.appliedAccountStateIndex.toNumber())
     callback()
   } catch (error) {
     callback(error)

--- a/scripts/claim_withdraw.js
+++ b/scripts/claim_withdraw.js
@@ -51,9 +51,7 @@ module.exports = async (callback) => {
       callback(`Error: No token registered at index ${tokenId}`)
     }
 
-    // Verify slot has been processed
-    const claimableState = await instance.claimableWithdraws(slot)
-    if (claimableState.appliedAccountStateIndex == 0) {
+    if (await instance.isPendingWithdrawActive(slot)) {
       callback(`Error: Requested slot ${slot} not been processed!`)
     }
 
@@ -72,9 +70,10 @@ module.exports = async (callback) => {
       }
     }
     const tree = new MerkleTree(withdraw_hashes, sha256)
+    const claimable_root = await instance.getClaimableWithdrawHash(slot)
     // Verify merkle roots agree
-    if (claimableState.merkleRoot != toHex(tree.getRoot())) {
-      callback(`Merkle Roots disagree: ${claimableState.merkleRoot} != ${toHex(tree.getRoot())}`)
+    if (claimable_root != toHex(tree.getRoot())) {
+      callback(`Merkle Roots disagree: ${claimable_root} != ${toHex(tree.getRoot())}`)
     }
 
     for (let i = 0; i < valid_withdrawals.length; i++) {

--- a/scripts/deposit.js
+++ b/scripts/deposit.js
@@ -34,7 +34,7 @@ module.exports = async (callback) => {
     const slot = tx.logs[0].args.slot.toNumber()
     const slot_index = tx.logs[0].args.slotIndex.toNumber()
   
-    const deposit_hash = (await instance.deposits(slot)).shaHash
+    const deposit_hash = (await instance.getDepositHash(slot))
     console.log("Deposit successful: Slot %s - Index %s - Hash %s", slot, slot_index, deposit_hash)
     callback()
   } catch(error) {

--- a/scripts/request_withdraw.js
+++ b/scripts/request_withdraw.js
@@ -26,7 +26,7 @@ module.exports = async (callback) => {
     const slot = tx.logs[0].args.slot.toNumber()
     const slot_index = tx.logs[0].args.slotIndex.toNumber()
   
-    const withdraw_hash = (await instance.pendingWithdraws(slot)).shaHash
+    const withdraw_hash = (await instance.getWithdrawHash(slot))
     console.log("Withdraw Request successful: Slot %s - Index %s - Hash %s", slot, slot_index, withdraw_hash)
     callback()
   } catch(error) {


### PR DESCRIPTION
I forget to adjust the truffle scripts the e2e test is using.

Fixes include:
1. Expose new view function to get `claimWithdraw`
2. Don't access state directly in truffle script, use view functions instead
3. Emit StateTransition as a uint since for some unknown reason `django-eth-events` does not react to events that are emitted with an enum (only when in a lib).

I will create an issue on their github for the last thing.

TestPlan:

Update contracts submodule in dex-services repo to this version (on the branch that is fixing the issues inside the services repo). Run e2e tests.