### PR TITLE
[FlakyTest] Query amount of seconds remaining in current batch

### DIFF
--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -109,6 +109,10 @@ contract EpochTokenLocker {
         return uint32(now / BATCH_TIME);
     }
 
+    function getSecondsRemainingInBatch() public view returns(uint) {
+        return BATCH_TIME - (now % BATCH_TIME);
+    }
+
     function getBalance(address user, address token) public view returns(uint256) {
         uint balance = balanceStates[user][token].balance;
         if (balanceStates[user][token].pendingDeposits.stateIndex < getCurrentStateIndex()) {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -167,8 +167,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -199,8 +199,8 @@ contract("StablecoinConverter", async (accounts) => {
       const batchIndex = (await stablecoinConverter.getCurrentStateIndex.call()).toNumber()
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, feeSubtracted(feeSubtracted(10000)), feeSubtracted(10000), { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = [10, 10]
       const owner = basicTrade.solution.owners
@@ -232,8 +232,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -273,8 +273,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -314,8 +314,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -369,8 +369,8 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, feeSubtracted(10000) - 1, 10000, { from: user_2 })
       const orderId4 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, feeSubtracted(10000) - 1, 10000, { from: user_3 })
 
-      // close auction
-      await waitForNSeconds(BATCH_TIME + 1)
+
+      await closeAuction()
 
       // amount of token1 sold 10000, amount of token2 bought 9990
       // amount of token2 sold 9990, amount of token1 bought 9980 by user2
@@ -416,8 +416,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -465,8 +465,8 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, true, batchIndex + 1, 9980, 9990, { from: user_2 })
       const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, true, batchIndex + 1, 9970, 9980, { from: user_3 })
 
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = [10, 10, 10]
       const owner = [user_1, user_2, user_3]  //tradeData is submitted as arrays
@@ -499,8 +499,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -557,8 +557,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
       // close another auction
       await waitForNSeconds(BATCH_TIME)
       const prices = basicTrade.solution.prices
@@ -588,8 +588,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex, basicTrade.orders[0].buyAmount + 1, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
@@ -616,8 +616,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
@@ -645,8 +645,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount - 1, basicTrade.orders[1].sellAmount, { from: user_2 })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -676,8 +676,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -710,8 +710,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, true, batchIndex, 5, 10, { from: user_1 })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 2, true, batchIndex, 5, 10, { from: user_2 })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
       const prices = [10, 10, 10]
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
@@ -739,8 +739,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -769,8 +769,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -832,8 +832,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = [0, 0]
       const owner = basicTrade.solution.owners
@@ -862,8 +862,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = [20, 10, 3, 4]
       const owner = basicTrade.solution.owners
@@ -898,8 +898,8 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, true, batchIndex + 1, 9970, 9980, { from: user_3 })
       const orderId4 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, feeSubtracted(59940), 59940, { from: user_2 })
 
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = [10, 10, 10]
       const owner = [user_1, user_2, user_3]
@@ -935,8 +935,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = [0, 0]
       const owner = basicTrade.solution.owners
@@ -965,8 +965,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -993,8 +993,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -1028,8 +1028,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME + 1)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -1061,8 +1061,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
-      // close auction
-      await waitForNSeconds(BATCH_TIME + 1)
+
+      await closeAuction()
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -1205,4 +1205,9 @@ function decodeAuctionElements(bytes) {
     })
   }
   return result
+}
+
+const closeAuction = async (instance) => {
+  const time_remaining = await instance.getSecondsRemainingInBatch()
+  await waitForNSeconds(time_remaining + 1)
 }

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -168,7 +168,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -200,7 +200,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, feeSubtracted(feeSubtracted(10000)), feeSubtracted(10000), { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = [10, 10]
       const owner = basicTrade.solution.owners
@@ -233,7 +233,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -274,7 +274,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -315,7 +315,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -370,7 +370,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId4 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, feeSubtracted(10000) - 1, 10000, { from: user_3 })
 
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       // amount of token1 sold 10000, amount of token2 bought 9990
       // amount of token2 sold 9990, amount of token1 bought 9980 by user2
@@ -417,7 +417,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -466,7 +466,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, true, batchIndex + 1, 9970, 9980, { from: user_3 })
 
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = [10, 10, 10]
       const owner = [user_1, user_2, user_3]  //tradeData is submitted as arrays
@@ -500,7 +500,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -558,7 +558,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
       // close another auction
       await waitForNSeconds(BATCH_TIME)
       const prices = basicTrade.solution.prices
@@ -589,7 +589,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex, basicTrade.orders[0].buyAmount + 1, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
@@ -617,7 +617,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
@@ -646,7 +646,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount - 1, basicTrade.orders[1].sellAmount, { from: user_2 })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -677,7 +677,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -711,7 +711,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, true, batchIndex, 5, 10, { from: user_1 })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 2, true, batchIndex, 5, 10, { from: user_2 })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
       const prices = [10, 10, 10]
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
@@ -740,7 +740,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -770,7 +770,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -833,7 +833,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = [0, 0]
       const owner = basicTrade.solution.owners
@@ -863,7 +863,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = [20, 10, 3, 4]
       const owner = basicTrade.solution.owners
@@ -899,7 +899,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId4 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, feeSubtracted(59940), 59940, { from: user_2 })
 
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = [10, 10, 10]
       const owner = [user_1, user_2, user_3]
@@ -936,7 +936,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = [0, 0]
       const owner = basicTrade.solution.owners
@@ -966,7 +966,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -994,7 +994,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -1029,7 +1029,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
@@ -1062,7 +1062,7 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
-      await closeAuction()
+      await closeAuction(stablecoinConverter)
 
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1208,6 +1208,6 @@ function decodeAuctionElements(bytes) {
 }
 
 const closeAuction = async (instance) => {
-  const time_remaining = await instance.getSecondsRemainingInBatch()
+  const time_remaining = (await instance.getSecondsRemainingInBatch()).toNumber()
   await waitForNSeconds(time_remaining + 1)
 }


### PR DESCRIPTION
We are seeing a bunch of flaky tests. In the errors, I can always see the following exception:

```
Error: Returned error: VM Exception while processing transaction: revert -- Reason given: Solutions are no longer accepted for this batch.
```

e.g. https://travis-ci.org/gnosis/dex-contracts/builds/583550493

I believe the reason for them is a timing issue in the way we forward tome for the auction to be over. We always forward the entire batch time (5 minutes). This means that if we are currently very close to the end of a  batch (e.g. less than 5s) and the time it takes to forwards time and then submit the solution is larger than that, we are already in the `k+2`nd batch.

My proposed fix is to wait for the auction to close by checking how much time is left in the current batch. To do this, I'm exposing a new view method, which I believe will be useful also for general interactions (e.g. when we place an order in the UI, we might want to know how long until we can expect people trading against it).

### Test Plan

No more flaky unit tests.