### PR TITLE
Emit validFromAuctionId in StandingOrder event

### DIFF
--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -40,6 +40,7 @@ contract SnappAuction is SnappBase {
 
     event StandingSellOrderBatch(
         uint currentBatchIndex,
+        uint validFromAuctionId,
         uint16 accountId,
         bytes packedOrders
     );
@@ -145,7 +146,7 @@ contract SnappAuction is SnappBase {
         //TODO: The case auctionIndex < currentOrderBatch.validFromIndex can happen once roll-backs are implemented
         //Then we have to revert the orderplacement
         standingOrders[accountId].reservedAccountOrders[currentBatchIndex] = currentOrderBatch;
-        emit StandingSellOrderBatch(currentBatchIndex, accountId, packedOrders);
+        emit StandingSellOrderBatch(currentBatchIndex, auctionIndex, accountId, packedOrders);
     }
 
     function placeSellOrder(


### PR DESCRIPTION
This is desirable, because it allows us to store and query the standing order for a given auction Id more easily.

The logic is basically: "For each account, give me the standingOrder record for which auctionId is largest, while also being <= the auctionIndex we want to participate in"

Or in MongoDb query terms:

```js
db.standing_orders.aggregate([
  {'$match': {'auctionId': {'$lte': <auction Index>}}}, //filter out standing orders that are too new
  {'$sort': {'auctionId': -1}}, // sort remaining descending
  {'$group' : { _id: '$accountId', orders:{'$first':'$orders'}}} // return the first one
])
```