### PR TITLE
[Travis] only run tests once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,5 @@ before_script:
 script:
   - npm run lint
   - npm run solhint
-  - npm test
   - solium -d contracts/
   - npm run coverage && cat ./coverage/lcov.info | coveralls


### PR DESCRIPTION
We currently run all truffle tests twice. Once with npm test and one more time for coverage. This PR removes the first pass and will only run the tests while collecting coverage information at the same time.

This should speed up tests significantly.

Before: https://travis-ci.org/gnosis/dex-contracts/builds/584594889?utm_source=github_status&utm_medium=notification


After: https://travis-ci.org/gnosis/dex-contracts/builds/584598950?utm_source=github_status&utm_medium=notification

Saving ~2.5 minutes

### Test Plan
Travics