### PR TITLE
Allow invokeViewFunction script to take parameters

### DIFF
--- a/scripts/invokeViewFunction.js
+++ b/scripts/invokeViewFunction.js
@@ -7,14 +7,14 @@ const { getArgumentsHelper } = require("./script_utilities.js")
 module.exports = async (callback) => {
   try {
     const arguments = getArgumentsHelper()
-    if (arguments.length != 1) {
-      callback("Error: This script requires arguments - <functionName>")
+    if (arguments.length < 1) {
+      callback("Error: This script requires arguments - <functionName> [..args]")
     }
-    const [functionName] = arguments
-    
+    const [functionName, ...args] = arguments
+
     const instance = await SnappAuction.deployed()
-    const info = await instance[functionName].call()
-    
+    const info = await instance[functionName].call(...args)
+
     console.log(info)
     callback()
   } catch (error) {


### PR DESCRIPTION
As title. This will be useful in e2e e.g. when we try to see who is the current winner of an auction bid

### Test Plan

Run 
```
npx truffle exect scripts/invokeViewFunction.js auctions 0
```

And see that we get the result of calling

```js
await instance.auctions.call(0)
```