### PR TITLE
[Script] convenience script to add token and query view functions

### DIFF
--- a/scripts/script_utilities.js
+++ b/scripts/script_utilities.js
@@ -1,5 +1,5 @@
 
-const getArgumentsHelper = function() {
+const getArgumentsHelper = function () {
   const arguments = process.argv.slice(4)
   const index = arguments.indexOf("--network")
   if (index > -1) {
@@ -8,7 +8,7 @@ const getArgumentsHelper = function() {
   return arguments
 }
 
-const getOrderData = async function(instance, callback, web3) {
+const getOrderData = async function (instance, callback, web3) {
   const arguments = getArgumentsHelper()
   if (arguments.length != 5) {
     callback("Error: This script requires arguments - <accountId> <buyToken> <sellToken> <minBuy> <maxSell>")
@@ -35,7 +35,26 @@ const getOrderData = async function(instance, callback, web3) {
   return [buyToken, sellToken, minBuy, maxSell, sender]
 }
 
+const invokeViewFunction = async function (contract, callback) {
+  try {
+    const arguments = getArgumentsHelper()
+    if (arguments.length < 1) {
+      callback("Error: This script requires arguments - <functionName> [..args]")
+    }
+    const [functionName, ...args] = arguments
+
+    const instance = await contract.deployed()
+    const info = await instance[functionName].call(...args)
+
+    console.log(info)
+    callback()
+  } catch (error) {
+    callback(error)
+  }
+}
+
 module.exports = {
   getArgumentsHelper,
-  getOrderData
+  getOrderData,
+  invokeViewFunction
 }

--- a/scripts/snapp/invokeViewFunction.js
+++ b/scripts/snapp/invokeViewFunction.js
@@ -1,23 +1,9 @@
 const SnappAuction = artifacts.require("SnappAuction")
-const { getArgumentsHelper } = require("../script_utilities.js")
+const { invokeViewFunction } = require("../script_utilities.js")
 
 // This script allows to view data from the SnappAuction contract
 // example for viewing the current stateRoots: truffle exec scripts/snapp/viewSnappBaseForCurrentIndex.js 'stateRoots'
 
 module.exports = async (callback) => {
-  try {
-    const arguments = getArgumentsHelper()
-    if (arguments.length < 1) {
-      callback("Error: This script requires arguments - <functionName> [..args]")
-    }
-    const [functionName, ...args] = arguments
-
-    const instance = await SnappAuction.deployed()
-    const info = await instance[functionName].call(...args)
-
-    console.log(info)
-    callback()
-  } catch (error) {
-    callback(error)
-  }
+  await invokeViewFunction(SnappAuction, callback)
 }

--- a/scripts/stablex/add_token.js
+++ b/scripts/stablex/add_token.js
@@ -1,0 +1,20 @@
+const StablecoinConverter = artifacts.require("StablecoinConverter")
+const { getArgumentsHelper } = require("../script_utilities.js")
+
+module.exports = async function (callback) {
+  try {
+    const arguments = getArgumentsHelper()
+    if (arguments.length != 1) {
+      callback("Error: This script requires arguments - <token address>")
+    }
+    const token_address = arguments[0]
+    const instance = await StablecoinConverter.deployed()
+
+    await instance.addToken(token_address)
+
+    console.log(`Successfully added token ${token_address}`)
+    callback()
+  } catch (error) {
+    callback(error)
+  }
+}

--- a/scripts/stablex/invokeViewFunction.js
+++ b/scripts/stablex/invokeViewFunction.js
@@ -1,0 +1,6 @@
+const StablecoinConverter = artifacts.require("StablecoinConverter")
+const { invokeViewFunction } = require("../script_utilities.js")
+
+module.exports = async (callback) => {
+  await invokeViewFunction(StablecoinConverter, callback)
+}


### PR DESCRIPTION
Adding tokens will be useful when we try to migrate this on Rinkeby or another real network. There we will need to add existing tokens.

Invoke view functions has proven powerful for dfusion and will likely be useful for StableX as well. Reusing most of the code here.

### Test Plan

```
npx truffle exec scripts/stablex/invokeViewFunction.js tokenAddressToIdMap 0x0000000000000000000000000000000000000001
```

See failure (not yet added)

```
npx truffle exec scripts/stablex/add_token.js 0x0000000000000000000000000000000000000001
```

Then re-running the first command should succeed.