### PR TITLE
Multi-Phase Auction II - Auction Settlement 

### DIFF
--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -315,19 +315,6 @@ contract SnappAuction is SnappBase {
         internalApplyAuction(slot, coreData.stateRoots[stateIndex()], trivialSolution);
     }
 
-    function internalApplyAuction(
-        uint slot,
-        bytes32 newStateRoot,
-        bytes memory pricesAndVolumes
-    )
-        internal
-    {
-        coreData.stateRoots.push(newStateRoot);
-        auctions[slot].appliedAccountStateIndex = stateIndex();
-        auctions[slot].solutionHash = sha256(pricesAndVolumes);
-        emit AuctionSettlement(slot, stateIndex(), newStateRoot, pricesAndVolumes);
-    }
-
     function applyAuction(
         uint slot,
         bytes32 _currStateRoot,
@@ -413,6 +400,19 @@ contract SnappAuction is SnappBase {
 
         sellToken = BytesLib.toUint8(orderData, 24);
         buyToken = BytesLib.toUint8(orderData, 25);
+    }
+
+    function internalApplyAuction(
+        uint slot,
+        bytes32 newStateRoot,
+        bytes memory pricesAndVolumes
+    )
+        internal
+    {
+        coreData.stateRoots.push(newStateRoot);
+        auctions[slot].appliedAccountStateIndex = stateIndex();
+        auctions[slot].solutionHash = sha256(pricesAndVolumes);
+        emit AuctionSettlement(slot, stateIndex(), newStateRoot, pricesAndVolumes);
     }
 
     function createNewPendingBatch() internal {

--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -296,40 +296,6 @@ contract SnappAuction is SnappBase {
         }
     }
 
-    // function applyAuction(
-    //     uint slot,
-    //     bytes32 _currStateRoot,
-    //     bytes32 _newStateRoot,
-    //     bytes32 _orderHash,
-    //     uint128[] memory _standingOrderIndex,
-    //     bytes memory pricesAndVolumes
-    // )
-    //     public onlyOwner()
-    // {
-    //     require(slot != MAX_UINT && slot <= auctionIndex, "Requested auction slot does not exist");
-    //     require(slot == 0 || auctions[slot-1].appliedAccountStateIndex != 0, "Must apply auction slots in order!");
-    //     require(auctions[slot].appliedAccountStateIndex == 0, "Auction already applied");
-    //     require(
-    //         calculateOrderHash(slot, _standingOrderIndex) == _orderHash,
-    //         "Order hash doesn't agree"
-    //     );
-    //     require(
-    //         block.timestamp > auctions[slot].creationTimestamp + 3 minutes ||
-    //             auctions[slot].numOrders == maxUnreservedOrderCount(),
-    //         "Requested auction slot is still active"
-    //     );
-    //     require(coreData.stateRoots[stateIndex()] == _currStateRoot, "Incorrect state root");
-
-    //     coreData.stateRoots.push(_newStateRoot);
-    //     auctions[slot].appliedAccountStateIndex = stateIndex();
-
-    //     // Store solution information in shaHash of pendingBatch (required for snark proof)
-    //     auctions[slot].solutionHash = sha256(pricesAndVolumes);
-    //     auctions[slot].auctionAppliedTime = block.timestamp;
-
-    //     emit AuctionSettlement(slot, stateIndex(), _newStateRoot, pricesAndVolumes);
-    // }
-
     function calculateOrderHash(uint slot, uint128[] memory _standingOrderIndex)
         public view returns (bytes32)
     {

--- a/contracts/SnappAuction.sol
+++ b/contracts/SnappAuction.sol
@@ -38,7 +38,7 @@ contract SnappAuction is SnappBase {
         bytes32 tentativeState;        // Proposed account state during bidding phase
         // Auction Settlement phase
         bytes32 solutionHash;          // Succinct record of trade execution & prices
-        uint solutionAcceptedTime;     // Time solution was accepted (written at time of solutionHash)
+        uint auctionAppliedTime;       // Time auction was applied (written at time of solutionHash)
         uint appliedAccountStateIndex; // stateIndex when batch applied - 0 implies unapplied.
     }
 
@@ -120,10 +120,10 @@ contract SnappAuction is SnappBase {
         // Solution bidding can only begin once the previous auction has settled
         // A1: | order collection | solution bidding | solution posting |
         // A2: |                  | order collection | solution bidding |  solution posting
-        // biddingStartTime = max(currentBatch.creationTimestamp + 3 minutes, previousBatch.solutionAcceptedTime)
+        // biddingStartTime = max(currentBatch.creationTimestamp + 3 minutes, previousBatch.auctionAppliedTime)
         uint bidStart = auctions[slot].creationTimestamp + 3 minutes;
-        if (slot > 0 && auctions[slot-1].solutionAcceptedTime > bidStart) {
-            bidStart = auctions[slot-1].solutionAcceptedTime;
+        if (slot > 0 && auctions[slot-1].auctionAppliedTime > bidStart) {
+            bidStart = auctions[slot-1].auctionAppliedTime;
         }
         return bidStart;
     }
@@ -230,7 +230,6 @@ contract SnappAuction is SnappBase {
         // Ensure that auction batch is inactive, unprocessed and in correct phase for bidding
         require(auctions[slot].appliedAccountStateIndex == 0, "Auction already applied");
         require(slot != MAX_UINT && slot <= auctionIndex, "Requested auction slot does not exist");
-
         require(
             block.timestamp > biddingStartTime(slot) || auctions[slot].numOrders == maxUnreservedOrderCount(),
             "Requested auction slot is still active"
@@ -252,102 +251,84 @@ contract SnappAuction is SnappBase {
         auctions[slot].tentativeState = proposedStateRoot;
     }
 
-    function winnerApplyAuction(
-        uint slot,
-        bytes memory pricesAndVolumes
-    )
-        public onlyOwner()
-    {
-        require(auctions[slot].appliedAccountStateIndex == 0, "Auction already applied");
-        require(
-            block.timestamp > biddingStartTime(slot) + 3 minutes,
-            "Requested auction still in bidding phase."
-        );
-        require(
-            block.timestamp < biddingStartTime(slot) + 270 seconds,  // 3 + 1.5 minutes
-            "Too late for winning result to submit solution"
-        );
-        require(
-            auctions[slot].solver == msg.sender,
-            "Only winner of bidding phase may apply auction here"
-        );
-        internalApplyAuction(slot, auctions[slot].tentativeState, pricesAndVolumes);
-    }
-
-    function fallbackApplyAuction(
-        uint slot,
-        bytes32 _currStateRoot,
-        bytes32 newStateRoot,
-        bytes memory pricesAndVolumes
-    )
-        public onlyOwner()
-    {
-        require(slot != MAX_UINT && slot <= auctionIndex, "Requested auction slot does not exist");
-        require(slot == 0 || auctions[slot-1].appliedAccountStateIndex != 0, "Must apply auction slots in order!");
-        require(auctions[slot].appliedAccountStateIndex == 0, "Auction already applied");
-        require(coreData.stateRoots[stateIndex()] == _currStateRoot, "Incorrect state root");
-
-        require(
-            block.timestamp > biddingStartTime(slot) + 270 seconds,  // 3 + 1.5 minutes
-            "Waiting on winner to provide solution"
-        );
-        require(
-            block.timestamp < biddingStartTime(slot) + 6 minutes,
-            "Waiting on winner to provide solution"
-        );
-        // TODO - Deal with this part of the settlement period.
-        // Assuming we take any provided solution and apply it!?
-        internalApplyAuction(slot, newStateRoot, pricesAndVolumes);
-    }
-
-    function nudgeTrivialAuction(uint slot) public {
-        require(slot != MAX_UINT && slot <= auctionIndex, "Requested auction slot does not exist");
-        require(slot == 0 || auctions[slot-1].appliedAccountStateIndex != 0, "Must apply auction slots in order!");
-        require(auctions[slot].appliedAccountStateIndex == 0, "Auction already applied");
-
-        require(
-            block.timestamp > biddingStartTime(slot) + 6 minutes,
-            "Requested auction still in settlement proposal phase"
-        );
-
-        bytes memory trivialSolution;  // p_i = 1 and (bA, sA)_j = (0, 0) \forall i, j
-        // Could simply state that null bytes represents trivial auction
-        internalApplyAuction(slot, coreData.stateRoots[stateIndex()], trivialSolution);
-    }
-
     function applyAuction(
         uint slot,
         bytes32 _currStateRoot,
-        bytes32 _newStateRoot,
+        bytes32 newStateRoot,                 // Only needed the case of fallback
         bytes32 _orderHash,
         uint128[] memory _standingOrderIndex,
-        bytes memory pricesAndVolumes
-    )
-        public onlyOwner()
-    {
+        bytes memory pricesAndVolumes         // Can be empty in the trivial case.
+    ) public onlyOwner() {
+        // Auction related constraints (slot exists, is inactive, no previous auction pending and not already applied)
         require(slot != MAX_UINT && slot <= auctionIndex, "Requested auction slot does not exist");
         require(slot == 0 || auctions[slot-1].appliedAccountStateIndex != 0, "Must apply auction slots in order!");
         require(auctions[slot].appliedAccountStateIndex == 0, "Auction already applied");
-        require(
-            calculateOrderHash(slot, _standingOrderIndex) == _orderHash,
-            "Order hash doesn't agree"
-        );
+
+        // State related constraints (order hash and state root agree)
+        require(coreData.stateRoots[stateIndex()] == _currStateRoot, "Incorrect state root");
+        require(calculateOrderHash(slot, _standingOrderIndex) == _orderHash, "Order hash doesn't agree");
+
+        // Phase related constraints
         require(
             block.timestamp > auctions[slot].creationTimestamp + 3 minutes ||
                 auctions[slot].numOrders == maxUnreservedOrderCount(),
             "Requested auction slot is still active"
         );
-        require(coreData.stateRoots[stateIndex()] == _currStateRoot, "Incorrect state root");
+        require(
+            block.timestamp > biddingStartTime(slot) + 3 minutes,
+            "Requested auction still in bidding phase or earlier"
+        );
 
-        coreData.stateRoots.push(_newStateRoot);
-        auctions[slot].appliedAccountStateIndex = stateIndex();
-
-        // Store solution information in shaHash of pendingBatch (required for snark proof)
-        auctions[slot].solutionHash = sha256(pricesAndVolumes);
-        auctions[slot].solutionAcceptedTime = block.timestamp;
-
-        emit AuctionSettlement(slot, stateIndex(), _newStateRoot, pricesAndVolumes);
+        if (block.timestamp < biddingStartTime(slot) + 270 seconds && auctions[slot].solver != address(0)) {
+            // Winner Apply Auction
+            require(
+                auctions[slot].solver == msg.sender,
+                "Only winner of bidding phase may apply auction here"
+            );
+            internalApplyAuction(slot, auctions[slot].tentativeState, pricesAndVolumes);
+        } else if (block.timestamp < biddingStartTime(slot) + 6 minutes) {
+            // Fallback Apply Auction
+            internalApplyAuction(slot, newStateRoot, pricesAndVolumes);
+        } else {
+            // Trivial Apply Auction
+            bytes memory trivialSolution;  // p_i = 1 and (bA, sA)_j = (0, 0) \forall i, j
+            internalApplyAuction(slot, coreData.stateRoots[stateIndex()], trivialSolution);
+        }
     }
+
+    // function applyAuction(
+    //     uint slot,
+    //     bytes32 _currStateRoot,
+    //     bytes32 _newStateRoot,
+    //     bytes32 _orderHash,
+    //     uint128[] memory _standingOrderIndex,
+    //     bytes memory pricesAndVolumes
+    // )
+    //     public onlyOwner()
+    // {
+    //     require(slot != MAX_UINT && slot <= auctionIndex, "Requested auction slot does not exist");
+    //     require(slot == 0 || auctions[slot-1].appliedAccountStateIndex != 0, "Must apply auction slots in order!");
+    //     require(auctions[slot].appliedAccountStateIndex == 0, "Auction already applied");
+    //     require(
+    //         calculateOrderHash(slot, _standingOrderIndex) == _orderHash,
+    //         "Order hash doesn't agree"
+    //     );
+    //     require(
+    //         block.timestamp > auctions[slot].creationTimestamp + 3 minutes ||
+    //             auctions[slot].numOrders == maxUnreservedOrderCount(),
+    //         "Requested auction slot is still active"
+    //     );
+    //     require(coreData.stateRoots[stateIndex()] == _currStateRoot, "Incorrect state root");
+
+    //     coreData.stateRoots.push(_newStateRoot);
+    //     auctions[slot].appliedAccountStateIndex = stateIndex();
+
+    //     // Store solution information in shaHash of pendingBatch (required for snark proof)
+    //     auctions[slot].solutionHash = sha256(pricesAndVolumes);
+    //     auctions[slot].auctionAppliedTime = block.timestamp;
+
+    //     emit AuctionSettlement(slot, stateIndex(), _newStateRoot, pricesAndVolumes);
+    // }
 
     function calculateOrderHash(uint slot, uint128[] memory _standingOrderIndex)
         public view returns (bytes32)
@@ -412,6 +393,7 @@ contract SnappAuction is SnappBase {
         coreData.stateRoots.push(newStateRoot);
         auctions[slot].appliedAccountStateIndex = stateIndex();
         auctions[slot].solutionHash = sha256(pricesAndVolumes);
+        auctions[slot].auctionAppliedTime = block.timestamp;
         emit AuctionSettlement(slot, stateIndex(), newStateRoot, pricesAndVolumes);
     }
 
@@ -429,7 +411,7 @@ contract SnappAuction is SnappBase {
             objectiveValue: 0,
             tentativeState: bytes32(0),
             solutionHash: bytes32(0),
-            solutionAcceptedTime: 0,
+            auctionAppliedTime: 0,
             appliedAccountStateIndex: 0
         });
     }

--- a/test/snapp_auction.js
+++ b/test/snapp_auction.js
@@ -531,8 +531,7 @@ contract("SnappAuction", async (accounts) => {
     it("records winning bid and allows fallback applyAuction", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
-      await instance.placeSellOrders(order, { from: user_1 })
+      await instance.placeSellOrder(0, 1, 1, 1, { from: user_1 })
 
       const slot = (await instance.auctionIndex.call()).toNumber()
       const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
@@ -542,18 +541,14 @@ contract("SnappAuction", async (accounts) => {
 
       // Wait for current order slot to be inactive
       await waitForNSeconds(181)
-      
       const current_state = await instance.getCurrentStateRoot()
       await instance.auctionSolutionBid(slot, current_state, new_state, 1)
       // Wait for bidding phase to pass
       await waitForNSeconds(181)
       // Wait for winner's chance to submit to pass (half a minute)
       await waitForNSeconds(91)
-
       // winner is owner in this context (and currently has to be)
-      await instance.applyAuction(
-        slot, current_state, new_state, orderhash, standingOrderIndexList, auctionSolution, { from: user_1 }
-      )
+      await instance.applyAuction(slot, current_state, new_state, orderhash, standingOrderIndexList, auctionSolution)
     })
 
     it("Reject: apply same slot twice", async () => {

--- a/test/snapp_auction.js
+++ b/test/snapp_auction.js
@@ -268,15 +268,13 @@ contract("SnappAuction", async (accounts) => {
     const prices = "0x" + "".padEnd(16*30 *2, "0") // represents 30 uint128 (token prices)
     const volumes = "0x" + "".padEnd(32*1000*2, "0") // represents 1000 * 2 uint128 (numerator, denominator)
     const auctionSolution = prices + volumes.slice(2)
+    const order = encodeOrder(0, 1, 1, 1)
 
     it("Cannot apply auction before first order", async () => {
       const instance = await SnappAuction.new()
-      const curr_slot = await instance.auctionIndex.call()
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
+      const current_slot = await instance.auctionIndex.call()
       await truffleAssert.reverts(
-        instance.applyAuction(curr_slot, "0x0", "0x0", "0x0", standingOrderIndexList, "0x0"),
+        instance.applyAuction(current_slot, "0x0", "0x0", "0x0"),
         "Requested auction slot does not exist"
       )
     })
@@ -284,37 +282,27 @@ contract("SnappAuction", async (accounts) => {
     it("Only owner", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const state_root = await instance.getCurrentStateRoot()
-      const auction_state = await instance.auctions.call(slot)
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const current_state = await instance.getCurrentStateRoot()
 
       await truffleAssert.reverts(
-        instance.applyAuction(slot, state_root, new_state, auction_state.orderHash, standingOrderIndexList, auctionSolution, { from: user_1 }))
+        instance.applyAuction(current_slot, current_state, new_state, auctionSolution, { from: user_1 }))
     })
 
     it("Reject: active slot", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const state_root = await instance.getCurrentStateRoot()
-      const auction_state = await instance.auctions.call(slot)
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
-      const orderhash = await instance.calculateOrderHash(slot, standingOrderIndexList)
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const current_state = await instance.getCurrentStateRoot()
+      const auction_state = await instance.auctions.call(current_slot)
       assert.equal(await isActive(auction_state), true)
 
       await truffleAssert.reverts(
-        instance.applyAuction(slot, state_root, new_state, orderhash, standingOrderIndexList, auctionSolution),
+        instance.applyAuction(current_slot, current_state, new_state, auctionSolution),
         "Requested auction slot is still active"
       )
     })
@@ -322,16 +310,11 @@ contract("SnappAuction", async (accounts) => {
     it("Reject: Incorrect state root", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const auction_state = await instance.auctions.call(slot)
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
-      const orderhash = await instance.calculateOrderHash(slot, standingOrderIndexList)
-      
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const auction_state = await instance.auctions.call(current_slot)
+
       // Wait for current order slot to be inactive
       await waitForNSeconds(181)
 
@@ -342,50 +325,19 @@ contract("SnappAuction", async (accounts) => {
       assert.notEqual(wrong_state_root, await instance.getCurrentStateRoot())
 
       await truffleAssert.reverts(
-        instance.applyAuction(slot, wrong_state_root, new_state, orderhash, standingOrderIndexList, auctionSolution),
+        instance.applyAuction(current_slot, wrong_state_root, new_state, auctionSolution),
         "Incorrect state root"
       )
-    })
-
-    it("Reject: Incorrect order hash", async () => {
-      const instance = await SnappAuction.new()
-      await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
-      await instance.placeSellOrders(order, { from: user_1 })
-
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const auction_state = await instance.auctions.call(slot)
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
-
-      // Wait for current order slot to be inactive
-      await waitForNSeconds(181)
-
-      // Ensure order slot is inactive
-      assert.equal(await isActive(auction_state), false)
-
-      const state_root = await instance.getCurrentStateRoot()
-      const wrong_order_hash = "0x1"
-
-      assert.notEqual(wrong_order_hash, auction_state.shaHash)
-
-      await truffleAssert.reverts(
-        instance.applyAuction(slot, state_root, new_state, wrong_order_hash, standingOrderIndexList, auctionSolution))
     })
 
     it("Reject: out-of-range slot", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const auction_state = await instance.auctions.call(slot)
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
-      const orderhash = await instance.calculateOrderHash(slot, standingOrderIndexList)
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const current_state = await instance.getCurrentStateRoot()
+      const auction_state = await instance.auctions.call(current_slot)
       
       // Wait for current order slot to be inactive
       await waitForNSeconds(181)
@@ -393,11 +345,8 @@ contract("SnappAuction", async (accounts) => {
       // Ensure order slot is inactive
       assert.equal(await isActive(auction_state), false)
 
-      const state_root = await instance.getCurrentStateRoot()
-      const curr_slot = (await instance.auctionIndex.call()).toNumber()
-
       await truffleAssert.reverts(
-        instance.applyAuction(curr_slot + 1, state_root, new_state, orderhash, standingOrderIndexList, auctionSolution),
+        instance.applyAuction(current_slot + 1, current_state, new_state, auctionSolution),
         "Requested auction slot does not exist"
       )
     })
@@ -405,124 +354,112 @@ contract("SnappAuction", async (accounts) => {
     it("rejects calls when still in bidding phase", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
-      const orderhash = await instance.calculateOrderHash(slot, standingOrderIndexList)
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const current_state = await instance.getCurrentStateRoot()
 
       // Wait for current order slot to be inactive & bidding phase to pass
       await waitForNSeconds(181)
 
-      const current_state = await instance.getCurrentStateRoot()
       await truffleAssert.reverts(
-        instance.applyAuction(slot, current_state, new_state, orderhash, standingOrderIndexList, auctionSolution),
+        instance.applyAuction(current_slot, current_state, new_state, auctionSolution),
         "Requested auction still in bidding phase or earlier"
       )
     })
 
-    it("Successfully apply auction", async () => {
+    it("successfully apply's auction", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const auction_state = await instance.auctions.call(slot)
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
-      const orderhash = await instance.calculateOrderHash(slot, standingOrderIndexList)
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const current_state = await instance.getCurrentStateRoot()
+      const auction_state = await instance.auctions.call(current_slot)
 
       // Wait for current order slot to be inactive & bidding phase to pass
       await waitForNSeconds(181 + 180)
 
       // Ensure order slot is inactive
       assert.equal(await isActive(auction_state), false)
-
-      const state_root = await instance.getCurrentStateRoot()
       
-      await instance.applyAuction(slot, state_root, new_state, orderhash, standingOrderIndexList, auctionSolution)
+      await instance.applyAuction(current_slot, current_state, new_state, auctionSolution)
 
       const state_index = (await instance.stateIndex.call()).toNumber()
-      const applied_index = ((await instance.auctions(slot)).appliedAccountStateIndex).toNumber()
+      const applied_index = ((await instance.auctions(current_slot)).appliedAccountStateIndex).toNumber()
 
       assert.equal(applied_index, state_index)
     })
 
-    it("apply trivial auction", async () => {
+    it("applies trivial auction", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
-      const orderhash = await instance.calculateOrderHash(slot, standingOrderIndexList)
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const current_state = await instance.getCurrentStateRoot()
 
       // Wait for current order slot to be inactive & bidding phase to pass
       await waitForNSeconds(181 + 180)
       // wait for regular settlement period to pass!
       await waitForNSeconds(181)
-
-      const state_root = await instance.getCurrentStateRoot()
       
       const tx = await instance.applyAuction(
-        slot, state_root, new_state, orderhash, standingOrderIndexList, auctionSolution)
+        current_slot, current_state, new_state, auctionSolution)
 
       assert.equal(tx.logs[0].args.pricesAndVolumes, null, "auction solution should be empty")
     })
 
-    it("accepts winner's solution", async () => {
+    it("accepts and applies winner's solution", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
-      const orderhash = await instance.calculateOrderHash(slot, standingOrderIndexList)
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const current_state = await instance.getCurrentStateRoot()
 
       // Wait for current order slot to be inactive
       await waitForNSeconds(181)
       
-      const current_state = await instance.getCurrentStateRoot()
-      await instance.auctionSolutionBid(slot, current_state, new_state, 1)
+      // Provide winning bid for auction solution.
+      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
+      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
+      standingOrderIndexList.fill(0)
+      const orderhash = await instance.calculateOrderHash(current_slot, standingOrderIndexList)
+      await instance.auctionSolutionBid(current_slot, current_state, orderhash, standingOrderIndexList, new_state, 1)
+
       // Wait for bidding phase to pass
       await waitForNSeconds(181)
       // winner is owner in this context (and currently has to be)
-      await instance.applyAuction(slot, current_state, new_state, orderhash, standingOrderIndexList, auctionSolution)
+      await instance.applyAuction(current_slot, current_state, new_state, auctionSolution)
     })
 
     it("rejects imposter winner's solution", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
-      const orderhash = await instance.calculateOrderHash(slot, standingOrderIndexList)
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const current_state = await instance.getCurrentStateRoot()
 
       // Wait for current order slot to be inactive
       await waitForNSeconds(181)
-      const current_state = await instance.getCurrentStateRoot()
-      await instance.auctionSolutionBid(slot, current_state, new_state, 1, { from: user_1 })
+      
+      // Provide winning bid for auction solution.
+      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
+      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
+      standingOrderIndexList.fill(0)
+      const orderhash = await instance.calculateOrderHash(current_slot, standingOrderIndexList)
+      await instance.auctionSolutionBid(
+        current_slot, current_state, orderhash, standingOrderIndexList, new_state, 1, { from: user_1 }
+      )
+
       // Wait for bidding phase to pass
       await waitForNSeconds(181)   
 
       await truffleAssert.reverts(
         instance.applyAuction(
-          slot, current_state, new_state, orderhash, standingOrderIndexList, auctionSolution
+          current_slot, current_state, new_state, auctionSolution
         ),
         "Only winner of bidding phase may apply auction here"
       )
@@ -531,24 +468,32 @@ contract("SnappAuction", async (accounts) => {
     it("records winning bid and allows fallback applyAuction", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      await instance.placeSellOrder(0, 1, 1, 1, { from: user_1 })
+      await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
-      const orderhash = await instance.calculateOrderHash(slot, standingOrderIndexList)
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const current_state = await instance.getCurrentStateRoot()
 
       // Wait for current order slot to be inactive
       await waitForNSeconds(181)
-      const current_state = await instance.getCurrentStateRoot()
-      await instance.auctionSolutionBid(slot, current_state, new_state, 1)
+      
+      // Provide winning bid for auction solution.
+      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
+      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
+      standingOrderIndexList.fill(0)
+      const orderhash = await instance.calculateOrderHash(current_slot, standingOrderIndexList)
+      await instance.auctionSolutionBid(
+        current_slot, current_state, orderhash, standingOrderIndexList, new_state, 1, { from: user_1 }
+      )
       // Wait for bidding phase to pass
       await waitForNSeconds(181)
-      // Wait for winner's chance to submit to pass (half a minute)
+
+      // Wait for winner's chance (user 1) to submit to pass (half a minute)
       await waitForNSeconds(91)
+
       // winner is owner in this context (and currently has to be)
-      await instance.applyAuction(slot, current_state, new_state, orderhash, standingOrderIndexList, auctionSolution)
+      await instance.applyAuction(
+        current_slot, current_state, new_state, auctionSolution
+      )
     })
 
     it("Reject: apply same slot twice", async () => {
@@ -557,27 +502,18 @@ contract("SnappAuction", async (accounts) => {
       const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const auction_state = await instance.auctions.call(slot)
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      standingOrderIndexList.fill(0)
-      const orderhash = await instance.calculateOrderHash(slot, standingOrderIndexList)
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const current_state = await instance.getCurrentStateRoot()
 
       // Wait for current order slot to be inactive & bidding phase to pass
       await waitForNSeconds(181 + 180)
 
-      // Ensure order slot is inactive
-      assert.equal(await isActive(auction_state), false)
-
-      const state_root = await instance.getCurrentStateRoot()
-
       // Apply auction once
-      await instance.applyAuction(slot, state_root, new_state, orderhash, standingOrderIndexList, auctionSolution)
+      await instance.applyAuction(current_slot, current_state, new_state, auctionSolution)
       
       // Try to apply same slot again
       await truffleAssert.reverts(
-        instance.applyAuction(slot, state_root, new_state, orderhash, standingOrderIndexList, auctionSolution),
+        instance.applyAuction(current_slot, current_state, new_state, auctionSolution),
         "Auction already applied"
       )
     })
@@ -585,26 +521,18 @@ contract("SnappAuction", async (accounts) => {
     it("Must apply slots sequentially", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
-      const first_standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      first_standingOrderIndexList.fill(0)
       // Wait for current order slot to be inactive & bidding phase to pass
       await waitForNSeconds(181 + 180)
 
       // Place an order to ensure second order slot is created.
       const order_tx = await instance.placeSellOrders(order, { from: user_1 })
       const second_slot = order_tx.logs[0].args.auctionId.toNumber()
-      const second_standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
-      second_standingOrderIndexList.fill(0)
-      const second_orderhash = await instance.calculateOrderHash(second_slot, second_standingOrderIndexList)
-
-      const state_root = await instance.getCurrentStateRoot()
+      const current_state = await instance.getCurrentStateRoot()
 
       await truffleAssert.reverts(
-        instance.applyAuction(second_slot, state_root, new_state, second_orderhash, second_standingOrderIndexList, auctionSolution),
+        instance.applyAuction(second_slot, current_state, new_state, auctionSolution),
         "Must apply auction slots in order!"
       )
     })
@@ -812,24 +740,31 @@ contract("SnappAuction", async (accounts) => {
     const volumes = "0x" + "".padEnd(32*1000*2, "0") // represents 1000 * 2 uint128 (numerator, denominator)
     const auctionSolution = prices + volumes.slice(2)
 
+    const order = encodeOrder(0, 1, 1, 1)
+
     it("Rejects if previous auction not resolved", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
+      
 
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const current_state =  await instance.getCurrentStateRoot()
+
       // Wait for first order slot to be inactive
       await waitForNSeconds(181)
 
       await instance.placeSellOrders(order, { from: user_1 })
       await waitForNSeconds(181)
 
-      const current_state =  await instance.getCurrentStateRoot()
+      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
+      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
+      standingOrderIndexList.fill(0)
+      const orderhash = await instance.calculateOrderHash(current_slot, standingOrderIndexList)
 
       await truffleAssert.reverts(
-        instance.auctionSolutionBid(slot + 1, current_state, new_state, 0),
+        instance.auctionSolutionBid(current_slot + 1, current_state, orderhash, standingOrderIndexList, new_state, 0),
         "Previous auction not yet resolved!"
       )
     })
@@ -837,31 +772,56 @@ contract("SnappAuction", async (accounts) => {
     it("Rejects on incorrect stateRoot", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
-      const auction_state = await instance.auctions.call(slot)
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
 
       // Wait for current order slot to be inactive
       await waitForNSeconds(181)
 
-      // Ensure order slot is inactive
-      assert.equal(await isActive(auction_state), false)
-
       const wrong_state_root = "0x1"
       assert.notEqual(wrong_state_root, await instance.getCurrentStateRoot())
 
+      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
+      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
+      standingOrderIndexList.fill(0)
+      const orderhash = await instance.calculateOrderHash(current_slot, standingOrderIndexList)
+
       await truffleAssert.reverts(
-        instance.auctionSolutionBid(slot, wrong_state_root, new_state, 0),
+        instance.auctionSolutionBid(current_slot, wrong_state_root, orderhash, standingOrderIndexList, new_state, 0),
         "Incorrect state root"
+      )
+    })
+
+    it("Rejects Incorrect order hash", async () => {
+      const instance = await SnappAuction.new()
+      await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
+      await instance.placeSellOrders(order, { from: user_1 })
+
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+      const current_state =  await instance.getCurrentStateRoot()
+
+      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
+      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
+      standingOrderIndexList.fill(0)
+      const orderhash = await instance.calculateOrderHash(current_slot, standingOrderIndexList)
+
+      // Wait for current order slot to be inactive
+      await waitForNSeconds(181)
+
+      const wrong_orderhash = "0x1"
+
+      assert.notEqual(wrong_orderhash, orderhash, "wrong order hash isn't wrong!")
+
+      await truffleAssert.reverts(
+        instance.auctionSolutionBid(current_slot, current_state, wrong_orderhash, standingOrderIndexList, new_state, 0),
+        "Order hash doesn't agree"
       )
     })
 
     it("Rejects if auction already applied", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
       const slot = (await instance.auctionIndex.call()).toNumber()
@@ -875,11 +835,11 @@ contract("SnappAuction", async (accounts) => {
 
       const state_root = await instance.getCurrentStateRoot()
 
-      await instance.applyAuction(slot, state_root, new_state, orderhash, standingOrderIndexList, auctionSolution)
+      await instance.applyAuction(slot, state_root, new_state, auctionSolution)
 
       // Note that state has already been updated to new, so we need to get past state checker.
       await truffleAssert.reverts(
-        instance.auctionSolutionBid(slot, new_state, new_state, 1),
+        instance.auctionSolutionBid(slot, new_state, orderhash, standingOrderIndexList, new_state, 1),
         "Auction already applied"
       )
     })
@@ -887,11 +847,33 @@ contract("SnappAuction", async (accounts) => {
     it("Rejects if requested auction slot doesn't exist", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
       await instance.placeSellOrders(order, { from: user_1 })
 
       // Wait for current order slot to be inactive and bidding phase is over
       await waitForNSeconds(181 + 180)
+
+      const current_state = await instance.getCurrentStateRoot()
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
+
+      await instance.applyAuction(
+        current_slot, current_state, new_state, auctionSolution
+      )
+
+      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
+      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
+      standingOrderIndexList.fill(0)
+      const orderhash = await instance.calculateOrderHash(current_slot + 1, standingOrderIndexList)
+
+      await truffleAssert.reverts(
+        instance.auctionSolutionBid(current_slot + 1, new_state, orderhash, standingOrderIndexList, new_state, 0),
+        "Requested auction slot does not exist"
+      )
+    })
+
+    it("Rejects if order collection still active", async () => {
+      const instance = await SnappAuction.new()
+      await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
+      await instance.placeSellOrders(order, { from: user_1 })
 
       const current_state = await instance.getCurrentStateRoot()
       const current_slot = (await instance.auctionIndex.call()).toNumber()
@@ -901,28 +883,8 @@ contract("SnappAuction", async (accounts) => {
       standingOrderIndexList.fill(0)
       const orderhash = await instance.calculateOrderHash(current_slot, standingOrderIndexList)
 
-
-      await instance.applyAuction(
-        current_slot, current_state, new_state, orderhash, standingOrderIndexList, auctionSolution
-      )
-
       await truffleAssert.reverts(
-        instance.auctionSolutionBid(current_slot + 1, new_state, new_state, 0),
-        "Requested auction slot does not exist"
-      )
-    })
-
-    it("Rejects if order collection still active", async () => {
-      const instance = await SnappAuction.new()
-      await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      const order = encodeOrder(0, 1, 1, 1)
-      await instance.placeSellOrders(order, { from: user_1 })
-
-      const state_root = await instance.getCurrentStateRoot()
-      const current_slot = (await instance.auctionIndex.call()).toNumber()
-
-      await truffleAssert.reverts(
-        instance.auctionSolutionBid(current_slot, state_root, new_state, 0),
+        instance.auctionSolutionBid(current_slot, current_state, orderhash, standingOrderIndexList, new_state, 0),
         "Requested auction slot is still active"
       )
     })
@@ -930,10 +892,15 @@ contract("SnappAuction", async (accounts) => {
     it("Rejects when bidding period has expired", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      await instance.placeSellOrder(0, 1, 1, 1, { from: user_1 })
+      await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
       const current_state = await instance.getCurrentStateRoot()
+
+      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
+      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
+      standingOrderIndexList.fill(0)
+      const orderhash = await instance.calculateOrderHash(current_slot, standingOrderIndexList)
 
       // Wait for current order slot to be inactive
       await waitForNSeconds(181)
@@ -941,7 +908,7 @@ contract("SnappAuction", async (accounts) => {
       await waitForNSeconds(181)
 
       await truffleAssert.reverts(
-        instance.auctionSolutionBid(slot, current_state, new_state, 0),
+        instance.auctionSolutionBid(current_slot, current_state, orderhash, standingOrderIndexList, new_state, 0),
         "Bidding period for this auction has expired"
       )
     })
@@ -949,17 +916,24 @@ contract("SnappAuction", async (accounts) => {
     it("Accepts and records first proposal", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      await instance.placeSellOrder(0, 1, 1, 1, { from: user_1 })
+      await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
       const current_state = await instance.getCurrentStateRoot()
+
+      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
+      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
+      standingOrderIndexList.fill(0)
+      const orderhash = await instance.calculateOrderHash(current_slot, standingOrderIndexList)
 
       // Wait for current order slot to be inactive
       await waitForNSeconds(181)
 
-      await instance.auctionSolutionBid(slot, current_state, new_state, 1, { from: user_1 })
+      await instance.auctionSolutionBid(
+        current_slot, current_state, orderhash, standingOrderIndexList, new_state, 1, { from: user_1 }
+      )
 
-      const auction_results = await instance.auctions(slot)
+      const auction_results = await instance.auctions(current_slot)
 
       assert.equal(
         auction_results.tentativeState,
@@ -972,24 +946,32 @@ contract("SnappAuction", async (accounts) => {
     it("Rejects proposed values < or = to current", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      await instance.placeSellOrder(0, 1, 1, 1, { from: user_1 })
+      await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
       const current_state = await instance.getCurrentStateRoot()
+
+      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
+      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
+      standingOrderIndexList.fill(0)
+      const orderhash = await instance.calculateOrderHash(current_slot, standingOrderIndexList)
+
       // Wait for current order slot to be inactive
       await waitForNSeconds(181)
 
       // reject Equal
       await truffleAssert.reverts(
-        instance.auctionSolutionBid(slot, current_state, new_state, 0),
+        instance.auctionSolutionBid(current_slot, current_state, orderhash, standingOrderIndexList, new_state, 0),
         "Proposed objective value is less than existing"
       )
 
-      await instance.auctionSolutionBid(slot, current_state, new_state, low_objective)
+      await instance.auctionSolutionBid(
+        current_slot, current_state, orderhash, standingOrderIndexList, new_state, low_objective
+      )
 
       // reject less than
       await truffleAssert.reverts(
-        instance.auctionSolutionBid(slot, current_state, new_state, 0),
+        instance.auctionSolutionBid(current_slot, current_state, orderhash, standingOrderIndexList, new_state, 0),
         "Proposed objective value is less than existing"
       )
     })
@@ -997,18 +979,27 @@ contract("SnappAuction", async (accounts) => {
     it("Accepts updates better proposal", async () => {
       const instance = await SnappAuction.new()
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
-      await instance.placeSellOrder(0, 1, 1, 1, { from: user_1 })
+      await instance.placeSellOrders(order, { from: user_1 })
 
-      const slot = (await instance.auctionIndex.call()).toNumber()
+      const current_slot = (await instance.auctionIndex.call()).toNumber()
       const current_state = await instance.getCurrentStateRoot()
+
+      const AUCTION_RESERVED_ACCOUNTS = await instance.AUCTION_RESERVED_ACCOUNTS()
+      const standingOrderIndexList = new Array(AUCTION_RESERVED_ACCOUNTS.toNumber())
+      standingOrderIndexList.fill(0)
+      const orderhash = await instance.calculateOrderHash(current_slot, standingOrderIndexList)
 
       // Wait for current order slot to be inactive
       await waitForNSeconds(181)
 
-      await instance.auctionSolutionBid(slot, current_state, new_state, low_objective)
-      await instance.auctionSolutionBid(slot, current_state, new_state, high_objective, { from: user_1 })
+      await instance.auctionSolutionBid(
+        current_slot, current_state, orderhash, standingOrderIndexList, new_state, low_objective
+      )
+      await instance.auctionSolutionBid(
+        current_slot, current_state, orderhash, standingOrderIndexList, new_state, high_objective, { from: user_1 }
+      )
 
-      const auction_results = await instance.auctions(slot)
+      const auction_results = await instance.auctions(current_slot)
 
       assert.equal(
         auction_results.tentativeState,
@@ -1023,10 +1014,10 @@ contract("SnappAuction", async (accounts) => {
       await setupEnvironment(MintableERC20, instance, token_owner, [user_1], 2)
 
       // First Auction
-      await instance.placeSellOrder(0, 1, 1, 1, { from: user_1 })
+      await instance.placeSellOrders(order, { from: user_1 })
       await waitForNSeconds(181)
       // Second Auction
-      await instance.placeSellOrder(0, 1, 1, 1, { from: user_1 })
+      await instance.placeSellOrders(order, { from: user_1 })
       await waitForNSeconds(181)
 
 
@@ -1038,12 +1029,12 @@ contract("SnappAuction", async (accounts) => {
       const orderhash = await instance.calculateOrderHash(current_slot, standingOrderIndexList)
 
       await instance.applyAuction(
-        current_slot - 1, current_state, current_state, orderhash, standingOrderIndexList, auctionSolution
+        current_slot - 1, current_state, current_state, auctionSolution
       )
       await waitForNSeconds(1)
 
       // This is the point where biddingStartTime = auctions[slot-1].auctionAppliedTime;
-      await instance.auctionSolutionBid(current_slot, current_state, new_state, 1)
+      await instance.auctionSolutionBid(current_slot, current_state, orderhash, standingOrderIndexList, new_state, 1)
       await waitForNSeconds(1)
 
       // Ensuring that slot > 0 and


### PR DESCRIPTION
Closes #151 

Creating this draft PR first to get some implementation opinions. There are beginning to be some constraints that could be offloaded into a modifier. Still need to kill the existing `applyAuction`. Notice how the `fallbackApplyAuction` is currently accepting the first submission that come in during its designated time interval. The reason for doing it this way (rather than having another bidding phase) is because the `pricesAndVolumes` need to be provided at the time of state transition. 

New functions include;

- `winnerApplyAuction`: Allows winner of bidding period the first 1.5 minutes of settlement window to provide solution.
- `fallbackApplyAuction`: Allows anyone to provide solution during the second 1.5 minutes (and accepts the first)
- `nudgeTrivialAuction`: Allows trivial solution to be applied after the Settlement window time has expired.

Looking for some feedback before unit tests are provided and code is taken any further!

