### PR TITLE
Revert #124

### DIFF
--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -23,7 +23,7 @@ contract SnappAuction is SnappBase {
         uint currentBatchIndex;
     }
 
-    mapping (uint24 => StandingOrderData) public standingOrders;
+    mapping (uint16 => StandingOrderData) public standingOrders;
 
     uint public auctionIndex = MAX_UINT;
     mapping (uint => SnappBaseCore.PendingBatch) public auctions;
@@ -31,7 +31,7 @@ contract SnappAuction is SnappBase {
     event SellOrder(
         uint auctionId,
         uint16 slotIndex,
-        uint24 accountId,
+        uint16 accountId,
         uint8 buyToken,
         uint8 sellToken,
         uint96 buyAmount,
@@ -40,7 +40,7 @@ contract SnappAuction is SnappBase {
 
     event StandingSellOrderBatch(
         uint currentBatchIndex,
-        uint24 accountId,
+        uint16 accountId,
         uint8[] buyToken,
         uint8[] sellToken,
         uint96[] buyAmount,
@@ -81,16 +81,16 @@ contract SnappAuction is SnappBase {
         return auctions[slot].appliedAccountStateIndex != 0;
     }
 
-    function getStandingOrderHash(uint24 accountId, uint128 batchIndex) public view returns (bytes32) {
-        return standingOrders[accountId].reservedAccountOrders[batchIndex].orderHash;
+    function getStandingOrderHash(uint16 userId, uint128 batchIndex) public view returns (bytes32) {
+        return standingOrders[userId].reservedAccountOrders[batchIndex].orderHash;
     }
 
-    function getStandingOrderValidFrom(uint24 accountId, uint128 batchIndex) public view returns (uint) {
-        return standingOrders[accountId].reservedAccountOrders[batchIndex].validFromIndex;
+    function getStandingOrderValidFrom(uint16 userId, uint128 batchIndex) public view returns (uint) {
+        return standingOrders[userId].reservedAccountOrders[batchIndex].validFromIndex;
     }
 
-    function getStandingOrderValidTo(uint24 accountId, uint128 batchIndex) public view returns (uint) {
-        uint validTo = standingOrders[accountId].reservedAccountOrders[batchIndex + 1].validFromIndex;
+    function getStandingOrderValidTo(uint16 userId, uint128 batchIndex) public view returns (uint) {
+        uint validTo = standingOrders[userId].reservedAccountOrders[batchIndex + 1].validFromIndex;
         if (validTo == 0) {
             return MAX_UINT;
         } else {
@@ -98,8 +98,8 @@ contract SnappAuction is SnappBase {
         }
     }
 
-    function getStandingOrderCounter(uint24 accountId) public view returns (uint) {
-        return standingOrders[accountId].currentBatchIndex;
+    function getStandingOrderCounter(uint16 userId) public view returns (uint) {
+        return standingOrders[userId].currentBatchIndex;
     }
 
     /**
@@ -113,7 +113,7 @@ contract SnappAuction is SnappBase {
     ) public onlyRegistered() {
 
         // Update Auction Hash based on request
-        uint24 accountId = publicKeyToAccountMap(msg.sender);
+        uint16 accountId = publicKeyToAccountMap(msg.sender);
         require(accountId <= AUCTION_RESERVED_ACCOUNTS, "Accout is not a reserved account");
 
         bytes32 orderHash;
@@ -167,7 +167,7 @@ contract SnappAuction is SnappBase {
         // Note that this could result failure of all orders if even one fails.
         require(packedOrders.length % 26 == 0, "Each order should be packed in 26 bytes!");
         // TODO - use ECRecover from signature contained in first 65 bytes of packedOrder
-        uint24 accountId = publicKeyToAccountMap(msg.sender);
+        uint16 accountId = publicKeyToAccountMap(msg.sender);
         bytes memory orderData;
 
         for (uint i = 0; i < packedOrders.length / 26; i++) {
@@ -236,7 +236,7 @@ contract SnappAuction is SnappBase {
     }
     
     function encodeOrder(
-        uint24 accountId,
+        uint16 accountId,
         uint8 buyToken,
         uint8 sellToken,
         uint96 buyAmount,

--- a/contracts/SnappBase.sol
+++ b/contracts/SnappBase.sol
@@ -80,30 +80,30 @@ contract SnappBase is Ownable {
         return block.timestamp <= coreData.deposits[slot].creationTimestamp + 3 minutes;
     }
 
-    function publicKeyToAccountMap(address addr) public view returns (uint24) {
+    function publicKeyToAccountMap(address addr) public view returns (uint16) {
         return coreData.publicKeyToAccountMap(addr);
     }
 
-    function accountToPublicKeyMap(uint24 id) public view returns (address) {
+    function accountToPublicKeyMap(uint16 id) public view returns (address) {
         return coreData.accountToPublicKeyMap(id);
     }
 
-    function tokenAddresToIdMap(address addr) public view returns (uint24) {
+    function tokenAddresToIdMap(address addr) public view returns (uint16) {
         return IdToAddressBiMap.getId(coreData.registeredTokens, addr);
     }
 
-    function tokenIdToAddressMap(uint24 id) public view returns (address) {
+    function tokenIdToAddressMap(uint16 id) public view returns (address) {
         return coreData.tokenIdToAddressMap(id);
     }
 
-    function hasAccount(uint24 accountId) public view returns (bool) {
+    function hasAccount(uint16 accountId) public view returns (bool) {
         return IdToAddressBiMap.hasId(coreData.registeredAccounts, accountId);
     }
 
     /**
      * General Snapp Functionality
      */
-    function openAccount(uint24 accountId) public {
+    function openAccount(uint16 accountId) public {
         coreData.openAccount(accountId);
     }
 
@@ -151,7 +151,7 @@ contract SnappBase is Ownable {
     function claimWithdrawal(
         uint slot,
         uint16 inclusionIndex,
-        uint24 accountId,
+        uint16 accountId,
         uint8 tokenId,
         uint128 amount,
         bytes memory proof

--- a/contracts/libraries/IdToAddressBiMap.sol
+++ b/contracts/libraries/IdToAddressBiMap.sol
@@ -3,11 +3,11 @@ pragma solidity ^0.5.0;
 
 library IdToAddressBiMap {
     struct Data {
-        mapping(uint24 => address) idToAddress;
-        mapping(address => uint24) addressToId;
+        mapping(uint16 => address) idToAddress;
+        mapping(address => uint16) addressToId;
     }
 
-    function hasId(Data storage self, uint24 id) public view returns (bool) {
+    function hasId(Data storage self, uint16 id) public view returns (bool) {
         return self.idToAddress[id + 1] != address(0);
     }
 
@@ -15,17 +15,17 @@ library IdToAddressBiMap {
         return self.addressToId[addr] != 0;
     }
 
-    function getAddressAt(Data storage self, uint24 id) public view returns (address) {
+    function getAddressAt(Data storage self, uint16 id) public view returns (address) {
         require(hasId(self, id), "Must have ID to get Address");
         return self.idToAddress[id + 1];
     }
 
-    function getId(Data storage self, address addr) public view returns (uint24) {
+    function getId(Data storage self, address addr) public view returns (uint16) {
         require(hasAddress(self, addr), "Must have Address to get ID");
         return self.addressToId[addr] - 1;
     }
 
-    function insert(Data storage self, uint24 id, address addr) public returns (bool) {
+    function insert(Data storage self, uint16 id, address addr) public returns (bool) {
         // Ensure bijectivity of the mappings
         if (self.addressToId[addr] != 0 || self.idToAddress[id + 1] != address(0)) {
             return false;

--- a/contracts/libraries/SnappBaseCore.sol
+++ b/contracts/libraries/SnappBaseCore.sol
@@ -10,15 +10,15 @@ library SnappBaseCore {
     using Merkle for bytes32;
 
     uint public constant MAX_UINT = 2**256 - 1;
-    uint24 public constant MAX_ACCOUNT_ID = 2**24 - 2;
+    uint8 public constant MAX_ACCOUNT_ID = 100;
     uint8 public constant MAX_TOKENS = 30;
     uint8 public constant DEPOSIT_BATCH_SIZE = 100;
     uint8 public constant WITHDRAW_BATCH_SIZE = 100;
 
-    event WithdrawRequest(uint24 accountId, uint8 tokenId, uint128 amount, uint slot, uint16 slotIndex);
-    event Deposit(uint24 accountId, uint8 tokenId, uint128 amount, uint slot, uint16 slotIndex);
+    event WithdrawRequest(uint16 accountId, uint8 tokenId, uint128 amount, uint slot, uint16 slotIndex);
+    event Deposit(uint16 accountId, uint8 tokenId, uint128 amount, uint slot, uint16 slotIndex);
     event StateTransition(uint8 transitionType, uint stateIndex, bytes32 stateHash, uint slot);
-    event SnappInitialization(bytes32 stateHash, uint8 maxTokens, uint24 maxAccounts);
+    event SnappInitialization(bytes32 stateHash, uint8 maxTokens, uint16 maxAccounts);
 
     enum TransitionType {
         Deposit,
@@ -67,23 +67,23 @@ library SnappBaseCore {
         return data.stateRoots.length - 1;
     }
 
-    function publicKeyToAccountMap(Data storage data, address addr) public view returns (uint24) {
+    function publicKeyToAccountMap(Data storage data, address addr) public view returns (uint16) {
         return IdToAddressBiMap.getId(data.registeredAccounts, addr);
     }
 
-    function accountToPublicKeyMap(Data storage data, uint24 accountId) public view returns (address) {
-        return IdToAddressBiMap.getAddressAt(data.registeredAccounts, accountId);
+    function accountToPublicKeyMap(Data storage data, uint16 id) public view returns (address) {
+        return IdToAddressBiMap.getAddressAt(data.registeredAccounts, id);
     }
 
-    function tokenIdToAddressMap(Data storage data, uint24 tokenId) public view returns (address) {
-        return IdToAddressBiMap.getAddressAt(data.registeredTokens, tokenId);
+    function tokenIdToAddressMap(Data storage data, uint16 id) public view returns (address) {
+        return IdToAddressBiMap.getAddressAt(data.registeredTokens, id);
     }
 
     /**
      * General Snapp Functionality
      */
-    function openAccount(Data storage data, uint24 accountId) public {
-        require(accountId <= MAX_ACCOUNT_ID, "Account index exceeds max");
+    function openAccount(Data storage data, uint16 accountId) public {
+        require(accountId < MAX_ACCOUNT_ID, "Account index exceeds max");
         require(
             IdToAddressBiMap.insert(data.registeredAccounts, accountId, msg.sender),
             "Address occupies slot or requested slot already taken"
@@ -124,7 +124,7 @@ library SnappBaseCore {
         }
 
         // Update Deposit Hash based on request
-        uint24 accountId = publicKeyToAccountMap(data, msg.sender);
+        uint16 accountId = publicKeyToAccountMap(data, msg.sender);
         bytes32 nextDepositHash = sha256(
             abi.encodePacked(data.deposits[data.depositIndex].shaHash, encodeFlux(accountId, tokenId, amount))
         );
@@ -191,7 +191,7 @@ library SnappBaseCore {
         }
 
         // Update Withdraw Hash based on request
-        uint24 accountId = publicKeyToAccountMap(data, msg.sender);
+        uint16 accountId = publicKeyToAccountMap(data, msg.sender);
         bytes32 nextWithdrawHash = sha256(
             abi.encodePacked(data.pendingWithdraws[data.withdrawIndex].shaHash, encodeFlux(accountId, tokenId, amount))
         );
@@ -241,7 +241,7 @@ library SnappBaseCore {
         Data storage data,
         uint slot,
         uint16 inclusionIndex,
-        uint24 accountId,
+        uint16 accountId,
         uint8 tokenId,
         uint128 amount,
         bytes memory proof
@@ -263,7 +263,7 @@ library SnappBaseCore {
         ERC20(tokenIdToAddressMap(data, tokenId)).transfer(accountToPublicKeyMap(data, accountId), amount);
     }
 
-    function encodeFlux(uint24 accountId, uint8 tokenId, uint128 amount) internal pure returns (bytes32) {
+    function encodeFlux(uint16 accountId, uint8 tokenId, uint128 amount) internal pure returns (bytes32) {
         return bytes32(uint(amount) + (uint(tokenId) << 128) + (uint(accountId) << 136));
     }
 }

--- a/contracts/libraries/wrapppers/IdToAddressBiMapWrapper.sol
+++ b/contracts/libraries/wrapppers/IdToAddressBiMapWrapper.sol
@@ -6,7 +6,7 @@ import "../IdToAddressBiMap.sol";
 contract IdToAddressBiMapWrapper {
     IdToAddressBiMap.Data private map;
 
-    function hasId(uint24 id) public view returns (bool) {
+    function hasId(uint16 id) public view returns (bool) {
         return IdToAddressBiMap.hasId(map, id);
     }
 
@@ -14,15 +14,15 @@ contract IdToAddressBiMapWrapper {
         return IdToAddressBiMap.hasAddress(map, addr);
     }
 
-    function getAddressAt(uint24 id) public view returns (address) {
+    function getAddressAt(uint16 id) public view returns (address) {
         return IdToAddressBiMap.getAddressAt(map, id);
     }
 
-    function getId(address addr) public view returns (uint24) {
+    function getId(address addr) public view returns (uint16) {
         return IdToAddressBiMap.getId(map, addr);
     }
 
-    function insert(uint24 id, address addr) public returns (bool) {
+    function insert(uint16 id, address addr) public returns (bool) {
         return IdToAddressBiMap.insert(map, id, addr);
     }
 }

--- a/test/snapp_base.js
+++ b/test/snapp_base.js
@@ -7,9 +7,6 @@ const MintableERC20 = artifacts.require("./ERC20Mintable.sol")
 const zeroHash = "0x0"
 const oneHash = "0x1"
 
-const BN = require("bn.js")
-const oneBN = new BN("1", 10)
-
 const truffleAssert = require("truffle-assertions")
 
 const Promise = require("es6-promise").Promise
@@ -95,22 +92,22 @@ contract("SnappBase", async (accounts) => {
   })
   
   describe("openAccount()", () => {
-    it("Do not allow open account at MAX_ACCOUNT_ID + 1", async () => {
+    it("Do not allow open account at index >= maxAccountNumber", async () => {
       const instance = await SnappBase.new()
       const core = await SnappBaseCore.new()
-      const maxAccoundId = await core.MAX_ACCOUNT_ID.call()
-      await truffleAssert.reverts(instance.openAccount(maxAccoundId.add(oneBN)), "Account index exceeds max")
+      const max_account_id = (await core.MAX_ACCOUNT_ID.call()).toNumber()
+      await truffleAssert.reverts(instance.openAccount(max_account_id), "Account index exceeds max")
+      await truffleAssert.reverts(instance.openAccount(max_account_id + 1), "Account index exceeds max")
     })
 
-    it("Generic Open Account: 0 <= index <= maxUint24 - 2 = 16 777 214", async () => {
+    it("Do allow open account at 0 <= index < maxAccountNumber", async () => {
       const instance = await SnappBase.new()
       const core = await SnappBaseCore.new()
-      const maxAccoundId = await core.MAX_ACCOUNT_ID.call()
-
-      await instance.openAccount(maxAccoundId)
+      const max_account_id = (await core.MAX_ACCOUNT_ID.call()).toNumber()
+      await instance.openAccount(max_account_id - 1)
       await instance.openAccount(0, { from: user_1 })
 
-      assert.equal((await instance.publicKeyToAccountMap.call(owner)).toNumber(), maxAccoundId)
+      assert.equal((await instance.publicKeyToAccountMap.call(owner)).toNumber(), max_account_id - 1)
       assert.equal((await instance.publicKeyToAccountMap.call(user_1)).toNumber(), 0)
     })
 


### PR DESCRIPTION
Needed, since it requires a lot of changes in the listener/driver which we don't want to block other development on.

Those changes should happen in parallel and then the original PR can be resubmitted once the driver/listener is ready.