### PR TITLE
[EASY] update & include pre-commit hook with instructions

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -6,6 +6,8 @@
   "rules": {
     "security/no-block-members": "off",
     "security/no-inline-assembly": "off",
+    "no-trailing-whitespace": "error",
+    "operator-whitespace": "error",
     "quotes": [
       "error",
       "double"

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Checkout the [Formal Specification](https://github.com/gnosis/dex-research/blob/
 Checkout our [wiki](https://github.com/gnosis/dex-contracts/wiki/Script-Usage-Examples)
 
 # Contributions
-Our continuoius integration is running several linters which must pass in order to make a contribution to this repo. For your convinience there is a `pre-commit` hook file contained in the project's root directory. You can make your life easier by executing the following command after cloning this project (it will ensure your changes pass linting before allowing commits).
+Our continuoius integration is running several linters which must pass in order to make a contribution to this repo. For your convenience there is a `pre-commit` hook file contained in the project's root directory. You can make your life easier by executing the following command after cloning this project (it will ensure your changes pass linting before allowing commits).
 
 ```bash
 cp pre-commit .git/hooks/

--- a/README.md
+++ b/README.md
@@ -16,8 +16,16 @@ Checkout the [Formal Specification](https://github.com/gnosis/dex-research/blob/
 
 Checkout our [wiki](https://github.com/gnosis/dex-contracts/wiki/Script-Usage-Examples)
 
+# Contributions
+Our continuoius integration is running several linters which must pass in order to make a contribution to this repo. For your convinience there is a `pre-commit` hook file contained in the project's root directory. You can make your life easier by executing the following command after cloning this project (it will ensure your changes pass linting before allowing commits).
 
-# Contributors
+```bash
+cp pre-commit .git/hooks/
+chmod +x .git/hooks/pre-commit
+```
+
+For any other questions, comments or concerns please feel free to contact any of the project admins:
+
 - Alex ([josojo](https://github.com/josojo))
 - Ben ([bh2smith](https://github.com/bh2smith))
 - Felix ([fleupold](https://github.com/fleupold))

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+STAGED_JS_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep ".jsx\{0,1\}$")
+STAGED_SOL_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep ".sol$")
+ESLINT="$(git rev-parse --show-toplevel)/node_modules/.bin/eslint"
+
+if [[ ("$STAGED_JS_FILES" = "") && ("$STAGED_SOL_FILES" = "") ]]; then
+  exit 0
+fi
+
+PASS=true
+
+printf "\nValidating Javascript:\n"
+
+# Check for eslint
+if [[ ! -x "$ESLINT" ]]; then
+  printf "\t\033[41mPlease install ESlint\033[0m (npm i --save-dev eslint)"
+  exit 1
+fi
+
+for FILE in $STAGED_JS_FILES
+do
+  "$ESLINT" "$FILE"
+
+  if [[ "$?" == 0 ]]; then
+    printf "\t\033[32mESLint Passed: $FILE\033[0m"
+  else
+    printf "\t\033[41mESLint Failed: $FILE\033[0m"
+    PASS=false
+  fi
+done
+
+printf "\nJavascript validation completed!\n"
+
+printf "\nValidating Solidity:\n"
+
+# Check for eslint
+which solhint &> /dev/null
+if [[ "$?" == 1 ]]; then
+  echo "\t\033[41mPlease install solhint\033[0m"
+  exit 1
+fi
+
+for FILE in $STAGED_SOL_FILES
+do
+  solhint "$FILE"
+
+  if [[ "$?" == 0 ]]; then
+    printf "\t\033[32msolhint Passed: $FILE\033[0m"
+  else
+    printf "\t\033[41msolhint Failed: $FILE\033[0m"
+    PASS=false
+  fi
+done
+
+for FILE in $STAGED_SOL_FILES
+do
+  solium --file "$FILE"
+
+  if [[ "$?" == 0 ]]; then
+    printf "\t\033[32msolium Passed: $FILE\033[0m"
+  else
+    printf "\t\033[41msolium Failed: $FILE\033[0m"
+    PASS=false
+  fi
+done
+
+printf "\nSolidity validation completed!\n"
+
+if ! $PASS; then
+  printf "\033[41mCOMMIT FAILED:\033[0m Your commit contains files that should pass Linting but do not. Please fix the errors and try again.\n"
+  exit 1
+else
+  printf "\033[42mCOMMIT SUCCEEDED\033[0m\n"
+fi
+
+exit $?


### PR DESCRIPTION
## Test Plan:

Run the instructions in the updated readme

```bash
cp pre-commit .git/hooks
chmod +x .git/hooks
```
Make a change to a JS and/or Solidity file that would violate the linter and run

```bash
git add .
.git/hooks/pre-commit
```


