### PR TITLE
[Easy] helper script for getting Auction Elements

### DIFF
--- a/scripts/stablex/get_auction_elements.js
+++ b/scripts/stablex/get_auction_elements.js
@@ -1,0 +1,17 @@
+const StablecoinConverter = artifacts.require("StablecoinConverter")
+
+const { decodeAuctionElements } = require("../../test/utilities.js")
+
+module.exports = async (callback) => {
+  try {
+    const instance = await StablecoinConverter.deployed()
+    const auctionElementsEncoded = await instance.getEncodedAuctionElements.call()
+    const auctionElementsDecoded = decodeAuctionElements(auctionElementsEncoded)
+
+    console.log(auctionElementsDecoded)
+
+    callback()
+  } catch (error) {
+    callback(error)
+  }
+}

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -7,7 +7,8 @@ const ERC20 = artifacts.require("ERC20")
 const truffleAssert = require("truffle-assertions")
 const {
   waitForNSeconds,
-  sendTxAndGetReturnValue
+  sendTxAndGetReturnValue,
+  decodeAuctionElements
 } = require("./utilities.js")
 
 const feeDenominator = 1000 // fee is (1 / feeDenominator)
@@ -1247,33 +1248,6 @@ contract("StablecoinConverter", async (accounts) => {
 })
 
 
-const ADDRESS_WIDTH = 20 * 2
-const UINT256_WIDTH = 32 * 2
-const UINT16_WIDTH = 2 * 2
-const UINT32_WIDTH = 4 * 2
-const UINT128_WIDTH = 16 * 2
-
-function decodeAuctionElements(bytes) {
-  const result = []
-  bytes = bytes.slice(2) // cutting of 0x
-  while (bytes.length > 0) {
-    const element = bytes.slice(0, 113 * 2).split("")
-    bytes = bytes.slice(113 * 2)
-    result.push({
-      user: "0x" + element.splice(0, ADDRESS_WIDTH).join(""), // address is only 20 bytes
-      sellTokenBalance: parseInt(element.splice(0, UINT256_WIDTH).join(""), 16),
-      buyToken: parseInt(element.splice(0, UINT16_WIDTH).join(""), 16),
-      sellToken: parseInt(element.splice(0, UINT16_WIDTH).join(""), 16),
-      validFrom: parseInt(element.splice(0, UINT32_WIDTH).join(""), 16),
-      validUntil: parseInt(element.splice(0, UINT32_WIDTH).join(""), 16),
-      isSellOrder: parseInt(element.splice(0, 2).join(""), 16) > 0,
-      priceNumerator: parseInt(element.splice(0, UINT128_WIDTH).join(""), 16),
-      priceDenominator: parseInt(element.splice(0, UINT128_WIDTH).join(""), 16),
-      remainingAmount: parseInt(element.splice(0, UINT128_WIDTH).join(""), 16),
-    })
-  }
-  return result
-}
 
 const closeAuction = async (instance) => {
   const time_remaining = (await instance.getSecondsRemainingInBatch()).toNumber()

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -173,6 +173,35 @@ function partitionArray(input, spacing) {
   return output
 }
 
+
+const ADDRESS_WIDTH = 20 * 2
+const UINT256_WIDTH = 32 * 2
+const UINT16_WIDTH = 2 * 2
+const UINT32_WIDTH = 4 * 2
+const UINT128_WIDTH = 16 * 2
+
+function decodeAuctionElements(bytes) {
+  const result = []
+  bytes = bytes.slice(2) // cutting of 0x
+  while (bytes.length > 0) {
+    const element = bytes.slice(0, 113 * 2).split("")
+    bytes = bytes.slice(113 * 2)
+    result.push({
+      user: "0x" + element.splice(0, ADDRESS_WIDTH).join(""), // address is only 20 bytes
+      sellTokenBalance: parseInt(element.splice(0, UINT256_WIDTH).join(""), 16),
+      buyToken: parseInt(element.splice(0, UINT16_WIDTH).join(""), 16),
+      sellToken: parseInt(element.splice(0, UINT16_WIDTH).join(""), 16),
+      validFrom: parseInt(element.splice(0, UINT32_WIDTH).join(""), 16),
+      validUntil: parseInt(element.splice(0, UINT32_WIDTH).join(""), 16),
+      isSellOrder: parseInt(element.splice(0, 2).join(""), 16) > 0,
+      priceNumerator: parseInt(element.splice(0, UINT128_WIDTH).join(""), 16),
+      priceDenominator: parseInt(element.splice(0, UINT128_WIDTH).join(""), 16),
+      remainingAmount: parseInt(element.splice(0, UINT128_WIDTH).join(""), 16),
+    })
+  }
+  return result
+}
+
 module.exports = {
   waitForNSeconds,
   fundAccounts,
@@ -185,5 +214,6 @@ module.exports = {
   generateMerkleTree,
   partitionArray,
   setupMultiCaller,
-  sendTxAndGetReturnValue
+  sendTxAndGetReturnValue,
+  decodeAuctionElements
 }


### PR DESCRIPTION
a very simple script for getting the auction elements.

This allows easy order inspection for the different networks.

testplan:

See the current orders in rinkeby:

```
npx truffle compile
npm run networks-inject
npx truffle exec scripts/stablex/get_auction_elements.js --network rinkeby  
```