### PR TITLE
[Easy] Removing unnecessary repeats for getting BATCH_TIME in tests

### DIFF
--- a/test/epoch_token_locker.js
+++ b/test/epoch_token_locker.js
@@ -11,7 +11,7 @@ contract("EpochTokenLocker", async (accounts) => {
   const [user_1, user_2] = accounts
 
   let BATCH_TIME
-  beforeEach(async () => {
+  before(async () => {
     const instance = await EpochTokenLocker.new()
     BATCH_TIME = (await instance.BATCH_TIME.call()).toNumber()
   })

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -20,7 +20,7 @@ contract("StablecoinConverter", async (accounts) => {
 
   const [user_1, user_2, user_3, solutionSubmitter] = accounts
   let BATCH_TIME
-  beforeEach(async () => {
+  before(async () => {
     const feeToken = await MockContract.new()
     const lib1 = await IdToAddressBiMap.new()
     const lib2 = await IterableAppendOnlySet.new()


### PR DESCRIPTION
Hopefully, this makes our tests a little bit faster...

--

testplan: unit tests