### PR TITLE
First step solution submission: adapting orders and balances

### DIFF
--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -128,7 +128,7 @@ contract EpochTokenLocker {
         balanceStates[user][token].balance = balanceStates[user][token].balance.add(amount);
     }
 
-    function substractBalance(address user, address token, uint amount) internal {
+    function subtractBalance(address user, address token, uint amount) internal {
         updateDepositsBalance(user, token);
         balanceStates[user][token].balance = balanceStates[user][token].balance.sub(amount);
     }

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -110,12 +110,13 @@ contract StablecoinConverter is EpochTokenLocker {
         return IdToAddressBiMap.getAddressAt(registeredTokens, id);
     }
 
+    mapping (uint16 => uint128) public currentPrices;
     struct TradeData {
         address owner;
         uint volume;
         uint16 orderIds;
     }
-    mapping (uint16 => uint128) public currentPrice;
+
     function submitSolution(
         uint32 batchIndex,
         address[] memory owners,  //tradeData is submitted as arrays
@@ -136,10 +137,10 @@ contract StablecoinConverter is EpochTokenLocker {
             require(order.validUntil >= batchIndex, "Order is no longer valid");
             // Assume for now that we always have sellOrders
             uint128 executedSellAmount = volumes[i];
-            require(currentPrice[order.sellToken] != 0, "prices are not allowed to be zero");
+            require(currentPrices[order.sellToken] != 0, "prices are not allowed to be zero");
             uint128 executedBuyAmount = uint128(
-                volumes[i].mul(currentPrice[order.buyToken]) /
-                currentPrice[order.sellToken]
+                volumes[i].mul(currentPrices[order.buyToken]) /
+                currentPrices[order.sellToken]
             );
             // Ensure executed price is not lower than the order price:
             //       executedSellAmount / executedBuyAmount >= order.sellAmount / order.buyAmount
@@ -168,12 +169,12 @@ contract StablecoinConverter is EpochTokenLocker {
         orders[owner][orderId].sellAmount = newSellAmount;
     }
 
-    function writeCurrentPrices(
+    function CurrentPrices(
         uint128[] memory prices,  //list of prices for touched token only
         uint16[] memory tokenIdsForPrice  // price[i] is the price for the token with tokenID tokenIdsForPrice[i]
     ) internal {
         for (uint i = 0; i < tokenIdsForPrice.length; i++) {
-            currentPrice[tokenIdsForPrice[i]] = prices[i];
+            currentPrices[tokenIdsForPrice[i]] = prices[i];
         }
     }
 }

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -121,8 +121,8 @@ contract StablecoinConverter is EpochTokenLocker {
         address[] memory owner,  //tradeData is submitted as arrays
         uint16[] memory orderId,
         uint128[] memory volume,
-        uint128[] memory prices,
-        uint16[] memory tokenIdForPrice
+        uint128[] memory prices,  //list of prices for touched token only
+        uint16[] memory tokenIdForPrice  // price[i] is the price for the token with tokenID tokenIdForPrice[i]
     ) public {
         require(
             batchIndex == getCurrentStateIndex() - 1,

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -144,9 +144,9 @@ contract StablecoinConverter is EpochTokenLocker {
                 currentPrices[order.sellToken]
             );
             // Ensure executed price is not lower than the order price:
-            //       executedSellAmount / executedBuyAmount >= order.sellAmount / order.buyAmount
+            //       executedSellAmount / executedBuyAmount <= order.sellAmount / order.buyAmount
             require(
-                executedSellAmount.mul(order.buyAmount) >= executedBuyAmount.mul(order.sellAmount),
+                executedSellAmount.mul(order.buyAmount) <= executedBuyAmount.mul(order.sellAmount),
                 "limit price not satisfied"
             );
             require(order.sellAmount >= executedSellAmount, "executedSellAmount bigger than specified in order");

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -155,8 +155,11 @@ contract StablecoinConverter is EpochTokenLocker {
         }
         // doing all subtractions after all additions (in order to avoid negative values)
         for (uint i = 0; i < len; i++) {
-            Order memory order = orders[owners[i]][orderIds[i]];
-            subtractBalance(owners[i], tokenIdToAddressMap(order.sellToken), volumes[i]);
+            subtractBalance(
+                owners[i],
+                tokenIdToAddressMap(orders[owners[i]][orderIds[i]].sellToken),
+                volumes[i]
+            );
         }
     }
 

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -154,7 +154,7 @@ contract StablecoinConverter is EpochTokenLocker {
             orders[owner[i]][orderId[i]].sellAmount = uint128(order.sellAmount.sub(sellVolume));
             addBalance(owner[i], tokenIdToAddressMap(order.buyToken), buyVolume);
         }
-        //doing the substracts after doing all additions, in order to avoid negative values
+        // doing all subtractions after all additions (in order to avoid negative values)
         for (uint i = 0; i < len; i++) {
             Order memory order = orders[owner[i]][orderId[i]];
             substractBalance(owner[i], tokenIdToAddressMap(order.sellToken), volume[i]);

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -111,6 +111,7 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     mapping (uint16 => uint128) public currentPrices;
+
     struct TradeData {
         address owner;
         uint volume;
@@ -169,7 +170,7 @@ contract StablecoinConverter is EpochTokenLocker {
         orders[owner][orderId].sellAmount = newSellAmount;
     }
 
-    function CurrentPrices(
+    function writeCurrentPrices(
         uint128[] memory prices,  //list of prices for touched token only
         uint16[] memory tokenIdsForPrice  // price[i] is the price for the token with tokenID tokenIdsForPrice[i]
     ) internal {

--- a/contracts/test/EpochTokenLockerTestInterface.sol
+++ b/contracts/test/EpochTokenLockerTestInterface.sol
@@ -12,7 +12,7 @@ contract EpochTokenLockerTestInterface is EpochTokenLocker {
         super.addBalance(user, token, amount);
     }
 
-    function substractBalanceTest(address user, address token, uint amount) public {
-        super.substractBalance(user, token, amount);
+    function subtractBalanceTest(address user, address token, uint amount) public {
+        super.subtractBalance(user, token, amount);
     }
 }

--- a/test/epoch_token_locker.js
+++ b/test/epoch_token_locker.js
@@ -12,8 +12,8 @@ contract("EpochTokenLocker", async (accounts) => {
 
   let BATCH_TIME
   beforeEach(async () => {
-    const stablecoinConverter = await EpochTokenLocker.new()
-    BATCH_TIME = (await stablecoinConverter.BATCH_TIME.call()).toNumber()
+    const instance = await EpochTokenLocker.new()
+    BATCH_TIME = (await instance.BATCH_TIME.call()).toNumber()
   })
 
   describe("deposit", () => {

--- a/test/epoch_token_locker.js
+++ b/test/epoch_token_locker.js
@@ -191,13 +191,13 @@ contract("EpochTokenLocker", async (accounts) => {
       assert.equal(await epochTokenLocker.getBalance(user_1, ERC20.address), 100)
     })
   })
-  describe("substractBalance", () => {  
-    it("modifies the balance by substracting", async () => {
+  describe("subtractBalance", () => {  
+    it("modifies the balance by subtracting", async () => {
       const epochTokenLocker = await EpochTokenLockerTestInterface.new()
       const ERC20 = await MockContract.new()
 
       await epochTokenLocker.addBalanceTest(user_1, ERC20.address, 100)
-      await epochTokenLocker.substractBalanceTest(user_1, ERC20.address, 50)
+      await epochTokenLocker.subtractBalanceTest(user_1, ERC20.address, 50)
 
       assert.equal(await epochTokenLocker.getBalance(user_1, ERC20.address), 50)
     })
@@ -208,7 +208,7 @@ contract("EpochTokenLocker", async (accounts) => {
 
       await epochTokenLocker.deposit(ERC20.address, 100, {from: user_2})
       await waitForNSeconds(BATCH_TIME)
-      await epochTokenLocker.substractBalanceTest(user_2, ERC20.address, 50)
+      await epochTokenLocker.subtractBalanceTest(user_2, ERC20.address, 50)
 
       assert.equal(await epochTokenLocker.getBalance(user_2, ERC20.address), 50)
     })
@@ -216,7 +216,7 @@ contract("EpochTokenLocker", async (accounts) => {
       const epochTokenLocker = await EpochTokenLockerTestInterface.new()
       const ERC20 = await MockContract.new()
   
-      await truffleAssert.reverts(epochTokenLocker.substractBalanceTest(user_1, ERC20.address, 50))
+      await truffleAssert.reverts(epochTokenLocker.subtractBalanceTest(user_1, ERC20.address, 50))
     })
   })
 })

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -396,7 +396,7 @@ contract("StablecoinConverter", async (accounts) => {
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
         stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice),
-        "limit price not met"
+        "limit price not satisfied"
       )
     })
     it("throws, if sell volume is bigger than order volume", async () => {
@@ -429,7 +429,7 @@ contract("StablecoinConverter", async (accounts) => {
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
         stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice),
-        "sellVolume bigger than specified in order"
+        "executedSellAmount bigger than specified in order"
       )
     })
     it("throws, if sell volume is bigger than balance available", async () => {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -331,7 +331,7 @@ contract("StablecoinConverter", async (accounts) => {
         "Order is not yet valid"
       )
     })
-    it("throws, if order is not yet valid", async () => {
+    it("throws, if order is no longer valid", async () => {
       const stablecoinConverter = await StablecoinConverter.new(2**16-1)
       const erc20_1 = await MockContract.new()
       const erc20_2 = await MockContract.new()

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -162,7 +162,7 @@ contract("StablecoinConverter", async (accounts) => {
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 20, 10, { from: user_1 })
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 10, 20, { from: user_1 })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 20, 20, { from: user_2 })
       // close auction
       await waitForNSeconds(BATCH_TIME)
@@ -381,7 +381,7 @@ contract("StablecoinConverter", async (accounts) => {
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 19, 10, { from: user_1 })
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 21, 10, { from: user_1 })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, { from: user_2 })
       // close auction
       await waitForNSeconds(BATCH_TIME)
@@ -471,7 +471,7 @@ contract("StablecoinConverter", async (accounts) => {
       await erc20_1.givenAnyReturnBool(true)
       await erc20_2.givenAnyReturnBool(true)
 
-      await stablecoinConverter.deposit(erc20_1.address, 8, { from: user_1 })
+      await stablecoinConverter.deposit(erc20_1.address, 10, { from: user_1 })
       await stablecoinConverter.deposit(erc20_2.address, 20, { from: user_2 })
 
       await stablecoinConverter.addToken(erc20_1.address)
@@ -486,8 +486,7 @@ contract("StablecoinConverter", async (accounts) => {
       const owner = [user_1, user_2]  //tradeData is submitted as arrays
       const orderId = [orderId1, orderId2]
       const volume = [10, 20]
-
-      const tokenIdsForPrice = [0, 0]
+      const tokenIdsForPrice = [1, 1]
 
       await truffleAssert.reverts(
         stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice),

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -138,9 +138,9 @@ contract("StablecoinConverter", async (accounts) => {
       const volume = [10, 20]
       
       
-      const tokenIdForPrice = [0, 1]
+      const tokenIdsForPrice = [0, 1]
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice)
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice)
       
       assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_1.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
       assert.equal(await stablecoinConverter.getBalance.call(user_1, erc20_2.address), 20, "Bought tokens were not adjusted correctly")
@@ -173,9 +173,9 @@ contract("StablecoinConverter", async (accounts) => {
       const volume = [10, 10]
       
       
-      const tokenIdForPrice = [0, 1]
+      const tokenIdsForPrice = [0, 1]
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice)
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice)
       
       assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_1.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
       assert.equal(await stablecoinConverter.getBalance.call(user_1, erc20_2.address), 10, "Bought tokens were not adjusted correctly")
@@ -206,9 +206,9 @@ contract("StablecoinConverter", async (accounts) => {
       const owner = [user_1, user_2]  //tradeData is submitted as arrays
       const orderId = [orderId1, orderId2]
       const volume = [5, 10]
-      const tokenIdForPrice = [0, 1]
+      const tokenIdsForPrice = [0, 1]
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice)
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice)
       
       assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_1.address)).toNumber(), 5, "Sold tokens were not adjusted correctly")
       assert.equal(await stablecoinConverter.getBalance.call(user_1, erc20_2.address), 10, "Bought tokens were not adjusted correctly")
@@ -254,9 +254,9 @@ contract("StablecoinConverter", async (accounts) => {
       const owner = [user_1, user_2, user_3]  //tradeData is submitted as arrays
       const orderId = [orderId1, orderId2, orderId3]
       const volume = [10, 10, 10]
-      const tokenIdForPrice = [0, 1, 2]
+      const tokenIdsForPrice = [0, 1, 2]
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice)
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice)
       
       assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_1.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
@@ -291,11 +291,11 @@ contract("StablecoinConverter", async (accounts) => {
       const volume = [5, 10]
       
       
-      const tokenIdForPrice = [0, 1]
+      const tokenIdsForPrice = [0, 1]
 
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex - 1, owner, orderId, volume,  prices, tokenIdForPrice),
+        stablecoinConverter.submitSolution(batchIndex - 1, owner, orderId, volume,  prices, tokenIdsForPrice),
         "Solutions are no longer accepted for this batch"
       )
     })
@@ -323,11 +323,11 @@ contract("StablecoinConverter", async (accounts) => {
       const volume = [5, 10]
       
       
-      const tokenIdForPrice = [0, 1]
+      const tokenIdsForPrice = [0, 1]
 
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex - 1, owner, orderId, volume,  prices, tokenIdForPrice),
+        stablecoinConverter.submitSolution(batchIndex - 1, owner, orderId, volume,  prices, tokenIdsForPrice),
         "Order is not yet valid"
       )
     })
@@ -358,11 +358,11 @@ contract("StablecoinConverter", async (accounts) => {
       const volume = [5, 10]
       
       
-      const tokenIdForPrice = [0, 1]
+      const tokenIdsForPrice = [0, 1]
 
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume,  prices, tokenIdForPrice),
+        stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume,  prices, tokenIdsForPrice),
         "Order is no longer valid"
       )
     })
@@ -391,11 +391,11 @@ contract("StablecoinConverter", async (accounts) => {
       const volume = [5, 10]
       
       
-      const tokenIdForPrice = [0, 1]
+      const tokenIdsForPrice = [0, 1]
 
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice),
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice),
         "limit price not satisfied"
       )
     })
@@ -424,11 +424,11 @@ contract("StablecoinConverter", async (accounts) => {
       const volume = [11, 10]
       
       
-      const tokenIdForPrice = [0, 1]
+      const tokenIdsForPrice = [0, 1]
 
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice),
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice),
         "executedSellAmount bigger than specified in order"
       )
     })
@@ -456,11 +456,11 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId = [orderId1, orderId2]
       const volume = [10, 20]
       
-      const tokenIdForPrice = [0, 1]
+      const tokenIdsForPrice = [0, 1]
 
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice)//,
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice)//,
       )
     })
     it("reverts, if a trade touches a token, for which no price is provided", async () => {
@@ -487,10 +487,10 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId = [orderId1, orderId2]
       const volume = [10, 20]
       
-      const tokenIdForPrice = [0, 0]
+      const tokenIdsForPrice = [0, 0]
 
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice),
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice),
         "Price not provided for token"
       )
     })

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1,5 +1,5 @@
 const StablecoinConverter = artifacts.require("StablecoinConverter")
-
+const MockContract = artifacts.require("MockContract")
 const IdToAddressBiMap = artifacts.require("IdToAddressBiMap")
 const ERC20 = artifacts.require("ERC20")
 
@@ -11,7 +11,7 @@ const {
 
 contract("StablecoinConverter", async (accounts) => {
 
-  const [user_1] = accounts 
+  const [user_1, user_2, user_3] = accounts 
   let BATCH_TIME
   beforeEach(async () => {
     const lib1 = await IdToAddressBiMap.new()
@@ -45,8 +45,12 @@ contract("StablecoinConverter", async (accounts) => {
       await stablecoinConverter.placeOrder(0, 1, true, 3, 10, 20, {from: user_1})
       const currentStateIndex = await stablecoinConverter.getCurrentStateIndex()
       await stablecoinConverter.cancelOrder(id, {from: user_1})
+      assert.equal(
+        ((await stablecoinConverter.orders.call(user_1,id)).validUntil).toNumber(),
+        (currentStateIndex.toNumber() - 1),
+        "validUntil was stored incorrectly"
+      )
 
-      assert.equal(((await stablecoinConverter.orders.call(user_1,id)).validUntil).toNumber(), currentStateIndex - 1, "validUntil was stored incorrectly")
     })
   })
   describe("freeStorageOfOrder", () => {
@@ -105,6 +109,390 @@ contract("StablecoinConverter", async (accounts) => {
       await instance.addToken((await ERC20.new()).address)
 
       await truffleAssert.reverts(instance.addToken((await ERC20.new()).address), "Max tokens reached")
+    })
+  })
+  describe("submitSolution()", () => {
+    it("places two orders and matches them in a solution with traders' Utility == 0", async () => {
+      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const erc20_1 = await MockContract.new()
+      const erc20_2 = await MockContract.new()
+      
+      await erc20_1.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
+      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
+      
+      await stablecoinConverter.addToken(erc20_1.address)
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 20, 10, {from: user_1})
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 10, 20, {from: user_2})
+      // close auction
+      await waitForNSeconds(BATCH_TIME)
+
+      const prices = [10, 20]
+      const owner = [user_1, user_2]  //tradeData is submitted as arrays
+      const orderId = [orderId1, orderId2]
+      const volume = [10, 20]
+      
+      
+      const tokenIdForPrice = [0, 1]
+
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice)
+      
+      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_1.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
+      assert.equal(await stablecoinConverter.getBalance.call(user_1, erc20_2.address), 20, "Bought tokens were not adjusted correctly")
+      assert.equal(await stablecoinConverter.getBalance.call(user_2, erc20_1.address), 10, "Bought tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
+    })
+    it("places two orders and matches them in a solution with traders' Utility >0", async () => {
+      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const erc20_1 = await MockContract.new()
+      const erc20_2 = await MockContract.new()
+      
+      await erc20_1.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
+      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
+      
+      await stablecoinConverter.addToken(erc20_1.address)
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 20, 10, {from: user_1})
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 20, 20, {from: user_2})
+      // close auction
+      await waitForNSeconds(BATCH_TIME)
+
+      const prices = [10, 10]
+      const owner = [user_1, user_2]  //tradeData is submitted as arrays
+      const orderId = [orderId1, orderId2]
+      const volume = [10, 10]
+      
+      
+      const tokenIdForPrice = [0, 1]
+
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice)
+      
+      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_1.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
+      assert.equal(await stablecoinConverter.getBalance.call(user_1, erc20_2.address), 10, "Bought tokens were not adjusted correctly")
+      assert.equal(await stablecoinConverter.getBalance.call(user_2, erc20_1.address), 10, "Bought tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), 10, "Sold tokens were not adjusted correctly")
+    })
+    it("places two orders, matches them partically and then checks correct order adjustments", async () => {
+      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const erc20_1 = await MockContract.new()
+      const erc20_2 = await MockContract.new()
+      
+      await erc20_1.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
+      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
+      
+      await stablecoinConverter.addToken(erc20_1.address)
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 20, 10, {from: user_1})
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 10, 20, {from: user_2})
+      // close auction
+      await waitForNSeconds(BATCH_TIME)
+
+      const prices = [10, 20]
+      const owner = [user_1, user_2]  //tradeData is submitted as arrays
+      const orderId = [orderId1, orderId2]
+      const volume = [5, 10]
+      const tokenIdForPrice = [0, 1]
+
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice)
+      
+      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_1.address)).toNumber(), 5, "Sold tokens were not adjusted correctly")
+      assert.equal(await stablecoinConverter.getBalance.call(user_1, erc20_2.address), 10, "Bought tokens were not adjusted correctly")
+      assert.equal(await stablecoinConverter.getBalance.call(user_2, erc20_1.address), 5, "Bought tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), 10, "Sold tokens were not adjusted correctly")
+      const orderResult1 = (await stablecoinConverter.orders.call(user_1,orderId1))
+      const orderResult2 = (await stablecoinConverter.orders.call(user_2, orderId2))
+
+      assert.equal((orderResult1.sellAmount).toNumber(), 5, "sellAmount was stored incorrectly")
+      assert.equal((orderResult1.buyAmount).toNumber(), 10, "buyAmount was stored incorrectly")
+
+      assert.equal((orderResult2.sellAmount).toNumber(), 10, "sellAmount was stored incorrectly")
+      assert.equal((orderResult2.buyAmount).toNumber(), 5, "buyAmount was stored incorrectly")
+    })
+    it("settles a ring trade between 3 tokens", async () => {
+      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const erc20_1 = await MockContract.new()
+      const erc20_2 = await MockContract.new()
+      const erc20_3 = await MockContract.new()
+
+      await erc20_1.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+      await erc20_3.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
+      await stablecoinConverter.deposit(erc20_2.address, 10, {from: user_2})
+      await stablecoinConverter.deposit(erc20_3.address, 10, {from: user_3})
+
+      await stablecoinConverter.addToken(erc20_1.address)
+      await stablecoinConverter.addToken(erc20_2.address)
+      await stablecoinConverter.addToken(erc20_3.address)
+
+      const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 10, 10, {from: user_1})
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, true, batchIndex + 1, 10, 10, {from: user_2})
+      const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, true, batchIndex + 1, 10, 10, {from: user_3})
+
+      // close auction
+      await waitForNSeconds(BATCH_TIME)
+
+      const prices = [10, 10, 10]
+      const owner = [user_1, user_2, user_3]  //tradeData is submitted as arrays
+      const orderId = [orderId1, orderId2, orderId3]
+      const volume = [10, 10, 10]
+      const tokenIdForPrice = [0, 1, 2]
+
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice)
+      
+      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_1.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_3, erc20_3.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
+      assert.equal(await stablecoinConverter.getBalance.call(user_1, erc20_2.address), 10, "Bought tokens were not adjusted correctly")
+      assert.equal(await stablecoinConverter.getBalance.call(user_2, erc20_3.address), 10, "Bought tokens were not adjusted correctly")
+      assert.equal(await stablecoinConverter.getBalance.call(user_3, erc20_1.address), 10, "Bought tokens were not adjusted correctly")
+    })
+    it("throws, if the batchIndex is incorrect", async () => {
+      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const erc20_1 = await MockContract.new()
+      const erc20_2 = await MockContract.new()
+      
+      await erc20_1.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
+      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
+      
+      await stablecoinConverter.addToken(erc20_1.address)
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, {from: user_1})
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      // close auction
+      await waitForNSeconds(BATCH_TIME)
+
+      const prices = [10, 20]
+      const owner = [user_1, user_2]  //tradeData is submitted as arrays
+      const orderId = [orderId1, orderId2]
+      const volume = [5, 10]
+      
+      
+      const tokenIdForPrice = [0, 1]
+
+      //correct batchIndex would be batchIndex
+      await truffleAssert.reverts(
+        stablecoinConverter.submitSolution(batchIndex - 1, owner, orderId, volume,  prices, tokenIdForPrice),
+        "Solutions are no longer accepted for this batch"
+      )
+    })
+    it("throws, if order is not yet valid", async () => {
+      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const erc20_1 = await MockContract.new()
+      const erc20_2 = await MockContract.new()
+      
+      await erc20_1.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
+      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
+      
+      await stablecoinConverter.addToken(erc20_1.address)
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, {from: user_1})
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+
+      const prices = [10, 20]
+      const owner = [user_1, user_2]  //tradeData is submitted as arrays
+      const orderId = [orderId1, orderId2]
+      const volume = [5, 10]
+      
+      
+      const tokenIdForPrice = [0, 1]
+
+      //correct batchIndex would be batchIndex
+      await truffleAssert.reverts(
+        stablecoinConverter.submitSolution(batchIndex - 1, owner, orderId, volume,  prices, tokenIdForPrice),
+        "Order is not yet valid"
+      )
+    })
+    it("throws, if order is not yet valid", async () => {
+      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const erc20_1 = await MockContract.new()
+      const erc20_2 = await MockContract.new()
+      
+      await erc20_1.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
+      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
+      
+      await stablecoinConverter.addToken(erc20_1.address)
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, {from: user_1})
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      // close auction
+      await waitForNSeconds(BATCH_TIME)
+      // close another auction
+      await waitForNSeconds(BATCH_TIME)
+      const prices = [10, 20]
+      const owner = [user_1, user_2]  //tradeData is submitted as arrays
+      const orderId = [orderId1, orderId2]
+      const volume = [5, 10]
+      
+      
+      const tokenIdForPrice = [0, 1]
+
+      //correct batchIndex would be batchIndex
+      await truffleAssert.reverts(
+        stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume,  prices, tokenIdForPrice),
+        "Order is no longer valid"
+      )
+    })
+    it("throws, if limit price is not met for an order", async () => {
+      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const erc20_1 = await MockContract.new()
+      const erc20_2 = await MockContract.new()
+      
+      await erc20_1.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
+      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
+      
+      await stablecoinConverter.addToken(erc20_1.address)
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 19, 10, {from: user_1})
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      // close auction
+      await waitForNSeconds(BATCH_TIME)
+      const prices = [10, 20]
+      const owner = [user_1, user_2]  //tradeData is submitted as arrays
+      const orderId = [orderId1, orderId2]
+      const volume = [5, 10]
+      
+      
+      const tokenIdForPrice = [0, 1]
+
+      //correct batchIndex would be batchIndex
+      await truffleAssert.reverts(
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice),
+        "limit price not met"
+      )
+    })
+    it("throws, if sell volume is bigger than order volume", async () => {
+      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const erc20_1 = await MockContract.new()
+      const erc20_2 = await MockContract.new()
+      
+      await erc20_1.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
+      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
+      
+      await stablecoinConverter.addToken(erc20_1.address)
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, {from: user_1})
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      // close auction
+      await waitForNSeconds(BATCH_TIME)
+      const prices = [10, 20]
+      const owner = [user_1, user_2]  //tradeData is submitted as arrays
+      const orderId = [orderId1, orderId2]
+      const volume = [11, 10]
+      
+      
+      const tokenIdForPrice = [0, 1]
+
+      //correct batchIndex would be batchIndex
+      await truffleAssert.reverts(
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice),
+        "sellVolume bigger than specified in order"
+      )
+    })
+    it("throws, if sell volume is bigger than balance available", async () => {
+      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const erc20_1 = await MockContract.new()
+      const erc20_2 = await MockContract.new()
+      
+      await erc20_1.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(erc20_1.address, 8, {from: user_1})
+      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
+      
+      await stablecoinConverter.addToken(erc20_1.address)
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, {from: user_1})
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      // close auction
+      await waitForNSeconds(BATCH_TIME)
+      const prices = [10, 20]
+      const owner = [user_1, user_2]  //tradeData is submitted as arrays
+      const orderId = [orderId1, orderId2]
+      const volume = [10, 20]
+      
+      const tokenIdForPrice = [0, 1]
+
+      //correct batchIndex would be batchIndex
+      await truffleAssert.reverts(
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice)//,
+      )
+    })
+    it("reverts, if a trade touches a token, for which no price is provided", async () => {
+      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const erc20_1 = await MockContract.new()
+      const erc20_2 = await MockContract.new()
+      
+      await erc20_1.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(erc20_1.address, 8, {from: user_1})
+      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
+      
+      await stablecoinConverter.addToken(erc20_1.address)
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, {from: user_1})
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      // close auction
+      await waitForNSeconds(BATCH_TIME)
+      const prices = [10, 20]
+      const owner = [user_1, user_2]  //tradeData is submitted as arrays
+      const orderId = [orderId1, orderId2]
+      const volume = [10, 20]
+      
+      const tokenIdForPrice = [0, 0]
+
+      await truffleAssert.reverts(
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdForPrice),
+        "Price not provided for token"
+      )
     })
   })
 })

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -11,23 +11,23 @@ const {
 
 contract("StablecoinConverter", async (accounts) => {
 
-  const [user_1, user_2, user_3] = accounts 
+  const [user_1, user_2, user_3] = accounts
   let BATCH_TIME
   beforeEach(async () => {
     const lib1 = await IdToAddressBiMap.new()
     await StablecoinConverter.link(IdToAddressBiMap, lib1.address)
 
-    const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+    const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
     BATCH_TIME = (await stablecoinConverter.BATCH_TIME.call()).toNumber()
   })
 
-  describe("placeOrder", () => { 
+  describe("placeOrder", () => {
     it("places Orders and checks parameters", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const currentStateIndex = await stablecoinConverter.getCurrentStateIndex()
-      const id = await stablecoinConverter.placeOrder.call(0, 1, true, 3, 10, 20, {from: user_1})
-      await stablecoinConverter.placeOrder(0, 1, true, 3, 10, 20, {from: user_1})
-      const orderResult = (await stablecoinConverter.orders.call(user_1,id))
+      const id = await stablecoinConverter.placeOrder.call(0, 1, true, 3, 10, 20, { from: user_1 })
+      await stablecoinConverter.placeOrder(0, 1, true, 3, 10, 20, { from: user_1 })
+      const orderResult = (await stablecoinConverter.orders.call(user_1, id))
       assert.equal((orderResult.sellAmount).toNumber(), 20, "sellAmount was stored incorrectly")
       assert.equal((orderResult.buyAmount).toNumber(), 10, "buyAmount was stored incorrectly")
       assert.equal((orderResult.sellToken).toNumber(), 1, "sellToken was stored incorrectly")
@@ -39,14 +39,14 @@ contract("StablecoinConverter", async (accounts) => {
   })
   describe("cancelOrder", () => {
     it("places orders, then cancels it and orders status", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
 
-      const id = await stablecoinConverter.placeOrder.call(0, 1, true, 3, 10, 20, {from: user_1})
-      await stablecoinConverter.placeOrder(0, 1, true, 3, 10, 20, {from: user_1})
+      const id = await stablecoinConverter.placeOrder.call(0, 1, true, 3, 10, 20, { from: user_1 })
+      await stablecoinConverter.placeOrder(0, 1, true, 3, 10, 20, { from: user_1 })
       const currentStateIndex = await stablecoinConverter.getCurrentStateIndex()
-      await stablecoinConverter.cancelOrder(id, {from: user_1})
+      await stablecoinConverter.cancelOrder(id, { from: user_1 })
       assert.equal(
-        ((await stablecoinConverter.orders.call(user_1,id)).validUntil).toNumber(),
+        ((await stablecoinConverter.orders.call(user_1, id)).validUntil).toNumber(),
         (currentStateIndex.toNumber() - 1),
         "validUntil was stored incorrectly"
       )
@@ -55,7 +55,7 @@ contract("StablecoinConverter", async (accounts) => {
   })
   describe("freeStorageOfOrder", () => {
     it("places a order, then cancels and deletes it", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
 
       const id = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, 3, 10, 20)
       await stablecoinConverter.cancelOrder(id)
@@ -65,15 +65,15 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((await stablecoinConverter.orders(user_1, id)).sellAmount, 0, "sellAmount was stored incorrectly")
     })
     it("fails to delete non-canceled order", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const currentStateIndex = await stablecoinConverter.getCurrentStateIndex()
 
       const id = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, currentStateIndex + 3, 10, 20)
       await truffleAssert.reverts(stablecoinConverter.freeStorageOfOrder(id), "Order is still valid")
     })
     it("fails to delete canceled order in same stateIndex", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
-    
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
+
       const id = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, 3, 10, 20)
       await stablecoinConverter.cancelOrder(id)
       await truffleAssert.reverts(stablecoinConverter.freeStorageOfOrder(id), "Order is still valid")
@@ -81,7 +81,7 @@ contract("StablecoinConverter", async (accounts) => {
   })
   describe("addToken()", () => {
     it("Anyone can add tokens", async () => {
-      const instance = await StablecoinConverter.new(2**16-1)
+      const instance = await StablecoinConverter.new(2 ** 16 - 1)
 
       const token_1 = await ERC20.new()
       await instance.addToken(token_1.address)
@@ -96,7 +96,7 @@ contract("StablecoinConverter", async (accounts) => {
     })
 
     it("Reject: add same token twice", async () => {
-      const instance = await StablecoinConverter.new(2**16-1)
+      const instance = await StablecoinConverter.new(2 ** 16 - 1)
       const token = await ERC20.new()
 
       await instance.addToken(token.address)
@@ -113,22 +113,22 @@ contract("StablecoinConverter", async (accounts) => {
   })
   describe("submitSolution()", () => {
     it("places two orders and matches them in a solution with traders' Utility == 0", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const erc20_1 = await MockContract.new()
       const erc20_2 = await MockContract.new()
-      
+
       await erc20_1.givenAnyReturnBool(true)
       await erc20_2.givenAnyReturnBool(true)
 
-      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
-      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
-      
+      await stablecoinConverter.deposit(erc20_1.address, 10, { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, 20, { from: user_2 })
+
       await stablecoinConverter.addToken(erc20_1.address)
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 20, 10, {from: user_1})
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 10, 20, {from: user_2})
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 20, 10, { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 10, 20, { from: user_2 })
       // close auction
       await waitForNSeconds(BATCH_TIME)
 
@@ -136,34 +136,34 @@ contract("StablecoinConverter", async (accounts) => {
       const owner = [user_1, user_2]  //tradeData is submitted as arrays
       const orderId = [orderId1, orderId2]
       const volume = [10, 20]
-      
-      
+
+
       const tokenIdsForPrice = [0, 1]
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice)
-      
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice)
+
       assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_1.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
       assert.equal(await stablecoinConverter.getBalance.call(user_1, erc20_2.address), 20, "Bought tokens were not adjusted correctly")
       assert.equal(await stablecoinConverter.getBalance.call(user_2, erc20_1.address), 10, "Bought tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
     })
     it("places two orders and matches them in a solution with traders' Utility >0", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const erc20_1 = await MockContract.new()
       const erc20_2 = await MockContract.new()
-      
+
       await erc20_1.givenAnyReturnBool(true)
       await erc20_2.givenAnyReturnBool(true)
 
-      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
-      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
-      
+      await stablecoinConverter.deposit(erc20_1.address, 10, { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, 20, { from: user_2 })
+
       await stablecoinConverter.addToken(erc20_1.address)
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 20, 10, {from: user_1})
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 20, 20, {from: user_2})
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 20, 10, { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 20, 20, { from: user_2 })
       // close auction
       await waitForNSeconds(BATCH_TIME)
 
@@ -171,34 +171,34 @@ contract("StablecoinConverter", async (accounts) => {
       const owner = [user_1, user_2]  //tradeData is submitted as arrays
       const orderId = [orderId1, orderId2]
       const volume = [10, 10]
-      
-      
+
+
       const tokenIdsForPrice = [0, 1]
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice)
-      
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice)
+
       assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_1.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
       assert.equal(await stablecoinConverter.getBalance.call(user_1, erc20_2.address), 10, "Bought tokens were not adjusted correctly")
       assert.equal(await stablecoinConverter.getBalance.call(user_2, erc20_1.address), 10, "Bought tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), 10, "Sold tokens were not adjusted correctly")
     })
     it("places two orders, matches them partically and then checks correct order adjustments", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const erc20_1 = await MockContract.new()
       const erc20_2 = await MockContract.new()
-      
+
       await erc20_1.givenAnyReturnBool(true)
       await erc20_2.givenAnyReturnBool(true)
 
-      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
-      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
-      
+      await stablecoinConverter.deposit(erc20_1.address, 10, { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, 20, { from: user_2 })
+
       await stablecoinConverter.addToken(erc20_1.address)
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 20, 10, {from: user_1})
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 10, 20, {from: user_2})
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 20, 10, { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 10, 20, { from: user_2 })
       // close auction
       await waitForNSeconds(BATCH_TIME)
 
@@ -208,13 +208,13 @@ contract("StablecoinConverter", async (accounts) => {
       const volume = [5, 10]
       const tokenIdsForPrice = [0, 1]
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice)
-      
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice)
+
       assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_1.address)).toNumber(), 5, "Sold tokens were not adjusted correctly")
       assert.equal(await stablecoinConverter.getBalance.call(user_1, erc20_2.address), 10, "Bought tokens were not adjusted correctly")
       assert.equal(await stablecoinConverter.getBalance.call(user_2, erc20_1.address), 5, "Bought tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), 10, "Sold tokens were not adjusted correctly")
-      const orderResult1 = (await stablecoinConverter.orders.call(user_1,orderId1))
+      const orderResult1 = (await stablecoinConverter.orders.call(user_1, orderId1))
       const orderResult2 = (await stablecoinConverter.orders.call(user_2, orderId2))
 
       assert.equal((orderResult1.sellAmount).toNumber(), 5, "sellAmount was stored incorrectly")
@@ -224,7 +224,7 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((orderResult2.buyAmount).toNumber(), 5, "buyAmount was stored incorrectly")
     })
     it("settles a ring trade between 3 tokens", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const erc20_1 = await MockContract.new()
       const erc20_2 = await MockContract.new()
       const erc20_3 = await MockContract.new()
@@ -233,9 +233,9 @@ contract("StablecoinConverter", async (accounts) => {
       await erc20_2.givenAnyReturnBool(true)
       await erc20_3.givenAnyReturnBool(true)
 
-      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
-      await stablecoinConverter.deposit(erc20_2.address, 10, {from: user_2})
-      await stablecoinConverter.deposit(erc20_3.address, 10, {from: user_3})
+      await stablecoinConverter.deposit(erc20_1.address, 10, { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, 10, { from: user_2 })
+      await stablecoinConverter.deposit(erc20_3.address, 10, { from: user_3 })
 
       await stablecoinConverter.addToken(erc20_1.address)
       await stablecoinConverter.addToken(erc20_2.address)
@@ -243,9 +243,9 @@ contract("StablecoinConverter", async (accounts) => {
 
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 10, 10, {from: user_1})
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, true, batchIndex + 1, 10, 10, {from: user_2})
-      const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, true, batchIndex + 1, 10, 10, {from: user_3})
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 10, 10, { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, true, batchIndex + 1, 10, 10, { from: user_2 })
+      const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, true, batchIndex + 1, 10, 10, { from: user_3 })
 
       // close auction
       await waitForNSeconds(BATCH_TIME)
@@ -256,8 +256,8 @@ contract("StablecoinConverter", async (accounts) => {
       const volume = [10, 10, 10]
       const tokenIdsForPrice = [0, 1, 2]
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice)
-      
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice)
+
       assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_1.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_3, erc20_3.address)).toNumber(), 0, "Sold tokens were not adjusted correctly")
@@ -266,22 +266,22 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal(await stablecoinConverter.getBalance.call(user_3, erc20_1.address), 10, "Bought tokens were not adjusted correctly")
     })
     it("throws, if the batchIndex is incorrect", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const erc20_1 = await MockContract.new()
       const erc20_2 = await MockContract.new()
-      
+
       await erc20_1.givenAnyReturnBool(true)
       await erc20_2.givenAnyReturnBool(true)
 
-      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
-      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
-      
+      await stablecoinConverter.deposit(erc20_1.address, 10, { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, 20, { from: user_2 })
+
       await stablecoinConverter.addToken(erc20_1.address)
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, {from: user_1})
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, { from: user_2 })
       // close auction
       await waitForNSeconds(BATCH_TIME)
 
@@ -289,65 +289,65 @@ contract("StablecoinConverter", async (accounts) => {
       const owner = [user_1, user_2]  //tradeData is submitted as arrays
       const orderId = [orderId1, orderId2]
       const volume = [5, 10]
-      
-      
+
+
       const tokenIdsForPrice = [0, 1]
 
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex - 1, owner, orderId, volume,  prices, tokenIdsForPrice),
+        stablecoinConverter.submitSolution(batchIndex - 1, owner, orderId, volume, prices, tokenIdsForPrice),
         "Solutions are no longer accepted for this batch"
       )
     })
     it("throws, if order is not yet valid", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const erc20_1 = await MockContract.new()
       const erc20_2 = await MockContract.new()
-      
+
       await erc20_1.givenAnyReturnBool(true)
       await erc20_2.givenAnyReturnBool(true)
 
-      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
-      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
-      
+      await stablecoinConverter.deposit(erc20_1.address, 10, { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, 20, { from: user_2 })
+
       await stablecoinConverter.addToken(erc20_1.address)
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, {from: user_1})
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, { from: user_2 })
 
       const prices = [10, 20]
       const owner = [user_1, user_2]  //tradeData is submitted as arrays
       const orderId = [orderId1, orderId2]
       const volume = [5, 10]
-      
-      
+
+
       const tokenIdsForPrice = [0, 1]
 
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex - 1, owner, orderId, volume,  prices, tokenIdsForPrice),
+        stablecoinConverter.submitSolution(batchIndex - 1, owner, orderId, volume, prices, tokenIdsForPrice),
         "Order is not yet valid"
       )
     })
     it("throws, if order is no longer valid", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const erc20_1 = await MockContract.new()
       const erc20_2 = await MockContract.new()
-      
+
       await erc20_1.givenAnyReturnBool(true)
       await erc20_2.givenAnyReturnBool(true)
 
-      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
-      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
-      
+      await stablecoinConverter.deposit(erc20_1.address, 10, { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, 20, { from: user_2 })
+
       await stablecoinConverter.addToken(erc20_1.address)
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, {from: user_1})
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, { from: user_2 })
       // close auction
       await waitForNSeconds(BATCH_TIME)
       // close another auction
@@ -356,142 +356,142 @@ contract("StablecoinConverter", async (accounts) => {
       const owner = [user_1, user_2]  //tradeData is submitted as arrays
       const orderId = [orderId1, orderId2]
       const volume = [5, 10]
-      
-      
+
+
       const tokenIdsForPrice = [0, 1]
 
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume,  prices, tokenIdsForPrice),
+        stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume, prices, tokenIdsForPrice),
         "Order is no longer valid"
       )
     })
     it("throws, if limit price is not met for an order", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const erc20_1 = await MockContract.new()
       const erc20_2 = await MockContract.new()
-      
+
       await erc20_1.givenAnyReturnBool(true)
       await erc20_2.givenAnyReturnBool(true)
 
-      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
-      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
-      
+      await stablecoinConverter.deposit(erc20_1.address, 10, { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, 20, { from: user_2 })
+
       await stablecoinConverter.addToken(erc20_1.address)
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 19, 10, {from: user_1})
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 19, 10, { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, { from: user_2 })
       // close auction
       await waitForNSeconds(BATCH_TIME)
       const prices = [10, 20]
       const owner = [user_1, user_2]  //tradeData is submitted as arrays
       const orderId = [orderId1, orderId2]
       const volume = [5, 10]
-      
-      
+
+
       const tokenIdsForPrice = [0, 1]
 
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice),
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice),
         "limit price not satisfied"
       )
     })
     it("throws, if sell volume is bigger than order volume", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const erc20_1 = await MockContract.new()
       const erc20_2 = await MockContract.new()
-      
+
       await erc20_1.givenAnyReturnBool(true)
       await erc20_2.givenAnyReturnBool(true)
 
-      await stablecoinConverter.deposit(erc20_1.address, 10, {from: user_1})
-      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
-      
+      await stablecoinConverter.deposit(erc20_1.address, 10, { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, 20, { from: user_2 })
+
       await stablecoinConverter.addToken(erc20_1.address)
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, {from: user_1})
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, { from: user_2 })
       // close auction
       await waitForNSeconds(BATCH_TIME)
       const prices = [10, 20]
       const owner = [user_1, user_2]  //tradeData is submitted as arrays
       const orderId = [orderId1, orderId2]
       const volume = [11, 10]
-      
-      
+
+
       const tokenIdsForPrice = [0, 1]
 
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice),
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice),
         "executedSellAmount bigger than specified in order"
       )
     })
     it("throws, if sell volume is bigger than balance available", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const erc20_1 = await MockContract.new()
       const erc20_2 = await MockContract.new()
-      
+
       await erc20_1.givenAnyReturnBool(true)
       await erc20_2.givenAnyReturnBool(true)
 
-      await stablecoinConverter.deposit(erc20_1.address, 8, {from: user_1})
-      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
-      
+      await stablecoinConverter.deposit(erc20_1.address, 8, { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, 20, { from: user_2 })
+
       await stablecoinConverter.addToken(erc20_1.address)
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, {from: user_1})
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, { from: user_2 })
       // close auction
       await waitForNSeconds(BATCH_TIME)
       const prices = [10, 20]
       const owner = [user_1, user_2]  //tradeData is submitted as arrays
       const orderId = [orderId1, orderId2]
       const volume = [10, 20]
-      
+
       const tokenIdsForPrice = [0, 1]
 
       //correct batchIndex would be batchIndex
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice)//,
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice)//,
       )
     })
     it("reverts, if a trade touches a token, for which no price is provided", async () => {
-      const stablecoinConverter = await StablecoinConverter.new(2**16-1)
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
       const erc20_1 = await MockContract.new()
       const erc20_2 = await MockContract.new()
-      
+
       await erc20_1.givenAnyReturnBool(true)
       await erc20_2.givenAnyReturnBool(true)
 
-      await stablecoinConverter.deposit(erc20_1.address, 8, {from: user_1})
-      await stablecoinConverter.deposit(erc20_2.address, 20, {from: user_2})
-      
+      await stablecoinConverter.deposit(erc20_1.address, 8, { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, 20, { from: user_2 })
+
       await stablecoinConverter.addToken(erc20_1.address)
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, {from: user_1})
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, {from: user_2})
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex, 20, 10, { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex, 10, 20, { from: user_2 })
       // close auction
       await waitForNSeconds(BATCH_TIME)
       const prices = [10, 20]
       const owner = [user_1, user_2]  //tradeData is submitted as arrays
       const orderId = [orderId1, orderId2]
       const volume = [10, 20]
-      
+
       const tokenIdsForPrice = [0, 0]
 
       await truffleAssert.reverts(
-        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume,  prices, tokenIdsForPrice),
-        "Price not provided for token"
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice),
+        "prices are not allowed to be zero"
       )
     })
   })


### PR DESCRIPTION
This pr allows a solution provider to submit their solution;

The function processes the solution, under the assumption that it was provided according to the time constraints and updates all balances and orders touched in a solution.

BuyOrders can not yet be submitted.

Tom already mentioned that we might wanna replace some equalities with delta checks, in order to make solution submission possible for him. But this will be postponed.

Testplan:
unit test