### PR TITLE
[Test] Big Number Compatibility

### DIFF
--- a/test/snapp_auction.js
+++ b/test/snapp_auction.js
@@ -616,7 +616,7 @@ contract("SnappAuction", async (accounts) => {
     it("Large sell order", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const largeNumberString = "79228162514264333000000000000"  // compare with 2**96 = 7.922816251426434e+28
+      const largeNumberString = "79228162514264337593543950335"  // This is 2**96 - 1
       const amount = new BN(largeNumberString, 10)
       const order = encodeOrder(0, 1, 1, amount)
       const tx = await instance.placeSellOrders(order, { from: user_1 })

--- a/test/snapp_auction.js
+++ b/test/snapp_auction.js
@@ -1,3 +1,4 @@
+const BN = require("bn.js")
 const SnappAuction = artifacts.require("SnappAuction")
 const MintableERC20 = artifacts.require("./ERC20Mintable.sol")
 
@@ -610,6 +611,16 @@ contract("SnappAuction", async (accounts) => {
 
       const auctionIndex = (await instance.auctionIndex.call()).toNumber()
       assert.equal(auctionIndex, 1)
+    })
+
+    it("Large sell order", async () => {
+      const instance = await SnappAuction.new()
+      await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
+      const largeNumberString = "79228162514264333000000000000"  // compare with 2**96 = 7.922816251426434e+28
+      const amount = new BN(largeNumberString, 10)
+      const order = encodeOrder(0, 1, 1, amount)
+      const tx = await instance.placeSellOrders(order, { from: user_1 })
+      assert.equal(tx.logs[0].args.sellAmount.toString(), largeNumberString)
     })
 
     it("Generic Multi order (2)", async () => {

--- a/test/snapp_utils.js
+++ b/test/snapp_utils.js
@@ -1,4 +1,5 @@
 const assert = require("assert")
+const BN = require("bn.js")
 
 // returns boolean array of length num filled with false 
 // except for those indicies in true_list
@@ -36,14 +37,15 @@ const uint16 = function(num) {
 
 // returns byte string of hexed-sliced-padded int
 const uint128 = function(num) {
-  assert(num < 2**128)
+  const twoPowOneTwentyEight = new BN(2).pow(new BN(128))
+  assert(num < twoPowOneTwentyEight)
   return num.toString(16).padStart(32, "0")
 }
 
 // returns byte string of hexed-sliced-padded int
 const uint96 = function(num) {
-  // TODO - make this interpret the large end of 2^96
-  assert(num < 2**96)
+  const twoPowNinteySix = new BN(2).pow(new BN(96))
+  assert(num < twoPowNinteySix)
   return num.toString(16).padStart(24, "0")
 }
 


### PR DESCRIPTION
closes #116 

There is still a weird issue that `encodeOrder` doesn't allow us to pass amounts like `2**96 - 1` since JS evaluates 

```
2**96 as 7.922816251426434e+28 which is 79228162514264334000000000000
```
However
```
12**96 = 79228162514264337593543950336
```

This is not a major concern since it does not affect the contract code. 