### PR TITLE
Solution submission step4: Introducing fee mechanism 

### DIFF
--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -44,7 +44,7 @@ contract StablecoinConverter is EpochTokenLocker {
 
     uint public MAX_TOKENS; // solhint-disable-line
     uint16 public numTokens = 0;
-    uint128 public feeDenominator;
+    uint128 public feeDenominator; // fee is (1 / feeDenominator)
 
     constructor(uint maxTokens, uint128 _feeDenominator, address feeToken) public {
         MAX_TOKENS = maxTokens;

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -149,6 +149,7 @@ contract StablecoinConverter is EpochTokenLocker {
         } else {
             currentFeeCollected = 0;
         }
+        require(tokenIdsForPrice[0] == 0, "fee token price has to be specified");
         updateCurrentPrices(prices, tokenIdsForPrice);
         delete previousSolution.trades;
         int[] memory tokenConservation = new int[](prices.length);
@@ -303,7 +304,6 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     function checkPriceOrdering(uint16[] memory tokenIdsForPrice) private pure returns (bool) {
-        require(tokenIdsForPrice[0] == 0, "fee token price has to be specified");
         for (uint i = 1; i < tokenIdsForPrice.length; i++) {
             if (tokenIdsForPrice[i] <= tokenIdsForPrice[i - 1]) {
                 return false;

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -26,7 +26,6 @@ contract StablecoinConverter is EpochTokenLocker {
         uint id
     );
 
-    //outstanding remainingAmount of an order is encoded as priceNominator or priceDenominator depending on isSellOrder
     struct Order {
         uint16 buyToken;
         uint16 sellToken;
@@ -248,21 +247,21 @@ contract StablecoinConverter is EpochTokenLocker {
                 address owner = previousSolution.trades[i].owner;
                 uint orderId = previousSolution.trades[i].orderId;
                 Order memory order = orders[owner][orderId];
-                uint sellremainingAmount = previousSolution.trades[i].remainingAmount;
-                addBalance(owner, tokenIdToAddressMap(order.sellToken), sellremainingAmount);
+                uint sellAmount = previousSolution.trades[i].remainingAmount;
+                addBalance(owner, tokenIdToAddressMap(order.sellToken), sellAmount);
             }
             for (uint i = 0; i < previousSolution.trades.length; i++) {
                 address owner = previousSolution.trades[i].owner;
                 uint orderId = previousSolution.trades[i].orderId;
                 Order memory order = orders[owner][orderId];
-                uint128 sellremainingAmount = previousSolution.trades[i].remainingAmount;
-                uint128 buyremainingAmount = getExecutedBuyAmount(
-                    sellremainingAmount,
+                uint128 sellAmount = previousSolution.trades[i].remainingAmount;
+                uint128 buyAmount = getExecutedBuyAmount(
+                    sellAmount,
                     currentPrices[order.buyToken],
                     currentPrices[order.sellToken]
                 );
-                revertRemainingOrder(owner, orderId, previousSolution.trades[i].remainingAmount);
-                subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyremainingAmount);
+                revertRemainingOrder(owner, orderId, sellAmount);
+                subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyAmount);
             }
         }
     }

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -247,21 +247,21 @@ contract StablecoinConverter is EpochTokenLocker {
                 address owner = previousSolution.trades[i].owner;
                 uint orderId = previousSolution.trades[i].orderId;
                 Order memory order = orders[owner][orderId];
-                uint sellAmount = previousSolution.trades[i].volume;
-                addBalance(owner, tokenIdToAddressMap(order.sellToken), sellAmount);
+                uint sellVolume = previousSolution.trades[i].volume;
+                addBalance(owner, tokenIdToAddressMap(order.sellToken), sellVolume);
             }
             for (uint i = 0; i < previousSolution.trades.length; i++) {
                 address owner = previousSolution.trades[i].owner;
                 uint orderId = previousSolution.trades[i].orderId;
                 Order memory order = orders[owner][orderId];
-                uint128 sellAmount = previousSolution.trades[i].volume;
-                uint128 buyAmount = getExecutedBuyAmount(
-                    sellAmount,
+                uint128 sellVolume = previousSolution.trades[i].volume;
+                uint128 buyVolume = getExecutedBuyAmount(
+                    sellVolume,
                     currentPrices[order.buyToken],
                     currentPrices[order.sellToken]
                 );
-                revertRemainingOrder(owner, orderId, sellAmount);
-                subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyAmount);
+                revertRemainingOrder(owner, orderId, sellVolume);
+                subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyVolume);
             }
         }
     }

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -201,9 +201,8 @@ contract StablecoinConverter is EpochTokenLocker {
         uint128[] memory prices,          // list of prices for touched tokens only, frist price is fee token price
         uint16[] memory tokenIdsForPrice  // price[i + 1] is the price for the token with tokenID tokenIdsForPrice[i]
     ) internal {
-        currentPrices[0] = prices[0];
         for (uint i = 0; i < tokenIdsForPrice.length; i++) {
-            currentPrices[tokenIdsForPrice[i]] = prices[i + 1];
+            currentPrices[tokenIdsForPrice[i]] = prices[i];
         }
     }
 
@@ -287,21 +286,16 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     function findPriceIndex(uint16 index, uint16[] memory tokenIdForPrice) private pure returns (uint) {
-        // return fee token
-        if (index == 0) {
-            return 0;
-        }
         // binary search for the other tokens
         uint leftValue = 0;
         uint rightValue = tokenIdForPrice.length - 1;
         while (rightValue >= leftValue) {
             uint middleValue = leftValue + (rightValue-leftValue) / 2;
             if (tokenIdForPrice[middleValue] == index) {
-                return middleValue + 1;
+                return middleValue;
             } else if (tokenIdForPrice[middleValue] < index) {
                 leftValue = middleValue + 1;
             } else {
-                require(middleValue > 0, "Price not provided for token, underflow would have happened");
                 rightValue = middleValue - 1;
             }
         }
@@ -309,7 +303,7 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     function checkPriceOrdering(uint16[] memory tokenIdsForPrice) private pure returns (bool) {
-        require(tokenIdsForPrice[0] > 0, "fee token price index does not have to be specified");
+        require(tokenIdsForPrice[0] == 0, "fee token price has to be specified");
         for (uint i = 1; i < tokenIdsForPrice.length; i++) {
             if (tokenIdsForPrice[i] <= tokenIdsForPrice[i - 1]) {
                 return false;

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -282,7 +282,7 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     function checkForBestSolutionSubmission(int256 fee) private {
-        require(fee > currentFeeCollected, "Fee is not higher than before");
+        require(fee > currentFeeCollected, "Solution does not generate a higher fee than a previous solution");
         currentFeeCollected = fee;
     }
 

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -137,7 +137,7 @@ contract StablecoinConverter is EpochTokenLocker {
         uint128[] memory volumes,
         uint128[] memory prices,  //list of prices for touched token only
         uint16[] memory tokenIdsForPrice  // price[i] is the price for the token with tokenID tokenIdsForPrice[i]
-                                          // tokenId for fee token does not need to be send, as it is always 0
+                                          // fee token id not required since always 0
     ) public {
         require(
             batchIndex == getCurrentStateIndex() - 1,

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -203,7 +203,7 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     function updateCurrentPrices(
-        uint128[] memory prices,  //list of prices for touched token only, frist price is fee Token price
+        uint128[] memory prices,          // list of prices for touched tokens only, frist price is fee token price
         uint16[] memory tokenIdsForPrice  // price[i + 1] is the price for the token with tokenID tokenIdsForPrice[i]
     ) internal {
         currentPrices[0] = prices[0];

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -34,7 +34,7 @@ contract StablecoinConverter is EpochTokenLocker {
         bool isSellOrder;
         uint128 priceNumerator;
         uint128 priceDenominator;
-        uint128 remainingAmount;
+        uint128 remainingAmount; // remainingAmount can either be a sellAmount or buyAmount, depending on the flag isSellOrder
     }
 
     // User-> Order
@@ -201,17 +201,17 @@ contract StablecoinConverter is EpochTokenLocker {
     function updateRemainingOrder(
         address owner,
         uint orderId,
-        uint128 volume
+        uint128 exectuedAmount
     ) internal returns (uint) {
-        orders[owner][orderId].remainingAmount = uint128(orders[owner][orderId].remainingAmount.sub(volume));
+        orders[owner][orderId].remainingAmount = uint128(orders[owner][orderId].remainingAmount.sub(exectuedAmount));
     }
 
     function revertRemainingOrder(
         address owner,
         uint orderId,
-        uint128 volume
+        uint128 exectuedAmount
     ) internal returns (uint) {
-        orders[owner][orderId].remainingAmount = uint128(orders[owner][orderId].remainingAmount.add(volume));
+        orders[owner][orderId].remainingAmount = uint128(orders[owner][orderId].remainingAmount.add(exectuedAmount));
     }
 
     function updateCurrentPrices(

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -189,11 +189,6 @@ contract StablecoinConverter is EpochTokenLocker {
         documentTrades(batchIndex, owners, orderIds, volumes, tokenIdsForPrice);
     }
 
-    function checkForBestSolutionSubmission(int256 fee) private {
-        require(fee > currentFeeCollected, "Fee is not higher than before");
-        currentFeeCollected = fee;
-    }
-
     function checkTokenConservation(
         int[] memory tokenConservation
     ) internal pure {
@@ -284,6 +279,11 @@ contract StablecoinConverter is EpochTokenLocker {
             revertRemainingOrder(owner, orderId, sellVolume);
             subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyVolume);
         }
+    }
+
+    function checkForBestSolutionSubmission(int256 fee) private {
+        require(fee > currentFeeCollected, "Fee is not higher than before");
+        currentFeeCollected = fee;
     }
 
     function findPriceIndex(uint16 index, uint16[] memory tokenIdForPrice) private pure returns (uint) {

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -161,7 +161,7 @@ contract StablecoinConverter is EpochTokenLocker {
                 executedSellAmount.mul(order.priceNumerator) <= executedBuyAmount.mul(order.priceDenominator),
                 "limit price not satisfied"
             );
-            require(order.priceDenominator >= executedSellAmount, "executedSellAmount bigger than specified in order");
+            require(order.remainingAmount >= executedSellAmount, "executedSellAmount bigger than specified in order");
             updateRemainingOrder(owners[i], orderIds[i], executedSellAmount);
             tokenConservation[findPriceIndex(order.buyToken, tokenIdsForPrice)] += int(executedBuyAmount);
             tokenConservation[findPriceIndex(order.sellToken, tokenIdsForPrice)] -= int(executedSellAmount);

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -28,8 +28,8 @@ contract("StablecoinConverter", async (accounts) => {
       const id = await stablecoinConverter.placeOrder.call(0, 1, true, 3, 10, 20, { from: user_1 })
       await stablecoinConverter.placeOrder(0, 1, true, 3, 10, 20, { from: user_1 })
       const orderResult = (await stablecoinConverter.orders.call(user_1, id))
-      assert.equal((orderResult.sellAmount).toNumber(), 20, "sellAmount was stored incorrectly")
-      assert.equal((orderResult.buyAmount).toNumber(), 10, "buyAmount was stored incorrectly")
+      assert.equal((orderResult.priceDenominator).toNumber(), 20, "priceDenominator was stored incorrectly")
+      assert.equal((orderResult.priceNominator).toNumber(), 10, "priceNominator was stored incorrectly")
       assert.equal((orderResult.sellToken).toNumber(), 1, "sellToken was stored incorrectly")
       assert.equal((orderResult.buyToken).toNumber(), 0, "buyToken was stored incorrectly")
       assert.equal(orderResult.isSellOrder, true, "sellTokenFlag was stored incorrectly")
@@ -62,7 +62,7 @@ contract("StablecoinConverter", async (accounts) => {
       await waitForNSeconds(BATCH_TIME)
       await stablecoinConverter.freeStorageOfOrder(id)
 
-      assert.equal((await stablecoinConverter.orders(user_1, id)).sellAmount, 0, "sellAmount was stored incorrectly")
+      assert.equal((await stablecoinConverter.orders(user_1, id)).priceDenominator, 0, "priceDenominator was stored incorrectly")
     })
     it("fails to delete non-canceled order", async () => {
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
@@ -213,12 +213,12 @@ contract("StablecoinConverter", async (accounts) => {
       const orderResult1 = (await stablecoinConverter.orders.call(user_1, orderId1))
       const orderResult2 = (await stablecoinConverter.orders.call(user_2, orderId2))
 
-      assert.equal((orderResult1.remainingAmount).toNumber(), 5, "volume was stored incorrectly")
-      assert.equal((orderResult1.sellAmount).toNumber(), 10, "sellAmount was stored incorrectly")
-      assert.equal((orderResult1.buyAmount).toNumber(), 20, "buyAmount was stored incorrectly")
-      assert.equal((orderResult2.remainingAmount).toNumber(), 10, "volume was stored incorrectly")
-      assert.equal((orderResult2.sellAmount).toNumber(), 20, "sellAmount was stored incorrectly")
-      assert.equal((orderResult2.buyAmount).toNumber(), 10, "buyAmount was stored incorrectly")
+      assert.equal((orderResult1.remainingAmount).toNumber(), 5, "remainingAmount was stored incorrectly")
+      assert.equal((orderResult1.priceDenominator).toNumber(), 10, "priceDenominator was stored incorrectly")
+      assert.equal((orderResult1.priceNominator).toNumber(), 20, "priceNominator was stored incorrectly")
+      assert.equal((orderResult2.remainingAmount).toNumber(), 10, "remainingAmount was stored incorrectly")
+      assert.equal((orderResult2.priceDenominator).toNumber(), 20, "priceDenominator was stored incorrectly")
+      assert.equal((orderResult2.priceNominator).toNumber(), 10, "priceNominator was stored incorrectly")
     })
     it("places two orders and first matches them partially and then fully in a 2nd solution submission", async () => {
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -394,7 +394,7 @@ contract("StablecoinConverter", async (accounts) => {
       //Now reverting should not throw, only later due to fee criteria
       await truffleAssert.reverts(
         stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice),
-        "Fee is not higher than before"
+        "Solution does not generate a higher fee than a previous solution"
       )
     })
     it("checks that trades documented from a previous trade are deleted and not considered for a new batchIndex", async () => {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -213,10 +213,10 @@ contract("StablecoinConverter", async (accounts) => {
       const orderResult1 = (await stablecoinConverter.orders.call(user_1, orderId1))
       const orderResult2 = (await stablecoinConverter.orders.call(user_2, orderId2))
 
-      assert.equal((orderResult1.volume).toNumber(), 5, "volume was stored incorrectly")
+      assert.equal((orderResult1.remainingAmount).toNumber(), 5, "volume was stored incorrectly")
       assert.equal((orderResult1.sellAmount).toNumber(), 10, "sellAmount was stored incorrectly")
       assert.equal((orderResult1.buyAmount).toNumber(), 20, "buyAmount was stored incorrectly")
-      assert.equal((orderResult2.volume).toNumber(), 10, "volume was stored incorrectly")
+      assert.equal((orderResult2.remainingAmount).toNumber(), 10, "volume was stored incorrectly")
       assert.equal((orderResult2.sellAmount).toNumber(), 20, "sellAmount was stored incorrectly")
       assert.equal((orderResult2.buyAmount).toNumber(), 10, "buyAmount was stored incorrectly")
     })

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -778,7 +778,7 @@ contract("StablecoinConverter", async (accounts) => {
 
       await truffleAssert.reverts(
         stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice),
-        "price for fee token should not be overwritten"
+        "fee token price index does not have to be specified"
       )
     })
     it("reverts, if price of sellToken == 0", async () => {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -29,7 +29,7 @@ contract("StablecoinConverter", async (accounts) => {
       await stablecoinConverter.placeOrder(0, 1, true, 3, 10, 20, { from: user_1 })
       const orderResult = (await stablecoinConverter.orders.call(user_1, id))
       assert.equal((orderResult.priceDenominator).toNumber(), 20, "priceDenominator was stored incorrectly")
-      assert.equal((orderResult.priceNominator).toNumber(), 10, "priceNominator was stored incorrectly")
+      assert.equal((orderResult.priceNumerator).toNumber(), 10, "priceNumerator was stored incorrectly")
       assert.equal((orderResult.sellToken).toNumber(), 1, "sellToken was stored incorrectly")
       assert.equal((orderResult.buyToken).toNumber(), 0, "buyToken was stored incorrectly")
       assert.equal(orderResult.isSellOrder, true, "sellTokenFlag was stored incorrectly")
@@ -215,10 +215,10 @@ contract("StablecoinConverter", async (accounts) => {
 
       assert.equal((orderResult1.remainingAmount).toNumber(), 5, "remainingAmount was stored incorrectly")
       assert.equal((orderResult1.priceDenominator).toNumber(), 10, "priceDenominator was stored incorrectly")
-      assert.equal((orderResult1.priceNominator).toNumber(), 20, "priceNominator was stored incorrectly")
+      assert.equal((orderResult1.priceNumerator).toNumber(), 20, "priceNumerator was stored incorrectly")
       assert.equal((orderResult2.remainingAmount).toNumber(), 10, "remainingAmount was stored incorrectly")
       assert.equal((orderResult2.priceDenominator).toNumber(), 20, "priceDenominator was stored incorrectly")
-      assert.equal((orderResult2.priceNominator).toNumber(), 10, "priceNominator was stored incorrectly")
+      assert.equal((orderResult2.priceNumerator).toNumber(), 10, "priceNumerator was stored incorrectly")
     })
     it("places two orders and first matches them partially and then fully in a 2nd solution submission", async () => {
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -213,11 +213,12 @@ contract("StablecoinConverter", async (accounts) => {
       const orderResult1 = (await stablecoinConverter.orders.call(user_1, orderId1))
       const orderResult2 = (await stablecoinConverter.orders.call(user_2, orderId2))
 
-      assert.equal((orderResult1.sellAmount).toNumber(), 5, "sellAmount was stored incorrectly")
-      assert.equal((orderResult1.buyAmount).toNumber(), 10, "buyAmount was stored incorrectly")
-
-      assert.equal((orderResult2.sellAmount).toNumber(), 10, "sellAmount was stored incorrectly")
-      assert.equal((orderResult2.buyAmount).toNumber(), 5, "buyAmount was stored incorrectly")
+      assert.equal((orderResult1.volume).toNumber(), 5, "volume was stored incorrectly")
+      assert.equal((orderResult1.sellAmount).toNumber(), 10, "sellAmount was stored incorrectly")
+      assert.equal((orderResult1.buyAmount).toNumber(), 20, "buyAmount was stored incorrectly")
+      assert.equal((orderResult2.volume).toNumber(), 10, "volume was stored incorrectly")
+      assert.equal((orderResult2.sellAmount).toNumber(), 20, "sellAmount was stored incorrectly")
+      assert.equal((orderResult2.buyAmount).toNumber(), 10, "buyAmount was stored incorrectly")
     })
     it("places two orders and first matches them partially and then fully in a 2nd solution submission", async () => {
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)


### PR DESCRIPTION
This Pr introduces the fee mechanism as discussed here: https://github.com/gnosis/dex-contracts/issues/173.

Now, the constructor takes a fee parameter and a fee token. The fee token will be the token with the token index 0 and must be part of any solution. 

In the solution vector, the tokenIdsForIndex array does not need to supply the feeToken index 0, as it must be part of any solution and hence we implicitly know that the first index would always have to be pointing to 0 anyways. 

Every solution must be constructed such that the imbalance of tokens bought and tokens sold is shifted into the fee token. Hence, the token conservation check is only done for all tokens, but the fee token.

-----
I was rewriting most of the tests to base them on a basic trade, as the fee mechanism required me to do this anyways. Now, we no longer have to check all the numbers in the tests, we just reuse the same numbers for the basic trade and modify them to archive specific test results.

---
Currently, this Pr is super long. If you do not want to review it, I can understand. Please let me know how I could do the test refactoring more efficient and more comprehensive.

---
Test plan: Unit tests only