### PR TITLE
Introducing Volumes in Orders, in order to prevent rounding issues

### DIFF
--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -26,7 +26,6 @@ contract StablecoinConverter is EpochTokenLocker {
         uint id
     );
 
-    //outstanding remainingAmount of an order is encoded as priceNominator or priceDenominator depending on isSellOrder
     struct Order {
         uint16 buyToken;
         uint16 sellToken;
@@ -248,21 +247,21 @@ contract StablecoinConverter is EpochTokenLocker {
                 address owner = previousSolution.trades[i].owner;
                 uint orderId = previousSolution.trades[i].orderId;
                 Order memory order = orders[owner][orderId];
-                uint sellremainingAmount = previousSolution.trades[i].remainingAmount;
-                addBalance(owner, tokenIdToAddressMap(order.sellToken), sellremainingAmount);
+                uint sellAmount = previousSolution.trades[i].remainingAmount;
+                addBalance(owner, tokenIdToAddressMap(order.sellToken), sellAmount);
             }
             for (uint i = 0; i < previousSolution.trades.length; i++) {
                 address owner = previousSolution.trades[i].owner;
                 uint orderId = previousSolution.trades[i].orderId;
                 Order memory order = orders[owner][orderId];
-                uint128 sellremainingAmount = previousSolution.trades[i].remainingAmount;
-                uint128 buyremainingAmount = getExecutedBuyAmount(
-                    sellremainingAmount,
+                uint128 sellAmount = previousSolution.trades[i].remainingAmount;
+                uint128 buyAmount = getExecutedBuyAmount(
+                    sellAmount,
                     currentPrices[order.buyToken],
                     currentPrices[order.sellToken]
                 );
-                revertRemainingOrder(owner, orderId, previousSolution.trades[i].remainingAmount);
-                subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyremainingAmount);
+                revertRemainingOrder(owner, orderId, sellAmount);
+                subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyAmount);
             }
         }
     }

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -247,21 +247,21 @@ contract StablecoinConverter is EpochTokenLocker {
                 address owner = previousSolution.trades[i].owner;
                 uint orderId = previousSolution.trades[i].orderId;
                 Order memory order = orders[owner][orderId];
-                uint sellAmount = previousSolution.trades[i].volume;
-                addBalance(owner, tokenIdToAddressMap(order.sellToken), sellAmount);
+                uint sellVolume = previousSolution.trades[i].volume;
+                addBalance(owner, tokenIdToAddressMap(order.sellToken), sellVolume);
             }
             for (uint i = 0; i < previousSolution.trades.length; i++) {
                 address owner = previousSolution.trades[i].owner;
                 uint orderId = previousSolution.trades[i].orderId;
                 Order memory order = orders[owner][orderId];
-                uint128 sellAmount = previousSolution.trades[i].volume;
-                uint128 buyAmount = getExecutedBuyAmount(
-                    sellAmount,
+                uint128 sellVolume = previousSolution.trades[i].volume;
+                uint128 buyVolume = getExecutedBuyAmount(
+                    sellVolume,
                     currentPrices[order.buyToken],
                     currentPrices[order.sellToken]
                 );
-                revertRemainingOrder(owner, orderId, sellAmount);
-                subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyAmount);
+                revertRemainingOrder(owner, orderId, sellVolume);
+                subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyVolume);
             }
         }
     }

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -34,7 +34,7 @@ contract StablecoinConverter is EpochTokenLocker {
         bool isSellOrder;
         uint128 priceNumerator;
         uint128 priceDenominator;
-        uint128 remainingAmount;
+        uint128 remainingAmount; // remainingAmount can either be a sellAmount or buyAmount, depending on the flag isSellOrder
     }
 
     // User-> Order
@@ -201,17 +201,17 @@ contract StablecoinConverter is EpochTokenLocker {
     function updateRemainingOrder(
         address owner,
         uint orderId,
-        uint128 volume
+        uint128 exectuedAmount
     ) internal returns (uint) {
-        orders[owner][orderId].remainingAmount = uint128(orders[owner][orderId].remainingAmount.sub(volume));
+        orders[owner][orderId].remainingAmount = uint128(orders[owner][orderId].remainingAmount.sub(exectuedAmount));
     }
 
     function revertRemainingOrder(
         address owner,
         uint orderId,
-        uint128 volume
+        uint128 exectuedAmount
     ) internal returns (uint) {
-        orders[owner][orderId].remainingAmount = uint128(orders[owner][orderId].remainingAmount.add(volume));
+        orders[owner][orderId].remainingAmount = uint128(orders[owner][orderId].remainingAmount.add(exectuedAmount));
     }
 
     function updateCurrentPrices(

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -161,7 +161,7 @@ contract StablecoinConverter is EpochTokenLocker {
                 executedSellAmount.mul(order.priceNumerator) <= executedBuyAmount.mul(order.priceDenominator),
                 "limit price not satisfied"
             );
-            require(order.priceDenominator >= executedSellAmount, "executedSellAmount bigger than specified in order");
+            require(order.remainingAmount >= executedSellAmount, "executedSellAmount bigger than specified in order");
             updateRemainingOrder(owners[i], orderIds[i], executedSellAmount);
             tokenConservation[findPriceIndex(order.buyToken, tokenIdsForPrice)] += int(executedBuyAmount);
             tokenConservation[findPriceIndex(order.sellToken, tokenIdsForPrice)] -= int(executedSellAmount);

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -28,8 +28,8 @@ contract("StablecoinConverter", async (accounts) => {
       const id = await stablecoinConverter.placeOrder.call(0, 1, true, 3, 10, 20, { from: user_1 })
       await stablecoinConverter.placeOrder(0, 1, true, 3, 10, 20, { from: user_1 })
       const orderResult = (await stablecoinConverter.orders.call(user_1, id))
-      assert.equal((orderResult.sellAmount).toNumber(), 20, "sellAmount was stored incorrectly")
-      assert.equal((orderResult.buyAmount).toNumber(), 10, "buyAmount was stored incorrectly")
+      assert.equal((orderResult.priceDenominator).toNumber(), 20, "priceDenominator was stored incorrectly")
+      assert.equal((orderResult.priceNominator).toNumber(), 10, "priceNominator was stored incorrectly")
       assert.equal((orderResult.sellToken).toNumber(), 1, "sellToken was stored incorrectly")
       assert.equal((orderResult.buyToken).toNumber(), 0, "buyToken was stored incorrectly")
       assert.equal(orderResult.isSellOrder, true, "sellTokenFlag was stored incorrectly")
@@ -62,7 +62,7 @@ contract("StablecoinConverter", async (accounts) => {
       await waitForNSeconds(BATCH_TIME)
       await stablecoinConverter.freeStorageOfOrder(id)
 
-      assert.equal((await stablecoinConverter.orders(user_1, id)).sellAmount, 0, "sellAmount was stored incorrectly")
+      assert.equal((await stablecoinConverter.orders(user_1, id)).priceDenominator, 0, "priceDenominator was stored incorrectly")
     })
     it("fails to delete non-canceled order", async () => {
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)
@@ -213,12 +213,12 @@ contract("StablecoinConverter", async (accounts) => {
       const orderResult1 = (await stablecoinConverter.orders.call(user_1, orderId1))
       const orderResult2 = (await stablecoinConverter.orders.call(user_2, orderId2))
 
-      assert.equal((orderResult1.remainingAmount).toNumber(), 5, "volume was stored incorrectly")
-      assert.equal((orderResult1.sellAmount).toNumber(), 10, "sellAmount was stored incorrectly")
-      assert.equal((orderResult1.buyAmount).toNumber(), 20, "buyAmount was stored incorrectly")
-      assert.equal((orderResult2.remainingAmount).toNumber(), 10, "volume was stored incorrectly")
-      assert.equal((orderResult2.sellAmount).toNumber(), 20, "sellAmount was stored incorrectly")
-      assert.equal((orderResult2.buyAmount).toNumber(), 10, "buyAmount was stored incorrectly")
+      assert.equal((orderResult1.remainingAmount).toNumber(), 5, "remainingAmount was stored incorrectly")
+      assert.equal((orderResult1.priceDenominator).toNumber(), 10, "priceDenominator was stored incorrectly")
+      assert.equal((orderResult1.priceNominator).toNumber(), 20, "priceNominator was stored incorrectly")
+      assert.equal((orderResult2.remainingAmount).toNumber(), 10, "remainingAmount was stored incorrectly")
+      assert.equal((orderResult2.priceDenominator).toNumber(), 20, "priceDenominator was stored incorrectly")
+      assert.equal((orderResult2.priceNominator).toNumber(), 10, "priceNominator was stored incorrectly")
     })
     it("places two orders and first matches them partially and then fully in a 2nd solution submission", async () => {
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -213,10 +213,10 @@ contract("StablecoinConverter", async (accounts) => {
       const orderResult1 = (await stablecoinConverter.orders.call(user_1, orderId1))
       const orderResult2 = (await stablecoinConverter.orders.call(user_2, orderId2))
 
-      assert.equal((orderResult1.volume).toNumber(), 5, "volume was stored incorrectly")
+      assert.equal((orderResult1.remainingAmount).toNumber(), 5, "volume was stored incorrectly")
       assert.equal((orderResult1.sellAmount).toNumber(), 10, "sellAmount was stored incorrectly")
       assert.equal((orderResult1.buyAmount).toNumber(), 20, "buyAmount was stored incorrectly")
-      assert.equal((orderResult2.volume).toNumber(), 10, "volume was stored incorrectly")
+      assert.equal((orderResult2.remainingAmount).toNumber(), 10, "volume was stored incorrectly")
       assert.equal((orderResult2.sellAmount).toNumber(), 20, "sellAmount was stored incorrectly")
       assert.equal((orderResult2.buyAmount).toNumber(), 10, "buyAmount was stored incorrectly")
     })

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -29,7 +29,7 @@ contract("StablecoinConverter", async (accounts) => {
       await stablecoinConverter.placeOrder(0, 1, true, 3, 10, 20, { from: user_1 })
       const orderResult = (await stablecoinConverter.orders.call(user_1, id))
       assert.equal((orderResult.priceDenominator).toNumber(), 20, "priceDenominator was stored incorrectly")
-      assert.equal((orderResult.priceNominator).toNumber(), 10, "priceNominator was stored incorrectly")
+      assert.equal((orderResult.priceNumerator).toNumber(), 10, "priceNumerator was stored incorrectly")
       assert.equal((orderResult.sellToken).toNumber(), 1, "sellToken was stored incorrectly")
       assert.equal((orderResult.buyToken).toNumber(), 0, "buyToken was stored incorrectly")
       assert.equal(orderResult.isSellOrder, true, "sellTokenFlag was stored incorrectly")
@@ -215,10 +215,10 @@ contract("StablecoinConverter", async (accounts) => {
 
       assert.equal((orderResult1.remainingAmount).toNumber(), 5, "remainingAmount was stored incorrectly")
       assert.equal((orderResult1.priceDenominator).toNumber(), 10, "priceDenominator was stored incorrectly")
-      assert.equal((orderResult1.priceNominator).toNumber(), 20, "priceNominator was stored incorrectly")
+      assert.equal((orderResult1.priceNumerator).toNumber(), 20, "priceNumerator was stored incorrectly")
       assert.equal((orderResult2.remainingAmount).toNumber(), 10, "remainingAmount was stored incorrectly")
       assert.equal((orderResult2.priceDenominator).toNumber(), 20, "priceDenominator was stored incorrectly")
-      assert.equal((orderResult2.priceNominator).toNumber(), 10, "priceNominator was stored incorrectly")
+      assert.equal((orderResult2.priceNumerator).toNumber(), 10, "priceNumerator was stored incorrectly")
     })
     it("places two orders and first matches them partially and then fully in a 2nd solution submission", async () => {
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -213,11 +213,12 @@ contract("StablecoinConverter", async (accounts) => {
       const orderResult1 = (await stablecoinConverter.orders.call(user_1, orderId1))
       const orderResult2 = (await stablecoinConverter.orders.call(user_2, orderId2))
 
-      assert.equal((orderResult1.sellAmount).toNumber(), 5, "sellAmount was stored incorrectly")
-      assert.equal((orderResult1.buyAmount).toNumber(), 10, "buyAmount was stored incorrectly")
-
-      assert.equal((orderResult2.sellAmount).toNumber(), 10, "sellAmount was stored incorrectly")
-      assert.equal((orderResult2.buyAmount).toNumber(), 5, "buyAmount was stored incorrectly")
+      assert.equal((orderResult1.volume).toNumber(), 5, "volume was stored incorrectly")
+      assert.equal((orderResult1.sellAmount).toNumber(), 10, "sellAmount was stored incorrectly")
+      assert.equal((orderResult1.buyAmount).toNumber(), 20, "buyAmount was stored incorrectly")
+      assert.equal((orderResult2.volume).toNumber(), 10, "volume was stored incorrectly")
+      assert.equal((orderResult2.sellAmount).toNumber(), 20, "sellAmount was stored incorrectly")
+      assert.equal((orderResult2.buyAmount).toNumber(), 10, "buyAmount was stored incorrectly")
     })
     it("places two orders and first matches them partially and then fully in a 2nd solution submission", async () => {
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1)


### PR DESCRIPTION
This PR introduces volumes in the orders.

We need to have volumes, as with the current logic, the reverting of trades is not always done correctly. 
With the current logic, I can happen that in 
`orders[owner][orderId].buyAmount = uint128(
            newSellAmount
            .mul(order.buyAmount) / order.sellAmount
        );`
there is rounding happening, which we will not be able to undo later.


Imagine the following case:
```
const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 3333, 9999, { from: user_1 })
      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 10000, 30000, { from: user_2 })
      const prices = [1, 3]
      const volume = [5000, 15000]
```
order 1 would be updated to sellVolume = 4999, buyVolume = 3333 - 4999*1/3 = 1666 would not longer have a same price
 the reverting of the order would have give a sellVolume of 9999 and the buyVolume of 1666 + 5000*1666/4999 = 3332
and now potentially, better solutions might be found.

If we would implement the isSellOrder flag, it might also happen, that limit prices are not reduced but increased, causing old valid solutions no longer to be valid.
