### PR TITLE
Objective Function Part II - penalize disregarded utility of touched orders

### DIFF
--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -235,14 +235,13 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     function evaluateUtility(uint128 execBuy, Order memory order) internal view returns(uint128) {
-        // Utility = ((execBuyAmt * order.sellAmt - preFeeSell * order.buyAmt) * price.buyToken) / order.sellAmt
+        // Utility = ((execBuyAmt * order.sellAmt - scaledSellAmount * order.buyAmt) * price.buyToken) / order.sellAmt
         uint256 scaledSellAmount = getExecutedSellAmount(
             execBuy,
             currentPrices[order.buyToken],
             currentPrices[order.sellToken],
             2
         );
-        //execBuy.mul(currentPrices[order.buyToken]).div(currentPrices[order.sellToken]);
         return uint128(
             execBuy.sub(
                 scaledSellAmount.mul(order.priceNumerator).div(order.priceDenominator)

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -257,10 +257,10 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     function evaluateDisregardedUtility(Order memory order, address user) internal view returns(uint128) {
-        // |disregardedUtility| = maxUtility - actualUtility
-        // where maxUtility is the utility achieved when execSellAmount == order.sellAmount.
-        // (((sellAmount - execSell) * currentPrices[order.buyToken]) * buyAmount) / sellAmount;
-        // Balances and orders have all been updated so: sellAmount - execSell == order.remainingAmount.
+        // |disregardedUtility| = (limitTerm * leftoverSellAmount) / order.sellAmount
+        // where limitTerm = price.SellToken * order.sellAmt - order.buyAmt * price.buyToken
+        // and leftoverSellAmount = order.sellAmt - execSellAmt
+        // Balances and orders have all been updated so: sellAmount - execSellAmt == order.remainingAmount.
         // For security reasons, we take the minimum of this with the user's token balance.
         uint256 leftoverSellAmount = Math.min(
             uint256(order.remainingAmount),

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -369,7 +369,6 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     function checkAndOverrideObjectiveValue(int newObjectiveValue) private {
-        emit Debug(getCurrentObjectiveValue(), newObjectiveValue, newObjectiveValue > getCurrentObjectiveValue());
         require(
             newObjectiveValue > getCurrentObjectiveValue(),
             "Solution does not have a higher objective value than a previous solution"

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -268,7 +268,7 @@ contract StablecoinConverter is EpochTokenLocker {
         // TODO - use SafeCast
         uint256 limitTerm = currentPrices[order.sellToken].mul(order.priceDenominator)
             .sub(currentPrices[order.buyToken].mul(order.priceNumerator));
-        return uint128(leftoverSellAmount.mul(limitTerm)) / order.priceDenominator;
+        return uint128(leftoverSellAmount.mul(limitTerm).div(order.priceDenominator));
     }
 
     function grantRewardToSolutionSubmitter(uint feeReward) internal {

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -14,7 +14,7 @@ contract StablecoinConverter is EpochTokenLocker {
     using TokenConservation for int[];
 
     uint constant private MAX_UINT128 = 2**128 - 1;
-    uint constant MAX_TOUCHED_ORDERS = 25;
+    uint constant public MAX_TOUCHED_ORDERS = 25;
 
     event OrderPlacement(
         address owner,

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -283,6 +283,7 @@ contract StablecoinConverter is EpochTokenLocker {
         //                    = ((executedBuyAmount * buyTokenPrice) / (feeDenominator - 1)) * feeDenominator) / sellTokenPrice
         uint256 sellAmount = uint256(executedBuyAmount).mul(buyTokenPrice).div(feeDenominator - 1)
             .mul(feeDenominator).div(sellTokenPrice);
+        // TODO - use SafeCast here.
         require(sellAmount < MAX_UINT128, "sellAmount too large");
         return uint128(sellAmount);
     }

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -222,10 +222,9 @@ contract StablecoinConverter is EpochTokenLocker {
                 evaluateDisregardedUtility(orders[owners[i]][orderIds[i]], owners[i])
             );
         }
-        // Objective function is the sum of utility + the burnt fees collected
-        // This ensures direct trades (when available) yield better solutions than longer rings!
         uint burntFees = uint(tokenConservation[0]) / 2;
         require(utility + burntFees > disregardedUtility, "Solution must be better than trivial");
+        // burntFees ensures direct trades (when available) yield better solutions than longer rings
         checkAndOverrideObjectiveValue(utility - disregardedUtility + burntFees);
         grantRewardToSolutionSubmitter(burntFees);
         tokenConservation.checkTokenConservation();

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -260,7 +260,7 @@ contract StablecoinConverter is EpochTokenLocker {
         // where limitTerm = price.SellToken * order.sellAmt - order.buyAmt * price.buyToken
         // and leftoverSellAmount = order.sellAmt - execSellAmt
         // Balances and orders have all been updated so: sellAmount - execSellAmt == order.remainingAmount.
-        // For security reasons, we take the minimum of this with the user's token balance.
+        // For correctness, we take the minimum of this with the user's token balance.
         uint256 leftoverSellAmount = Math.min(
             uint256(order.remainingAmount),
             getBalance(user, tokenIdToAddressMap(order.sellToken))

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -230,20 +230,20 @@ contract StablecoinConverter is EpochTokenLocker {
         }
     }
 
-    function evaluateUtility(uint128 execBuy, uint128 execSell, Order memory order) internal returns(int) {
+    function evaluateUtility(uint128 execBuy, uint128 execSell, Order memory order) internal view returns(int) {
         // Utility = ((execBuyAmt * order.sellAmt - execSellAmt * order.buyAmt) * price.buyToken) / order.sellAmt
         (uint128 buyAmount, uint128 sellAmount) = getBuyAndSellAmounts(order);
         return (execBuy - ((execSell * buyAmount) / sellAmount)) * currentPrices[order.buyToken];
     }
 
-    function evaluateDisregardedUtility(uint128 execSell, Order memory order) internal returns(int) {
+    function evaluateDisregardedUtility(uint128 execSell, Order memory order) internal view returns(int) {
         // |disregardedUtility| = maxUtility - actualUtility
         // where maxUtility is the utility achieved when execSellAmount == order.sellAmount.
         (uint128 buyAmount, uint128 sellAmount) = getBuyAndSellAmounts(order);
         return (((sellAmount - execSell) * currentPrices[order.buyToken]) * buyAmount) / sellAmount;
     }
 
-    function getBuyAndSellAmounts(Order memory order) internal returns(uint128, uint128) {
+    function getBuyAndSellAmounts(Order memory order) internal pure returns(uint128, uint128) {
         // Recall that, initially
         // priceNumerator: buyAmount
         // priceDenominator: sellAmount

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -189,8 +189,6 @@ contract StablecoinConverter is EpochTokenLocker {
             Order memory order = orders[owners[i]][orderIds[i]];
             require(checkOrderValidity(order, batchIndex), "Order is invalid");
             (uint128 executedBuyAmount, uint128 executedSellAmount) = getTradedAmounts(volumes[i], order);
-            // accumulate utility before updateRemainingOrder
-            utility = utility.add(evaluateUtility(executedBuyAmount, order));
             tokenConservation.updateTokenConservation(
                 order.buyToken,
                 order.sellToken,
@@ -205,6 +203,8 @@ contract StablecoinConverter is EpochTokenLocker {
                 executedSellAmount.mul(order.priceNumerator) <= executedBuyAmount.mul(order.priceDenominator),
                 "limit price not satisfied"
             );
+            // accumulate utility before updateRemainingOrder, but after limitPrice verified!
+            utility = utility.add(evaluateUtility(executedBuyAmount, order));
             updateRemainingOrder(owners[i], orderIds[i], executedSellAmount);
             addBalanceAndPostponeWithdraw(owners[i], tokenIdToAddressMap(order.buyToken), executedBuyAmount);
         }

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -218,7 +218,6 @@ contract StablecoinConverter is EpochTokenLocker {
             disregardedUtility = disregardedUtility.add(
                 evaluateDisregardedUtility(orders[owners[i]][orderIds[i]], owners[i])
             );
-            emit DebugUtil(evaluateDisregardedUtility(orders[owners[i]][orderIds[i]], owners[i]), 0);
         }
         require(utility >= disregardedUtility, "Solution must be better than trivial");
         checkAndOverrideObjectiveValue(utility - disregardedUtility);

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -236,8 +236,12 @@ contract StablecoinConverter is EpochTokenLocker {
 
     function evaluateUtility(uint128 execBuy, Order memory order) internal view returns(uint128) {
         // Utility = ((execBuyAmt * order.sellAmt - preFeeSell * order.buyAmt) * price.buyToken) / order.sellAmt
-        uint128 preFeeSell = uint128(execBuy.mul(currentPrices[order.buyToken]).div(currentPrices[order.sellToken]));
-        return (execBuy - ((preFeeSell * order.priceNumerator) / order.priceDenominator)) * currentPrices[order.buyToken];
+        uint256 preFeeSell = execBuy.mul(currentPrices[order.buyToken]).div(currentPrices[order.sellToken]);
+        return uint128(
+            execBuy.sub(
+                preFeeSell.mul(order.priceNumerator).div(order.priceDenominator)
+            ).mul(currentPrices[order.buyToken])
+        );
     }
 
     function grantRewardToSolutionSubmitter(uint feeReward) internal {

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -277,10 +277,10 @@ contract StablecoinConverter is EpochTokenLocker {
         // where phi = 1/feeDenominator
         // Note that: 1 - phi = (feeDenominator - 1) / feeDenominator
         // And so, 1/(1-phi) = feeDenominator / (feeDenominator - 1)
-        // executedSellAmount = (execBuyAmount * p[buyToken]) / (p[sellToken] * (1 - phi))
-        //                    = (execBuyAmount * buyTokenPrice / sellTokenPrice) * feeDenominator / (feeDenominator - 1)
-        //                    in order to minimize rounding errors, the order is switched
-        //                    = ((executedBuyAmount * buyTokenPrice) / (feeDenominator - 1)) * feeDenominator) / sellTokenPrice
+        // execSellAmount = (execBuyAmount * p[buyToken]) / (p[sellToken] * (1 - phi))
+        //                = (execBuyAmount * buyTokenPrice / sellTokenPrice) * feeDenominator / (feeDenominator - 1)
+        //    in order to minimize rounding errors, the order of operations is switched
+        //                = ((executedBuyAmount * buyTokenPrice) / (feeDenominator - 1)) * feeDenominator) / sellTokenPrice
         uint256 sellAmount = uint256(executedBuyAmount).mul(buyTokenPrice).div(feeDenominator - 1)
             .mul(feeDenominator).div(sellTokenPrice);
         // TODO - use SafeCast here.

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -52,7 +52,6 @@ contract StablecoinConverter is EpochTokenLocker {
     uint public MAX_TOKENS;  // solhint-disable var-name-mixedcase
     uint16 public numTokens = 0;
     uint128 public feeDenominator; // fee is (1 / feeDenominator)
-    // uint128 private utilityAdjustmentFactor = 2;
 
     constructor(uint maxTokens, uint128 _feeDenominator, address feeToken) public {
         MAX_TOKENS = maxTokens;
@@ -218,6 +217,8 @@ contract StablecoinConverter is EpochTokenLocker {
                 executedSellAmount
             );
         }
+        // Objective function is the sum of utility + the burnt fees collected
+        // This ensures direct trades (when available) yield better solutions than longer rings!
         checkAndOverrideObjectiveValue(utility + uint(tokenConservation[0]) / 2);
         grantRewardToSolutionSubmitter(uint(tokenConservation[0]) / 2);
         tokenConservation.checkTokenConservation();

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -14,6 +14,7 @@ contract StablecoinConverter is EpochTokenLocker {
     using TokenConservation for int[];
 
     uint constant private MAX_UINT128 = 2**128 - 1;
+    uint constant MAX_TOUCHED_ORDERS = 25;
 
     event OrderPlacement(
         address owner,
@@ -176,12 +177,10 @@ contract StablecoinConverter is EpochTokenLocker {
         uint16[] memory tokenIdsForPrice  // price[i] is the price for the token with tokenID tokenIdsForPrice[i]
                                           // fee token id not required since always 0
     ) public {
-        require(
-            batchIndex == getCurrentBatchId() - 1,
-            "Solutions are no longer accepted for this batch"
-        );
+        require(batchIndex == getCurrentBatchId() - 1, "Solutions are no longer accepted for this batch");
         require(tokenIdsForPrice[0] == 0, "fee token price has to be specified");
         require(checkPriceOrdering(tokenIdsForPrice), "prices are not ordered by tokenId");
+        require(owners.length <= MAX_TOUCHED_ORDERS, "Solution exceeds MAX_TOUCHED_ORDERS");
         undoPreviousSolution(batchIndex);
         updateCurrentPrices(prices, tokenIdsForPrice);
         delete previousSolution.trades;

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -247,7 +247,7 @@ contract StablecoinConverter is EpochTokenLocker {
         return (execBuy - ((preFeeSell * order.priceNumerator) / order.priceDenominator)) * currentPrices[order.buyToken];
     }
 
-    function evaluateDisregardedUtility(Order memory order, address user) internal returns(uint128) {
+    function evaluateDisregardedUtility(Order memory order, address user) internal view returns(uint128) {
         // |disregardedUtility| = maxUtility - actualUtility
         // where maxUtility is the utility achieved when execSellAmount == order.sellAmount.
         // (((sellAmount - execSell) * currentPrices[order.buyToken]) * buyAmount) / sellAmount;

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -230,7 +230,7 @@ contract StablecoinConverter is EpochTokenLocker {
         }
     }
 
-    function evaluateUtility(uint128 execBuy, uint128 execSell, Order memory order) internal returns(int) {
+    function evaluateUtility(uint128 execBuy, uint128 execSell, Order memory order) internal view returns(int) {
         // Utility = ((execBuyAmt * order.sellAmt - execSellAmt * order.buyAmt) * price.buyToken) / order.sellAmt
         (uint128 buyAmount, uint128 sellAmount) = getBuySellAmounts(order);
         return ((execBuy * sellAmount - execSell * buyAmount) * currentPrices[order.buyToken]) / sellAmount;

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -32,8 +32,8 @@ contract StablecoinConverter is EpochTokenLocker {
     struct Order {
         uint16 buyToken;
         uint16 sellToken;
-        uint32 validFrom;  // order is valid from auction collection period: validFrom inclusively
-        uint32 validUntil;  // order is valid till auction collection period: validUntil inclusively
+        uint32 validFrom;   // order is valid from auction collection period: validFrom inclusive
+        uint32 validUntil;  // order is valid till auction collection period: validUntil inclusive
         bool isSellOrder;
         uint128 priceNumerator;
         uint128 priceDenominator;
@@ -165,10 +165,10 @@ contract StablecoinConverter is EpochTokenLocker {
 
     function submitSolution(
         uint32 batchIndex,
-        address[] memory owners,  //tradeData is submitted as arrays
+        address[] memory owners,          // tradeData is submitted as arrays
         uint16[] memory orderIds,
         uint128[] memory volumes,
-        uint128[] memory prices,  //list of prices for touched token only
+        uint128[] memory prices,          // list of prices for touched tokens only
         uint16[] memory tokenIdsForPrice  // price[i] is the price for the token with tokenID tokenIdsForPrice[i]
                                           // fee token id not required since always 0
     ) public {
@@ -285,7 +285,7 @@ contract StablecoinConverter is EpochTokenLocker {
 
     function documentTrades(
         uint32 batchIndex,
-        address[] memory owners,  //tradeData is submitted as arrays
+        address[] memory owners,  // tradeData is submitted as arrays
         uint16[] memory orderIds,
         uint128[] memory volumes,
         uint16[] memory tokenIdsForPrice
@@ -319,7 +319,7 @@ contract StablecoinConverter is EpochTokenLocker {
                 revertRemainingOrder(owner, orderId, sellAmount);
                 subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyAmount);
             }
-            // substract granted fees:
+            // subtract granted fees:
             subtractBalance(
                 previousSolution.solutionSubmitter,
                 tokenIdToAddressMap(0),
@@ -334,7 +334,7 @@ contract StablecoinConverter is EpochTokenLocker {
         uint16[] memory tokenIdsForPrice,
         uint128 buyAmount,
         uint128 sellAmount
-    ) private {
+    ) private pure {
         tokenConservation[findPriceIndex(order.buyToken, tokenIdsForPrice)] -= int(buyAmount);
         tokenConservation[findPriceIndex(order.sellToken, tokenIdsForPrice)] += int(sellAmount);
     }
@@ -348,7 +348,7 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     function getTradedAmounts(uint128 volume, Order memory order) private view returns (uint128, uint128) {
-        // ToDo: implement logic also for buyOrders
+        // TODO: implement logic also for buyOrders
         uint128 executedBuyAmount = volume;
         require(currentPrices[order.sellToken] != 0, "prices are not allowed to be zero");
         uint128 executedSellAmount = getExecutedSellAmount(

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -14,6 +14,7 @@ contract StablecoinConverter is EpochTokenLocker {
     using TokenConservation for int[];
 
     uint constant private MAX_UINT128 = 2**128 - 1;
+    uint constant MAX_TOUCHED_ORDERS = 25;
 
     event OrderPlacement(
         address owner,
@@ -174,12 +175,10 @@ contract StablecoinConverter is EpochTokenLocker {
         uint16[] memory tokenIdsForPrice  // price[i] is the price for the token with tokenID tokenIdsForPrice[i]
                                           // fee token id not required since always 0
     ) public {
-        require(
-            batchIndex == getCurrentBatchId() - 1,
-            "Solutions are no longer accepted for this batch"
-        );
+        require(batchIndex == getCurrentBatchId() - 1, "Solutions are no longer accepted for this batch");
         require(tokenIdsForPrice[0] == 0, "fee token price has to be specified");
         require(checkPriceOrdering(tokenIdsForPrice), "prices are not ordered by tokenId");
+        require(owners.length <= MAX_TOUCHED_ORDERS, "Solution exceeds MAX_TOUCHED_ORDERS");
         undoPreviousSolution(batchIndex);
         updateCurrentPrices(prices, tokenIdsForPrice);
         delete previousSolution.trades;

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -367,7 +367,7 @@ contract StablecoinConverter is EpochTokenLocker {
         tokenConservation[findPriceIndex(order.buyToken, tokenIdsForPrice)] -= int(buyAmount);
         tokenConservation[findPriceIndex(order.sellToken, tokenIdsForPrice)] += int(sellAmount);
     }
-    event Debug(int currVal, int newVal, bool isGood);
+
     function checkAndOverrideObjectiveValue(int newObjectiveValue) private {
         emit Debug(getCurrentObjectiveValue(), newObjectiveValue, newObjectiveValue > getCurrentObjectiveValue());
         require(

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -257,14 +257,13 @@ contract StablecoinConverter is EpochTokenLocker {
         // (((sellAmount - execSell) * currentPrices[order.buyToken]) * buyAmount) / sellAmount;
         // Balances and orders have all been updated so: sellAmount - execSell == order.remainingAmount.
         // For security reasons, we take the minimum of this with the user's token balance.
-        uint128 leftoverSellAmount = uint128(
-            Math.min(uint(order.remainingAmount), getBalance(user, tokenIdToAddressMap(order.sellToken)))
+        uint256 leftoverSellAmount = Math.min(
+            uint256(order.remainingAmount),
+            getBalance(user, tokenIdToAddressMap(order.sellToken))
         );
         // TODO - use SafeCast
-        uint128 limitTerm = uint128(
-            currentPrices[order.sellToken].mul(order.priceDenominator)
-            .sub(currentPrices[order.buyToken].mul(order.priceNumerator))
-        );
+        uint256 limitTerm = currentPrices[order.sellToken].mul(order.priceDenominator)
+            .sub(currentPrices[order.buyToken].mul(order.priceNumerator));
         return uint128(leftoverSellAmount.mul(limitTerm)) / order.priceDenominator;
     }
 

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -14,7 +14,6 @@ contract StablecoinConverter is EpochTokenLocker {
     using TokenConservation for int[];
 
     uint constant private MAX_UINT128 = 2**128 - 1;
-    int constant private MIN_INT = int256(uint256(1) << 255);
 
     event OrderPlacement(
         address owner,

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -163,8 +163,7 @@ contract StablecoinConverter is EpochTokenLocker {
         uint128 volume;
         uint16 orderId;
     }
-    event DebugUtility(int u, int du);
-    event DebugExecutedAmts(uint128 exBuy, uint128 exSell);
+
     function submitSolution(
         uint32 batchIndex,
         address[] memory owners,  // tradeData is submitted as arrays
@@ -191,10 +190,8 @@ contract StablecoinConverter is EpochTokenLocker {
             require(checkOrderValidity(order, batchIndex), "Order is invalid");
             (uint128 executedBuyAmount, uint128 executedSellAmount) = getTradedAmounts(volumes[i], order);
             // accumulate objective values before updateRemainingOrder
-            emit DebugExecutedAmts(executedBuyAmount, executedSellAmount);
             utility += evaluateUtility(executedBuyAmount, executedSellAmount, order);
             disregardedUtility += evaluateDisregardedUtility(executedSellAmount, order);
-            emit DebugUtility(utility, disregardedUtility);
             updateTokenConservation(tokenConservation, order, tokenIdsForPrice, executedBuyAmount, executedSellAmount);
             require(order.remainingAmount >= executedSellAmount, "executedSellAmount bigger than specified in order");
             // Ensure executed price is not lower than the order price:
@@ -232,11 +229,10 @@ contract StablecoinConverter is EpochTokenLocker {
             return MIN_INT;
         }
     }
-    event DebugBuySellAmounts(uint128 buy, uint128 sell);
+
     function evaluateUtility(uint128 execBuy, uint128 execSell, Order memory order) internal returns(int) {
         // Utility = ((execBuyAmt * order.sellAmt - execSellAmt * order.buyAmt) * price.buyToken) / order.sellAmt
         (uint128 buyAmount, uint128 sellAmount) = getBuySellAmounts(order);
-        emit DebugBuySellAmounts(buyAmount, sellAmount);
         return ((execBuy * sellAmount - execSell * buyAmount) * currentPrices[order.buyToken]) / sellAmount;
     }
 
@@ -374,13 +370,12 @@ contract StablecoinConverter is EpochTokenLocker {
         tokenConservation[findPriceIndex(order.buyToken, tokenIdsForPrice)] -= int(buyAmount);
         tokenConservation[findPriceIndex(order.sellToken, tokenIdsForPrice)] += int(sellAmount);
     }
-    event DebugObjective(int x, int y);
+
     function checkAndOverrideObjectiveValue(int newObjectiveValue) private {
         require(
             newObjectiveValue > getCurrentObjectiveValue(),
             "Solution does not have a higher objective value than a previous solution"
         );
-        emit DebugObjective(getCurrentObjectiveValue(), newObjectiveValue);
         previousSolution.objectiveValue = newObjectiveValue;
     }
 

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -161,7 +161,7 @@ contract("StablecoinConverter", async (accounts) => {
     })
   })
   describe("submitSolution()", () => {
-    it("places two orders and matches them in a solution with traders' Utility == 0", async () => {
+    it("rejects trivial solution (the only solution with zero utility", async () => {
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
       const erc20_2 = await MockContract.new()
@@ -183,17 +183,16 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = basicTrade.solution.volume
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - getSellVolume(volume[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), volume[0], "Bought tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), volume[1], "Bought tokens were not adjusted correctly")
+      await truffleAssert.reverts(
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, [0, 0], prices, tokenIdsForPrice, { from: solutionSubmitter }),
+        "Solution does not have a higher objective value than a previous solution"
+      )
+      const currentObjectiveValue = (await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber()
+      assert.equal(0, currentObjectiveValue)
     })
     it("places two orders and matches them in a solution with Utility > 0", async () => {
-
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
       const erc20_2 = await MockContract.new()
@@ -224,6 +223,9 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), volume[0], "Bought tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), volume[1], "Bought tokens were not adjusted correctly")
+
+      const currentObjectiveValue = (await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber()
+      assert(currentObjectiveValue > 0)
     })
 
     it("places two orders, matches them partially and then checks correct order adjustments", async () => {
@@ -289,8 +291,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [4000, feeSubtracted(4000) * 2]
-
+      const volume = [7000, feeSubtracted(7000) * 2]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
@@ -331,14 +332,12 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [5000, feeSubtracted(5000) * 2]
+      const volume = [7000, feeSubtracted(7000) * 2]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
-
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
-      const volume2 = [6000, feeSubtracted(6000) * 2]
-
+      const volume2 = [8000, feeSubtracted(8000) * 2]
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
       const volume3 = basicTrade.solution.volume
@@ -393,7 +392,7 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), 0, "Bought and sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_3, erc20_2.address)).toNumber(), feeAdded(10000) - getSellVolume(volume[3], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
 
-      //Now reverting should not throw due to temporarily negative balances, only later due to objective value criteria
+      // Now reverting should not throw due to temporarily negative balances, only later due to objective value criteria
       await truffleAssert.reverts(
         stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter }),
         "Solution does not have a higher objective value than a previous solution"
@@ -421,7 +420,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [5000, feeSubtracted(5000) * 2]
+      const volume = [7000, feeSubtracted(7000) * 2]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
@@ -433,12 +432,13 @@ contract("StablecoinConverter", async (accounts) => {
 
       await waitForNSeconds(BATCH_TIME)
 
-      await stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
+      const volume2 = [2000, feeSubtracted(2000) * 2]
+      await stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - 2 * getSellVolume(volume[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), 2 * volume[0], "Bought tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - 2 * getSellVolume(volume[1], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), 2 * volume[1], "Bought tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - getSellVolume(volume[0], prices[0], prices[1]) - getSellVolume(volume2[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), volume[0] + volume2[0], "Bought tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1], prices[1], prices[0]) - getSellVolume(volume2[1], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), volume[1] + volume2[1], "Bought tokens were not adjusted correctly")
     })
     it("settles a ring trade between 3 tokens", async () => {
       const feeToken = await MockContract.new()
@@ -817,40 +817,40 @@ contract("StablecoinConverter", async (accounts) => {
       await erc20_3.givenAnyReturnBool(true)
 
 
-      await stablecoinConverter.deposit(feeToken.address, 60000, { from: user_1 })
-      await stablecoinConverter.deposit(erc20_2.address, 60000, { from: user_2 })
-      await stablecoinConverter.deposit(erc20_3.address, 10000, { from: user_3 })
+      await stablecoinConverter.deposit(feeToken.address, feeAdded(110000), { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, feeAdded(100000), { from: user_2 })
+      await stablecoinConverter.deposit(erc20_3.address, feeAdded(10000), { from: user_3 })
 
       await stablecoinConverter.addToken(erc20_2.address)
       await stablecoinConverter.addToken(erc20_3.address)
 
       const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 10000, 60000, { from: user_1 })
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, true, batchIndex + 1, 10000, 60000, { from: user_2 })
-      const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, true, batchIndex + 1, 10000, 60000, { from: user_3 })
-      const orderId4 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 10000, 60000, { from: user_2 })
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 10000, feeAdded(10000), { from: user_1 })
+      const orderId5 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 100000, feeAdded(100000), { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, true, batchIndex + 1, 10000, feeAdded(10000), { from: user_2 })
+      const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, true, batchIndex + 1, 10000, feeAdded(10000), { from: user_3 })
+      const orderId4 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 100000, feeAdded(100000), { from: user_2 })
 
 
       await closeAuction(stablecoinConverter)
 
-      const prices = [10000000, 10000000, 10000000]
+      const prices = [1, 1, 1]
       const owner = [user_1, user_2, user_3]
       const orderId = [orderId1, orderId2, orderId3]
-      const volume = [10000, 9990, 9981]
+      const volume = [10000, 10000, 10000]
       const tokenIdsForPrice = [0, 1, 2]
-
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice)
-      assert.equal((await stablecoinConverter.currentPrices.call(2)).toNumber(), 10000000, "CurrentPrice were not adjusted correctly")
 
-      const prices2 = [10, 10]
+      assert.equal(1, (await stablecoinConverter.currentPrices.call(2)).toNumber(), "CurrentPrice were not adjusted correctly")
+      const prices2 = [1, 1]
       const owner2 = [user_1, user_2]
-      const orderIds2 = [orderId1, orderId4]
-      const volume2 = [50000, feeSubtracted(50000)]
+      const orderIds2 = [orderId5, orderId4]
+      const volume2 = [100000, 100000]
       const tokenIdsForPrice2 = [0, 1]
 
       await stablecoinConverter.submitSolution(batchIndex, owner2, orderIds2, volume2, prices2, tokenIdsForPrice2)
-      assert.equal((await stablecoinConverter.currentPrices.call(2)).toNumber(), 0, "CurrentPrice were not adjusted correctly")
+      assert.equal(0, (await stablecoinConverter.currentPrices.call(2)).toNumber(), "CurrentPrice were not adjusted correctly")
     })
     it("reverts, if price of buyToken == 0", async () => {
       const feeToken = await MockContract.new()
@@ -932,13 +932,13 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [5000, feeSubtracted(5000) * 2]
+      const volume = [7000, feeSubtracted(7000) * 2]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
       assert.equal((await stablecoinConverter.getBalance.call(solutionSubmitter, feeToken.address)).toNumber(), (getSellVolume(volume[0], prices[0], prices[1]) - volume[1]) / 2, "fee was not granted correctly")
 
-      const volume2 = [6000, feeSubtracted(6000) * 2]
+      const volume2 = [8000, feeSubtracted(8000) * 2]
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume2, prices, tokenIdsForPrice)
       assert.equal((await stablecoinConverter.getBalance.call(solutionSubmitter, feeToken.address)).toNumber(), 0, "fee was not reverted")
@@ -1004,7 +1004,6 @@ contract("StablecoinConverter", async (accounts) => {
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
-
       await truffleAssert.reverts(
         stablecoinConverter.withdraw(feeToken.address, { from: solutionSubmitter }),
         "withdraw was not registered previously"
@@ -1028,21 +1027,40 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
       await closeAuction(stablecoinConverter)
-
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [4000, feeSubtracted(4000) * 2]
+      const buyVolume = [7000, feeSubtracted(7000) * 2]
+      const sellVolume = [
+        getExecutedSellAmount(buyVolume[0], prices[1], prices[0]),
+        getExecutedSellAmount(buyVolume[1], prices[0], prices[1]),
+      ]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
+      const tradeUtilities = [
+        evaluateTradeUtility(basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, buyVolume[0], sellVolume[0], prices[1], prices[0]),
+        evaluateTradeUtility(basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, buyVolume[1], sellVolume[1], prices[0], prices[1])
+      ]
+      const totalUtility = tradeUtilities.reduce((a, b) => a + b, 0)
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, buyVolume, prices, tokenIdsForPrice, { from: solutionSubmitter })
+      const actualObjectiveValue = (await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber()
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
+      assert.equal(actualObjectiveValue, totalUtility, "Objective value is not stored correct")
 
-      assert.equal((await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber(), (getSellVolume(volume[0], prices[0], prices[1]) - volume[1]), "Objective value is not stored correct")
+      const buyVolume2 = basicTrade.solution.volume
+      const sellVolume2 = [
+        getExecutedSellAmount(buyVolume2[0], prices[1], prices[0]),
+        getExecutedSellAmount(buyVolume2[1], prices[0], prices[1]),
+      ]
+      const tradeUtilities2 = [
+        evaluateTradeUtility(basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, buyVolume2[0], sellVolume2[0], prices[1], prices[0]),
+        evaluateTradeUtility(basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, buyVolume2[1], sellVolume2[1], prices[0], prices[1])
+      ]
+      const totalUtility2 = tradeUtilities2.reduce((a, b) => a + b, 0)
 
-      const volume2 = basicTrade.solution.volume
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, buyVolume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
+      const actualObjectiveValue2 = (await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber()
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
-      assert.equal((await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber(), (getSellVolume(volume2[0], prices[0], prices[1]) - volume2[1]), "Objective value is not stored correct after a second solution submission")
+      assert.equal(actualObjectiveValue2, totalUtility2, "Objective value incorrect after second solution submission")
     })
     it("checks that the objective value is returned correctly after getting into a new batch", async () => {
       const feeToken = await MockContract.new()
@@ -1066,14 +1084,14 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [4000, feeSubtracted(4000) * 2]
+      const volume = [7000, feeSubtracted(7000) * 2]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
       await closeAuction(stablecoinConverter)
-
-      assert.equal((await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber(), 0, "Objective value is not returned correct")
+      const actualObjectiveValue = (await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber()
+      assert.equal(actualObjectiveValue, 0, "Objective value is not returned correct")
     })
     it("reverts, if downcast from u256 to u128 would change the value", async () => {
       const feeToken = await MockContract.new()
@@ -1215,7 +1233,15 @@ contract("StablecoinConverter", async (accounts) => {
   })
 })
 
+function getExecutedSellAmount(executedBuyAmount, buyTokenPrice, sellTokenPrice) {
+  return Math.floor(Math.floor((executedBuyAmount * buyTokenPrice) / (feeDenominator - 1)) * feeDenominator / sellTokenPrice)
+}
 
+function evaluateTradeUtility(buyAmount, sellAmount, executedBuyAmount, executedSellAmount, priceBuyToken, priceSellToken) {
+  // Utility = ((execBuyAmt * order.sellAmt - preFeeSell * order.buyAmt) * price.buyToken) / order.sellAmt
+  const preFeeSell = (executedBuyAmount * priceBuyToken) / priceSellToken
+  return (executedBuyAmount - Math.floor((preFeeSell * buyAmount) / sellAmount)) * priceBuyToken
+}
 
 const closeAuction = async (instance) => {
   const time_remaining = (await instance.getSecondsRemainingInBatch()).toNumber()

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1133,7 +1133,7 @@ contract("StablecoinConverter", async (accounts) => {
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
       await closeAuction(stablecoinConverter)

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1046,8 +1046,8 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId = [orderId1, orderId2]
       const buyVolume = [7000, feeSubtracted(7000) * 2]
       const sellVolume = [
-        getExecutedSellAmount(buyVolume[0], prices[1], prices[0]),
-        getExecutedSellAmount(buyVolume[1], prices[0], prices[1]),
+        getExecutedSellAmount(buyVolume[0], prices[1], prices[0], 1),
+        getExecutedSellAmount(buyVolume[1], prices[0], prices[1], 1),
       ]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
       const tradeUtilities = [
@@ -1062,8 +1062,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const buyVolume2 = basicTrade.solution.volume
       const sellVolume2 = [
-        getExecutedSellAmount(buyVolume2[0], prices[1], prices[0]),
-        getExecutedSellAmount(buyVolume2[1], prices[0], prices[1]),
+        getExecutedSellAmount(buyVolume2[0], prices[1], prices[0], 1),
+        getExecutedSellAmount(buyVolume2[1], prices[0], prices[1], 1),
       ]
       const tradeUtilities2 = [
         evaluateTradeUtility(basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, buyVolume2[0], sellVolume2[0], prices[1], prices[0]),
@@ -1253,9 +1253,8 @@ function getExecutedSellAmount(executedBuyAmount, buyTokenPrice, sellTokenPrice,
 }
 
 function evaluateTradeUtility(buyAmount, sellAmount, executedBuyAmount, executedSellAmount, priceBuyToken, priceSellToken) {
-  // Utility = ((execBuyAmt * order.sellAmt - preFeeSell * order.buyAmt) * price.buyToken) / order.sellAmt
-  const preFeeSell = (executedBuyAmount * priceBuyToken) / priceSellToken
-  return (executedBuyAmount - Math.floor((preFeeSell * buyAmount) / sellAmount)) * priceBuyToken
+  const scaledSellAmount = getExecutedSellAmount(executedBuyAmount, priceBuyToken, priceSellToken, 2)
+  return (executedBuyAmount - Math.floor((scaledSellAmount * buyAmount) / sellAmount)) * priceBuyToken
 }
 
 const closeAuction = async (instance) => {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -247,7 +247,7 @@ contract("StablecoinConverter", async (accounts) => {
 
       await closeAuction(stablecoinConverter)
 
-      const prices = [10, 10]
+      const prices = [1, 1]
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
       const volume = [10000, feeSubtracted(10000)]

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -51,7 +51,7 @@ contract("StablecoinConverter", async (accounts) => {
       { sellToken: 0, buyToken: 1, sellAmount: feeAdded(20000), buyAmount: 10000, user: user_1 },
       { sellToken: 1, buyToken: 0, sellAmount: feeAdded(10000), buyAmount: feeSubtracted(10000) * 2, user: user_2 }
     ],
-    solution: { prices: [1, 2], owners: [user_1, user_2], volume: [10000, feeSubtracted(10000) * 2], tokenIdsForPrice: [0, 1] }
+    solution: { prices: [1, 2], owners: [user_1, user_2], volume: [10000, 20000], tokenIdsForPrice: [0, 1] }
   }
 
   describe("placeOrder()", () => {
@@ -228,7 +228,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = [10, 10]
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [10000, feeSubtracted(10000)]
+      const volume = [10000, 10000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
@@ -264,7 +264,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [10000, feeSubtracted(10000) * 2]
+      const volume = [10000, 20000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
@@ -305,7 +305,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [7000, feeSubtracted(7000) * 2]
+      const volume = [7000, 14000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
@@ -346,12 +346,12 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [7000, feeSubtracted(7000) * 2]
+      const volume = [7000, 14000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
-      const volume2 = [8000, feeSubtracted(8000) * 2]
+      const volume2 = [8000, 16000]
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
       const volume3 = basicTrade.solution.volume
@@ -434,7 +434,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [7000, feeSubtracted(7000) * 2]
+      const volume = [7000, 14000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
@@ -446,7 +446,7 @@ contract("StablecoinConverter", async (accounts) => {
 
       await waitForNSeconds(BATCH_TIME)
 
-      const volume2 = [2000, feeSubtracted(2000) * 2]
+      const volume2 = [2000, 4000]
       await stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
       assert.equal(
@@ -680,7 +680,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [basicTrade.solution.volume[0], basicTrade.solution.volume[1] - 1]
+      const volume = [basicTrade.solution.volume[0], basicTrade.solution.volume[1] - 21]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
 
@@ -856,11 +856,11 @@ contract("StablecoinConverter", async (accounts) => {
 
       const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 10000, feeAdded(10000), { from: user_1 })
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, true, batchIndex + 1, 10000, feeAdded(10000), { from: user_2 })
-      const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, true, batchIndex + 1, 10000, feeAdded(10000), { from: user_3 })
-      const orderId4 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 100000, feeAdded(100000), { from: user_2 })
-      const orderId5 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 100000, feeAdded(100000), { from: user_1 })
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, batchIndex + 1, 10000, feeAdded(10000), { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, batchIndex + 1, 10000, feeAdded(10000), { from: user_2 })
+      const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, batchIndex + 1, 10000, feeAdded(10000), { from: user_3 })
+      const orderId4 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, batchIndex + 1, 100000, feeAdded(100000), { from: user_2 })
+      const orderId5 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, batchIndex + 1, 100000, feeAdded(100000), { from: user_1 })
 
       await closeAuction(stablecoinConverter)
 
@@ -961,13 +961,13 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [7000, feeSubtracted(7000) * 2]
+      const volume = [7000, 14000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
       assert.equal((await stablecoinConverter.getBalance.call(solutionSubmitter, feeToken.address)).toNumber(), (getSellVolume(volume[0], prices[0], prices[1]) - volume[1]) / 2, "fee was not granted correctly")
 
-      const volume2 = [8000, feeSubtracted(8000) * 2]
+      const volume2 = [8000, 16000]
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume2, prices, tokenIdsForPrice)
       assert.equal((await stablecoinConverter.getBalance.call(solutionSubmitter, feeToken.address)).toNumber(), 0, "fee was not reverted")
@@ -1062,7 +1062,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const buyVolume = [7000, feeSubtracted(7000) * 2]
+      const buyVolume = [7000, 14000]
       const sellVolume = [
         getExecutedSellAmount(buyVolume[0], prices[1], prices[0], 1),
         getExecutedSellAmount(buyVolume[1], prices[0], prices[1], 1),
@@ -1116,7 +1116,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [7000, feeSubtracted(7000) * 2]
+      const volume = [7000, 14000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -201,7 +201,7 @@ contract("StablecoinConverter", async (accounts) => {
 
       await truffleAssert.reverts(
         stablecoinConverter.submitSolution(batchIndex, owner, orderId, [0, 0], prices, tokenIdsForPrice, { from: solutionSubmitter }),
-        "Solution does not have a higher objective value than a previous solution"
+        "Solution must be better than trivial"
       )
       const currentObjectiveValue = (await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber()
       assert.equal(0, currentObjectiveValue)

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -161,7 +161,7 @@ contract("StablecoinConverter", async (accounts) => {
     })
   })
   describe("submitSolution()", () => {
-    it("rejects trivial solution (the only solution with zero utility", async () => {
+    it("rejects trivial solution (the only solution with zero utility)", async () => {
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
       const erc20_2 = await MockContract.new()

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -435,10 +435,26 @@ contract("StablecoinConverter", async (accounts) => {
       const volume2 = [2000, feeSubtracted(2000) * 2]
       await stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - getSellVolume(volume[0] - volume2[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), volume[0] + volume2[0], "Bought tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1] - volume2[0], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), volume[1] + volume2[1], "Bought tokens were not adjusted correctly")
+      assert.equal(
+        basicTrade.deposits[0].amount - getSellVolume(volume[0] + volume2[0], prices[0], prices[1]),
+        (await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(),
+        "Sold tokens were not adjusted correctly"
+      )
+      assert.equal(
+        volume[0] + volume2[0],
+        (await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(),
+        "Bought tokens were not adjusted correctly"
+      )
+      assert.equal(
+        basicTrade.deposits[1].amount - getSellVolume(volume[1] + volume2[1], prices[1], prices[0]),
+        (await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(),
+        "Sold tokens were not adjusted correctly"
+      )
+      assert.equal(
+        volume[1] + volume2[1],
+        (await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(),
+        "Bought tokens were not adjusted correctly"
+      )
     })
     it("settles a ring trade between 3 tokens", async () => {
       const feeToken = await MockContract.new()

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -435,9 +435,9 @@ contract("StablecoinConverter", async (accounts) => {
       const volume2 = [2000, feeSubtracted(2000) * 2]
       await stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - getSellVolume(volume[0], prices[0], prices[1]) - getSellVolume(volume2[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - getSellVolume(volume[0] - volume2[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), volume[0] + volume2[0], "Bought tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1], prices[1], prices[0]) - getSellVolume(volume2[1], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1] - volume2[0], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), volume[1] + volume2[1], "Bought tokens were not adjusted correctly")
     })
     it("settles a ring trade between 3 tokens", async () => {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1119,7 +1119,40 @@ contract("StablecoinConverter", async (accounts) => {
         "sellAmount too large"
       )
     })
+    it("reverts if max touched orders is exceeded", async () => {
+      const feeToken = await MockContract.new()
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
+      const erc20_2 = await MockContract.new()
 
+      await feeToken.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(feeToken.address, basicTrade.deposits[0].amount, { from: basicTrade.deposits[0].user })
+      await stablecoinConverter.deposit(erc20_2.address, basicTrade.deposits[1].amount, { from: basicTrade.deposits[1].user })
+
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
+
+      await closeAuction(stablecoinConverter)
+
+      const prices = basicTrade.solution.prices
+      const seedOwners = basicTrade.solution.owners
+      const seedVolumes = basicTrade.solution.volume
+      const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
+
+      const halfNumTouched = 20
+      const owner = Array(halfNumTouched).fill(seedOwners[0]).concat(Array(halfNumTouched).fill(seedOwners[1]))
+      const orderId = Array(halfNumTouched).fill(orderId1).concat(Array(halfNumTouched).fill(orderId2))
+      const volume = Array(halfNumTouched).fill(seedVolumes[0] / halfNumTouched).concat(Array(halfNumTouched).fill(seedVolumes[1] / halfNumTouched))
+
+      await truffleAssert.reverts(
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice),
+        "Solution exceeds MAX_TOUCHED_ORDERS"
+      )
+    })
   })
   describe("getEncodedAuctionElements()", async () => {
     it("returns all orders that are have ever been submitted", async () => {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -53,7 +53,7 @@ contract("StablecoinConverter", async (accounts) => {
     solution: { prices: [1, 2], owners: [user_1, user_2], volume: [10000, feeSubtracted(10000) * 2], tokenIdsForPrice: [0, 1] }
   }
 
-  describe("placeOrder", () => {
+  describe("placeOrder()", () => {
     it("places Orders and checks parameters", async () => {
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
@@ -71,7 +71,7 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((orderResult.validUntil).toNumber(), 3, "validUntil was stored incorrectly")
     })
   })
-  describe("cancelOrder", () => {
+  describe("cancelOrder()", () => {
     it("places orders, then cancels it and orders status", async () => {
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
@@ -88,7 +88,7 @@ contract("StablecoinConverter", async (accounts) => {
 
     })
   })
-  describe("freeStorageOfOrder", () => {
+  describe("freeStorageOfOrder()", () => {
     it("places a order, then cancels and deletes it", async () => {
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
@@ -117,7 +117,7 @@ contract("StablecoinConverter", async (accounts) => {
       await truffleAssert.reverts(stablecoinConverter.freeStorageOfOrder(id), "Order is still valid")
     })
   })
-  describe("addToken", () => {
+  describe("addToken()", () => {
     it("feeToken is set by default", async () => {
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
@@ -159,7 +159,7 @@ contract("StablecoinConverter", async (accounts) => {
       await truffleAssert.reverts(stablecoinConverter.addToken((await ERC20.new()).address), "Max tokens reached")
     })
   })
-  describe("submitSolution", () => {
+  describe("submitSolution()", () => {
     it("places two orders and matches them in a solution with traders' Utility == 0", async () => {
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
@@ -191,7 +191,7 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), volume[1], "Bought tokens were not adjusted correctly")
     })
-    it("places two orders and matches them in a solution with traders' Utility >0", async () => {
+    it("places two orders and matches them in a solution with Utility > 0", async () => {
 
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
@@ -289,6 +289,7 @@ contract("StablecoinConverter", async (accounts) => {
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
       const volume = [4000, feeSubtracted(4000) * 2]
+
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
@@ -1138,7 +1139,7 @@ contract("StablecoinConverter", async (accounts) => {
     })
 
   })
-  describe("getEncodedAuctionElements", async () => {
+  describe("getEncodedAuctionElements()", async () => {
     it("returns all orders that are have ever been submitted", async () => {
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -291,6 +291,7 @@ contract("StablecoinConverter", async (accounts) => {
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
       const volume = [7000, feeSubtracted(7000) * 2]
+
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
@@ -1147,7 +1148,40 @@ contract("StablecoinConverter", async (accounts) => {
         "sellAmount too large"
       )
     })
+    it("reverts if max touched orders is exceeded", async () => {
+      const feeToken = await MockContract.new()
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
+      const erc20_2 = await MockContract.new()
 
+      await feeToken.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(feeToken.address, basicTrade.deposits[0].amount, { from: basicTrade.deposits[0].user })
+      await stablecoinConverter.deposit(erc20_2.address, basicTrade.deposits[1].amount, { from: basicTrade.deposits[1].user })
+
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
+
+      await closeAuction(stablecoinConverter)
+
+      const prices = basicTrade.solution.prices
+      const seedOwners = basicTrade.solution.owners
+      const seedVolumes = basicTrade.solution.volume
+      const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
+
+      const halfNumTouched = 20
+      const owner = Array(halfNumTouched).fill(seedOwners[0]).concat(Array(halfNumTouched).fill(seedOwners[1]))
+      const orderId = Array(halfNumTouched).fill(orderId1).concat(Array(halfNumTouched).fill(orderId2))
+      const volume = Array(halfNumTouched).fill(seedVolumes[0] / halfNumTouched).concat(Array(halfNumTouched).fill(seedVolumes[1] / halfNumTouched))
+
+      await truffleAssert.reverts(
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice),
+        "Solution exceeds MAX_TOUCHED_ORDERS"
+      )
+    })
   })
   describe("getEncodedAuctionElements()", async () => {
     it("returns all orders that are have ever been submitted", async () => {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1134,7 +1134,7 @@ contract("StablecoinConverter", async (accounts) => {
       const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
       await closeAuction(stablecoinConverter)
 

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1233,8 +1233,9 @@ contract("StablecoinConverter", async (accounts) => {
   })
 })
 
-function getExecutedSellAmount(executedBuyAmount, buyTokenPrice, sellTokenPrice) {
-  return Math.floor(Math.floor((executedBuyAmount * buyTokenPrice) / (feeDenominator - 1)) * feeDenominator / sellTokenPrice)
+function getExecutedSellAmount(executedBuyAmount, buyTokenPrice, sellTokenPrice, scale) {
+  const scaledFee = scale * feeDenominator
+  return Math.floor(Math.floor((executedBuyAmount * buyTokenPrice) / (scaledFee - 1)) * scaledFee / sellTokenPrice)
 }
 
 function evaluateTradeUtility(buyAmount, sellAmount, executedBuyAmount, executedSellAmount, priceBuyToken, priceSellToken) {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -54,42 +54,6 @@ contract("StablecoinConverter", async (accounts) => {
     solution: { prices: [1, 2], owners: [user_1, user_2], volume: [10000, feeSubtracted(10000) * 2], tokenIdsForPrice: [0, 1] }
   }
 
-  // const advancedTrade = {
-  //   deposits: [
-  //     { amount: 20000, token: 0, user: user_1 },
-  //     { amount: 20000, token: 1, user: user_2 },
-  //   ],
-  //   orders: [
-  //     { sellToken: 0, buyToken: 1, sellAmount: 20000, buyAmount: 10000, user: user_1 },
-  //     { sellToken: 1, buyToken: 0, sellAmount: 20000, buyAmount: 10000, user: user_2 },
-  //   ],
-  //   solution: {
-  //     prices: [1, 1],
-  //     owners: [user_1, user_2, user_3],
-  //     executedBuyAmounts: [10000, 10000],
-  //     tokenIdsForPrice: [0, 1]
-  //   }
-  // }
-
-  // const ringTrade = {
-  //   deposits: [
-  //     { amount: feeAdded(10000), token: 0, user: user_1 },
-  //     { amount: feeAdded(10000), token: 1, user: user_2 },
-  //     { amount: feeAdded(10000), token: 2, user: user_3 }
-  //   ],
-  //   orders: [
-  //     { sellToken: 0, buyToken: 1, sellAmount: 20000, buyAmount: 10000, user: user_1 },
-  //     { sellToken: 1, buyToken: 2, sellAmount: 20000, buyAmount: 10000, user: user_2 },
-  //     { sellToken: 2, buyToken: 0, sellAmount: 20000, buyAmount: 10000, user: user_3 },
-  //   ],
-  //   solution: {
-  //     prices: [1, 2, 3],
-  //     owners: [user_1, user_2, user_3],
-  //     executedBuyAmounts: [10000,],
-  //     tokenIdsForPrice: [0, 1, 2]
-  //   }
-  // }
-
   describe("placeOrder()", () => {
     it("places Orders and checks parameters", async () => {
       const feeToken = await MockContract.new()
@@ -468,10 +432,26 @@ contract("StablecoinConverter", async (accounts) => {
       const volume2 = [2000, feeSubtracted(2000) * 2]
       await stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - getSellVolume(volume[0] - volume2[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), volume[0] + volume2[0], "Bought tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1] - volume2[0], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), volume[1] + volume2[1], "Bought tokens were not adjusted correctly")
+      assert.equal(
+        basicTrade.deposits[0].amount - getSellVolume(volume[0] + volume2[0], prices[0], prices[1]),
+        (await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(),
+        "Sold tokens were not adjusted correctly"
+      )
+      assert.equal(
+        volume[0] + volume2[0],
+        (await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(),
+        "Bought tokens were not adjusted correctly"
+      )
+      assert.equal(
+        basicTrade.deposits[1].amount - getSellVolume(volume[1] + volume2[1], prices[1], prices[0]),
+        (await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(),
+        "Sold tokens were not adjusted correctly"
+      )
+      assert.equal(
+        volume[1] + volume2[1],
+        (await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(),
+        "Bought tokens were not adjusted correctly"
+      )
     })
     it("settles a ring trade between 3 tokens", async () => {
       const feeToken = await MockContract.new()

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -197,7 +197,7 @@ contract("StablecoinConverter", async (accounts) => {
     })
   })
   describe("submitSolution()", () => {
-    it("rejects trivial solution (the only solution with zero utility", async () => {
+    it("rejects trivial solution (the only solution with zero utility)", async () => {
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
       const erc20_2 = await MockContract.new()
@@ -223,7 +223,7 @@ contract("StablecoinConverter", async (accounts) => {
 
       await truffleAssert.reverts(
         stablecoinConverter.submitSolution(batchIndex, owner, orderId, [0, 0], prices, tokenIdsForPrice, { from: solutionSubmitter }),
-        "Solution does not have a higher objective value than a previous solution"
+        "Solution must be better than trivial"
       )
       const currentObjectiveValue = (await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber()
       assert.equal(0, currentObjectiveValue)


### PR DESCRIPTION
This PR is intended to provide an objective function to auction settlement which rewards total traders utility while penalizing solutions whose touched orders have disregarded utility.

In brief, the objective function is `U - dU` where `U`, the total utility, is the sum over all touched orders of their individual trade utilities `u_i`; 
```
 u_i = ((execBuyAmount * sellAmount - execSellAmount * buyAmount) * priceBuyToken) // sellAmount
```
and `dU`, the total disregarded utility, is the sum over all touched orders of their individual disregarded utilities `dU_i`; 
```
dU_i = (((sellAmount - execSellAmount) * priceBuyToken) * buyAmount) // sellAmount
```

The gas reporter gives the following estimates (for a basic trade of two orders).

```
Two Orders:
|···························································································│
|  Optimizer enabled: true  ·         Runs: 200  ·        Block limit: 6721975 gas          │
|···························································································│
|  Methods            ·               20 gwei/gas               ·       183.32 usd/eth      │
|·····················|·················|·········|········|·········|·········|············│
|                     ·  Method         ·  Min    ·  Max   ·  Avg    · # calls ·  usd (avg) │
|  With New Objective ·  submitSolution ·  410182 · 865437 ·  610996 ·  35     · 2.24       │
|  Without Objective  ·  submitSolution ·  406816 · 858665 ·  615099 ·  35     · 2.26       │
|···························································································│
```


TODO - run this same gas estimate on a larger collection of orders!

