### PR TITLE
rearrage account variable in order_placement.js

### DIFF
--- a/scripts/stablex/place_order.js
+++ b/scripts/stablex/place_order.js
@@ -26,12 +26,12 @@ const argv = require("yargs")
 
 module.exports = async (callback) => {
   try {
-    const account = accounts[argv.accountId]
     const minBuy = web3.utils.toWei(String(argv.minBuy))
     const maxSell = web3.utils.toWei(String(argv.maxSell))
 
     const instance = await StablecoinConverter.deployed()
     const accounts = await web3.eth.getAccounts()
+    const account = accounts[argv.accountId]
 
     const batch_index = (await instance.getCurrentStateIndex.call()).toNumber()
     const valid_until = batch_index + parseInt(argv.validFor)


### PR DESCRIPTION
I always got the error that accounts was not found.

No clue, why it seemed to work for you guys.

---

testplan: place an order with the orderscript