### PR TITLE
[StableX] Rounding the buyAmount

### DIFF
--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -254,7 +254,7 @@ contract StablecoinConverter is EpochTokenLocker {
         uint128 buyTokenPrice,
         uint128 sellTokenPrice
     ) internal view returns (uint128) {
-        uint128 buyAmount = uint128(executedSellAmount.mul(sellTokenPrice) / buyTokenPrice);
+        uint128 buyAmount = uint128(ceiledDiv(executedSellAmount.mul(sellTokenPrice), buyTokenPrice));
         // executedBuyAmount = buyAmount * (1 - (1/feeDenominator))
         //                   = buyAmount - buyAmount/feeDenominator (*)
         //                   = (buyAmount * feeDenominator)/ feeDenominator - buyAmount/feeDenominator
@@ -379,5 +379,9 @@ contract StablecoinConverter is EpochTokenLocker {
         element = element.concat(abi.encodePacked(order.priceDenominator));
         element = element.concat(abi.encodePacked(order.remainingAmount));
         return element;
+    }
+
+    function ceiledDiv(uint256 dividend, uint256 divisor) private pure returns (uint256) {
+        return dividend.add(divisor).sub(1).div(divisor);
     }
 }


### PR DESCRIPTION
We are still seeing some rounding issues between the naive solver's solution and the smart contract. My hunch is that this might be due to not rounding the buyAmounts upwards (and thus potentially giving people less than they specified in their order). With this change, the example from the naive solver passes.

However I'm not sure if we now might get instances in which we round up where we should not round up.

Another way around this would be to introduce an epsilon of 1 wei into the equalities for token balances  and limit prices.

Looking forward to your thoughts.