### PR TITLE
Objective Fuction Part I - Total Utility as objective.

### DIFF
--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -235,14 +235,13 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     function evaluateUtility(uint128 execBuy, Order memory order) internal view returns(uint128) {
-        // Utility = ((execBuyAmt * order.sellAmt - preFeeSell * order.buyAmt) * price.buyToken) / order.sellAmt
+        // Utility = ((execBuyAmt * order.sellAmt - scaledSellAmount * order.buyAmt) * price.buyToken) / order.sellAmt
         uint256 scaledSellAmount = getExecutedSellAmount(
             execBuy,
             currentPrices[order.buyToken],
             currentPrices[order.sellToken],
             2
         );
-        //execBuy.mul(currentPrices[order.buyToken]).div(currentPrices[order.sellToken]);
         return uint128(
             execBuy.sub(
                 scaledSellAmount.mul(order.priceNumerator).div(order.priceDenominator)

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -14,7 +14,7 @@ contract StablecoinConverter is EpochTokenLocker {
     using TokenConservation for int[];
 
     uint constant private MAX_UINT128 = 2**128 - 1;
-    uint constant MAX_TOUCHED_ORDERS = 25;
+    uint constant public MAX_TOUCHED_ORDERS = 25;
 
     event OrderPlacement(
         address owner,

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -283,6 +283,7 @@ contract StablecoinConverter is EpochTokenLocker {
         //                    = ((executedBuyAmount * buyTokenPrice) / (feeDenominator - 1)) * feeDenominator) / sellTokenPrice
         uint256 sellAmount = uint256(executedBuyAmount).mul(buyTokenPrice).div(feeDenominator - 1)
             .mul(feeDenominator).div(sellTokenPrice);
+        // TODO - use SafeCast here.
         require(sellAmount < MAX_UINT128, "sellAmount too large");
         return uint128(sellAmount);
     }

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -189,8 +189,6 @@ contract StablecoinConverter is EpochTokenLocker {
             Order memory order = orders[owners[i]][orderIds[i]];
             require(checkOrderValidity(order, batchIndex), "Order is invalid");
             (uint128 executedBuyAmount, uint128 executedSellAmount) = getTradedAmounts(volumes[i], order);
-            // accumulate utility before updateRemainingOrder
-            utility = utility.add(evaluateUtility(executedBuyAmount, order));
             tokenConservation.updateTokenConservation(
                 order.buyToken,
                 order.sellToken,
@@ -205,6 +203,8 @@ contract StablecoinConverter is EpochTokenLocker {
                 executedSellAmount.mul(order.priceNumerator) <= executedBuyAmount.mul(order.priceDenominator),
                 "limit price not satisfied"
             );
+            // accumulate utility before updateRemainingOrder, but after limitPrice verified!
+            utility = utility.add(evaluateUtility(executedBuyAmount, order));
             updateRemainingOrder(owners[i], orderIds[i], executedSellAmount);
             addBalanceAndPostponeWithdraw(owners[i], tokenIdToAddressMap(order.buyToken), executedBuyAmount);
         }

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -236,8 +236,12 @@ contract StablecoinConverter is EpochTokenLocker {
 
     function evaluateUtility(uint128 execBuy, Order memory order) internal view returns(uint128) {
         // Utility = ((execBuyAmt * order.sellAmt - preFeeSell * order.buyAmt) * price.buyToken) / order.sellAmt
-        uint128 preFeeSell = uint128(execBuy.mul(currentPrices[order.buyToken]).div(currentPrices[order.sellToken]));
-        return (execBuy - ((preFeeSell * order.priceNumerator) / order.priceDenominator)) * currentPrices[order.buyToken];
+        uint256 preFeeSell = execBuy.mul(currentPrices[order.buyToken]).div(currentPrices[order.sellToken]);
+        return uint128(
+            execBuy.sub(
+                preFeeSell.mul(order.priceNumerator).div(order.priceDenominator)
+            ).mul(currentPrices[order.buyToken])
+        );
     }
 
     function grantRewardToSolutionSubmitter(uint feeReward) internal {

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -277,10 +277,10 @@ contract StablecoinConverter is EpochTokenLocker {
         // where phi = 1/feeDenominator
         // Note that: 1 - phi = (feeDenominator - 1) / feeDenominator
         // And so, 1/(1-phi) = feeDenominator / (feeDenominator - 1)
-        // executedSellAmount = (execBuyAmount * p[buyToken]) / (p[sellToken] * (1 - phi))
-        //                    = (execBuyAmount * buyTokenPrice / sellTokenPrice) * feeDenominator / (feeDenominator - 1)
-        //                    in order to minimize rounding errors, the order is switched
-        //                    = ((executedBuyAmount * buyTokenPrice) / (feeDenominator - 1)) * feeDenominator) / sellTokenPrice
+        // execSellAmount = (execBuyAmount * p[buyToken]) / (p[sellToken] * (1 - phi))
+        //                = (execBuyAmount * buyTokenPrice / sellTokenPrice) * feeDenominator / (feeDenominator - 1)
+        //    in order to minimize rounding errors, the order of operations is switched
+        //                = ((executedBuyAmount * buyTokenPrice) / (feeDenominator - 1)) * feeDenominator) / sellTokenPrice
         uint256 sellAmount = uint256(executedBuyAmount).mul(buyTokenPrice).div(feeDenominator - 1)
             .mul(feeDenominator).div(sellTokenPrice);
         // TODO - use SafeCast here.

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -52,7 +52,6 @@ contract StablecoinConverter is EpochTokenLocker {
     uint public MAX_TOKENS;  // solhint-disable var-name-mixedcase
     uint16 public numTokens = 0;
     uint128 public feeDenominator; // fee is (1 / feeDenominator)
-    // uint128 private utilityAdjustmentFactor = 2;
 
     constructor(uint maxTokens, uint128 _feeDenominator, address feeToken) public {
         MAX_TOKENS = maxTokens;
@@ -218,6 +217,8 @@ contract StablecoinConverter is EpochTokenLocker {
                 executedSellAmount
             );
         }
+        // Objective function is the sum of utility + the burnt fees collected
+        // This ensures direct trades (when available) yield better solutions than longer rings!
         checkAndOverrideObjectiveValue(utility + uint(tokenConservation[0]) / 2);
         grantRewardToSolutionSubmitter(uint(tokenConservation[0]) / 2);
         tokenConservation.checkTokenConservation();

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -14,6 +14,7 @@ contract StablecoinConverter is EpochTokenLocker {
     using TokenConservation for int[];
 
     uint constant private MAX_UINT128 = 2**128 - 1;
+    uint constant MAX_TOUCHED_ORDERS = 25;
 
     event OrderPlacement(
         address owner,
@@ -176,12 +177,10 @@ contract StablecoinConverter is EpochTokenLocker {
         uint16[] memory tokenIdsForPrice  // price[i] is the price for the token with tokenID tokenIdsForPrice[i]
                                           // fee token id not required since always 0
     ) public {
-        require(
-            batchIndex == getCurrentBatchId() - 1,
-            "Solutions are no longer accepted for this batch"
-        );
+        require(batchIndex == getCurrentBatchId() - 1, "Solutions are no longer accepted for this batch");
         require(tokenIdsForPrice[0] == 0, "fee token price has to be specified");
         require(checkPriceOrdering(tokenIdsForPrice), "prices are not ordered by tokenId");
+        require(owners.length <= MAX_TOUCHED_ORDERS, "Solution exceeds MAX_TOUCHED_ORDERS");
         undoPreviousSolution(batchIndex);
         updateCurrentPrices(prices, tokenIdsForPrice);
         delete previousSolution.trades;

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -161,7 +161,7 @@ contract("StablecoinConverter", async (accounts) => {
     })
   })
   describe("submitSolution()", () => {
-    it("places two orders and matches them in a solution with traders' Utility == 0", async () => {
+    it("rejects trivial solution (the only solution with zero utility", async () => {
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
       const erc20_2 = await MockContract.new()
@@ -183,17 +183,16 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = basicTrade.solution.volume
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - getSellVolume(volume[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), volume[0], "Bought tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), volume[1], "Bought tokens were not adjusted correctly")
+      await truffleAssert.reverts(
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, [0, 0], prices, tokenIdsForPrice, { from: solutionSubmitter }),
+        "Solution does not have a higher objective value than a previous solution"
+      )
+      const currentObjectiveValue = (await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber()
+      assert.equal(0, currentObjectiveValue)
     })
     it("places two orders and matches them in a solution with Utility > 0", async () => {
-
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
       const erc20_2 = await MockContract.new()
@@ -224,6 +223,9 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), volume[0], "Bought tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), volume[1], "Bought tokens were not adjusted correctly")
+
+      const currentObjectiveValue = (await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber()
+      assert(currentObjectiveValue > 0)
     })
 
     it("places two orders, matches them partially and then checks correct order adjustments", async () => {
@@ -289,8 +291,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [4000, feeSubtracted(4000) * 2]
-
+      const volume = [7000, feeSubtracted(7000) * 2]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
@@ -331,14 +332,12 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [5000, feeSubtracted(5000) * 2]
+      const volume = [7000, feeSubtracted(7000) * 2]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
-
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
-      const volume2 = [6000, feeSubtracted(6000) * 2]
-
+      const volume2 = [8000, feeSubtracted(8000) * 2]
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
       const volume3 = basicTrade.solution.volume
@@ -393,7 +392,7 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), 0, "Bought and sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_3, erc20_2.address)).toNumber(), feeAdded(10000) - getSellVolume(volume[3], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
 
-      //Now reverting should not throw due to temporarily negative balances, only later due to objective value criteria
+      // Now reverting should not throw due to temporarily negative balances, only later due to objective value criteria
       await truffleAssert.reverts(
         stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter }),
         "Solution does not have a higher objective value than a previous solution"
@@ -421,7 +420,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [5000, feeSubtracted(5000) * 2]
+      const volume = [7000, feeSubtracted(7000) * 2]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
@@ -433,12 +432,13 @@ contract("StablecoinConverter", async (accounts) => {
 
       await waitForNSeconds(BATCH_TIME)
 
-      await stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
+      const volume2 = [2000, feeSubtracted(2000) * 2]
+      await stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - 2 * getSellVolume(volume[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), 2 * volume[0], "Bought tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - 2 * getSellVolume(volume[1], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), 2 * volume[1], "Bought tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - getSellVolume(volume[0], prices[0], prices[1]) - getSellVolume(volume2[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), volume[0] + volume2[0], "Bought tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1], prices[1], prices[0]) - getSellVolume(volume2[1], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), volume[1] + volume2[1], "Bought tokens were not adjusted correctly")
     })
     it("settles a ring trade between 3 tokens", async () => {
       const feeToken = await MockContract.new()
@@ -817,40 +817,40 @@ contract("StablecoinConverter", async (accounts) => {
       await erc20_3.givenAnyReturnBool(true)
 
 
-      await stablecoinConverter.deposit(feeToken.address, 60000, { from: user_1 })
-      await stablecoinConverter.deposit(erc20_2.address, 60000, { from: user_2 })
-      await stablecoinConverter.deposit(erc20_3.address, 10000, { from: user_3 })
+      await stablecoinConverter.deposit(feeToken.address, feeAdded(110000), { from: user_1 })
+      await stablecoinConverter.deposit(erc20_2.address, feeAdded(100000), { from: user_2 })
+      await stablecoinConverter.deposit(erc20_3.address, feeAdded(10000), { from: user_3 })
 
       await stablecoinConverter.addToken(erc20_2.address)
       await stablecoinConverter.addToken(erc20_3.address)
 
       const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 10000, 60000, { from: user_1 })
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, true, batchIndex + 1, 10000, 60000, { from: user_2 })
-      const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, true, batchIndex + 1, 10000, 60000, { from: user_3 })
-      const orderId4 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 10000, 60000, { from: user_2 })
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 10000, feeAdded(10000), { from: user_1 })
+      const orderId5 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 100000, feeAdded(100000), { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, true, batchIndex + 1, 10000, feeAdded(10000), { from: user_2 })
+      const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, true, batchIndex + 1, 10000, feeAdded(10000), { from: user_3 })
+      const orderId4 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 100000, feeAdded(100000), { from: user_2 })
 
 
       await closeAuction(stablecoinConverter)
 
-      const prices = [10000000, 10000000, 10000000]
+      const prices = [1, 1, 1]
       const owner = [user_1, user_2, user_3]
       const orderId = [orderId1, orderId2, orderId3]
-      const volume = [10000, 9990, 9981]
+      const volume = [10000, 10000, 10000]
       const tokenIdsForPrice = [0, 1, 2]
-
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice)
-      assert.equal((await stablecoinConverter.currentPrices.call(2)).toNumber(), 10000000, "CurrentPrice were not adjusted correctly")
 
-      const prices2 = [10, 10]
+      assert.equal(1, (await stablecoinConverter.currentPrices.call(2)).toNumber(), "CurrentPrice were not adjusted correctly")
+      const prices2 = [1, 1]
       const owner2 = [user_1, user_2]
-      const orderIds2 = [orderId1, orderId4]
-      const volume2 = [50000, feeSubtracted(50000)]
+      const orderIds2 = [orderId5, orderId4]
+      const volume2 = [100000, 100000]
       const tokenIdsForPrice2 = [0, 1]
 
       await stablecoinConverter.submitSolution(batchIndex, owner2, orderIds2, volume2, prices2, tokenIdsForPrice2)
-      assert.equal((await stablecoinConverter.currentPrices.call(2)).toNumber(), 0, "CurrentPrice were not adjusted correctly")
+      assert.equal(0, (await stablecoinConverter.currentPrices.call(2)).toNumber(), "CurrentPrice were not adjusted correctly")
     })
     it("reverts, if price of buyToken == 0", async () => {
       const feeToken = await MockContract.new()
@@ -932,13 +932,13 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [5000, feeSubtracted(5000) * 2]
+      const volume = [7000, feeSubtracted(7000) * 2]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
       assert.equal((await stablecoinConverter.getBalance.call(solutionSubmitter, feeToken.address)).toNumber(), (getSellVolume(volume[0], prices[0], prices[1]) - volume[1]) / 2, "fee was not granted correctly")
 
-      const volume2 = [6000, feeSubtracted(6000) * 2]
+      const volume2 = [8000, feeSubtracted(8000) * 2]
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume2, prices, tokenIdsForPrice)
       assert.equal((await stablecoinConverter.getBalance.call(solutionSubmitter, feeToken.address)).toNumber(), 0, "fee was not reverted")
@@ -1004,7 +1004,6 @@ contract("StablecoinConverter", async (accounts) => {
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
-
       await truffleAssert.reverts(
         stablecoinConverter.withdraw(feeToken.address, { from: solutionSubmitter }),
         "withdraw was not registered previously"
@@ -1028,21 +1027,40 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
       await closeAuction(stablecoinConverter)
-
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [4000, feeSubtracted(4000) * 2]
+      const buyVolume = [7000, feeSubtracted(7000) * 2]
+      const sellVolume = [
+        getExecutedSellAmount(buyVolume[0], prices[1], prices[0]),
+        getExecutedSellAmount(buyVolume[1], prices[0], prices[1]),
+      ]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
+      const tradeUtilities = [
+        evaluateTradeUtility(basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, buyVolume[0], sellVolume[0], prices[1], prices[0]),
+        evaluateTradeUtility(basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, buyVolume[1], sellVolume[1], prices[0], prices[1])
+      ]
+      const totalUtility = tradeUtilities.reduce((a, b) => a + b, 0)
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, buyVolume, prices, tokenIdsForPrice, { from: solutionSubmitter })
+      const actualObjectiveValue = (await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber()
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
+      assert.equal(actualObjectiveValue, totalUtility, "Objective value is not stored correct")
 
-      assert.equal((await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber(), (getSellVolume(volume[0], prices[0], prices[1]) - volume[1]), "Objective value is not stored correct")
+      const buyVolume2 = basicTrade.solution.volume
+      const sellVolume2 = [
+        getExecutedSellAmount(buyVolume2[0], prices[1], prices[0]),
+        getExecutedSellAmount(buyVolume2[1], prices[0], prices[1]),
+      ]
+      const tradeUtilities2 = [
+        evaluateTradeUtility(basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, buyVolume2[0], sellVolume2[0], prices[1], prices[0]),
+        evaluateTradeUtility(basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, buyVolume2[1], sellVolume2[1], prices[0], prices[1])
+      ]
+      const totalUtility2 = tradeUtilities2.reduce((a, b) => a + b, 0)
 
-      const volume2 = basicTrade.solution.volume
+      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, buyVolume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
+      const actualObjectiveValue2 = (await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber()
 
-      await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
-      assert.equal((await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber(), (getSellVolume(volume2[0], prices[0], prices[1]) - volume2[1]), "Objective value is not stored correct after a second solution submission")
+      assert.equal(actualObjectiveValue2, totalUtility2, "Objective value incorrect after second solution submission")
     })
     it("checks that the objective value is returned correctly after getting into a new batch", async () => {
       const feeToken = await MockContract.new()
@@ -1066,14 +1084,14 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [4000, feeSubtracted(4000) * 2]
+      const volume = [7000, feeSubtracted(7000) * 2]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
       await closeAuction(stablecoinConverter)
-
-      assert.equal((await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber(), 0, "Objective value is not returned correct")
+      const actualObjectiveValue = (await stablecoinConverter.getCurrentObjectiveValue.call()).toNumber()
+      assert.equal(actualObjectiveValue, 0, "Objective value is not returned correct")
     })
     it("reverts, if downcast from u256 to u128 would change the value", async () => {
       const feeToken = await MockContract.new()
@@ -1215,7 +1233,15 @@ contract("StablecoinConverter", async (accounts) => {
   })
 })
 
+function getExecutedSellAmount(executedBuyAmount, buyTokenPrice, sellTokenPrice) {
+  return Math.floor(Math.floor((executedBuyAmount * buyTokenPrice) / (feeDenominator - 1)) * feeDenominator / sellTokenPrice)
+}
 
+function evaluateTradeUtility(buyAmount, sellAmount, executedBuyAmount, executedSellAmount, priceBuyToken, priceSellToken) {
+  // Utility = ((execBuyAmt * order.sellAmt - preFeeSell * order.buyAmt) * price.buyToken) / order.sellAmt
+  const preFeeSell = (executedBuyAmount * priceBuyToken) / priceSellToken
+  return (executedBuyAmount - Math.floor((preFeeSell * buyAmount) / sellAmount)) * priceBuyToken
+}
 
 const closeAuction = async (instance) => {
   const time_remaining = (await instance.getSecondsRemainingInBatch()).toNumber()

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1133,7 +1133,7 @@ contract("StablecoinConverter", async (accounts) => {
       await stablecoinConverter.addToken(erc20_2.address)
       const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
       const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
       await closeAuction(stablecoinConverter)

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1046,8 +1046,8 @@ contract("StablecoinConverter", async (accounts) => {
       const orderId = [orderId1, orderId2]
       const buyVolume = [7000, feeSubtracted(7000) * 2]
       const sellVolume = [
-        getExecutedSellAmount(buyVolume[0], prices[1], prices[0]),
-        getExecutedSellAmount(buyVolume[1], prices[0], prices[1]),
+        getExecutedSellAmount(buyVolume[0], prices[1], prices[0], 1),
+        getExecutedSellAmount(buyVolume[1], prices[0], prices[1], 1),
       ]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
       const tradeUtilities = [
@@ -1062,8 +1062,8 @@ contract("StablecoinConverter", async (accounts) => {
 
       const buyVolume2 = basicTrade.solution.volume
       const sellVolume2 = [
-        getExecutedSellAmount(buyVolume2[0], prices[1], prices[0]),
-        getExecutedSellAmount(buyVolume2[1], prices[0], prices[1]),
+        getExecutedSellAmount(buyVolume2[0], prices[1], prices[0], 1),
+        getExecutedSellAmount(buyVolume2[1], prices[0], prices[1], 1),
       ]
       const tradeUtilities2 = [
         evaluateTradeUtility(basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, buyVolume2[0], sellVolume2[0], prices[1], prices[0]),
@@ -1253,9 +1253,8 @@ function getExecutedSellAmount(executedBuyAmount, buyTokenPrice, sellTokenPrice,
 }
 
 function evaluateTradeUtility(buyAmount, sellAmount, executedBuyAmount, executedSellAmount, priceBuyToken, priceSellToken) {
-  // Utility = ((execBuyAmt * order.sellAmt - preFeeSell * order.buyAmt) * price.buyToken) / order.sellAmt
-  const preFeeSell = (executedBuyAmount * priceBuyToken) / priceSellToken
-  return (executedBuyAmount - Math.floor((preFeeSell * buyAmount) / sellAmount)) * priceBuyToken
+  const scaledSellAmount = getExecutedSellAmount(executedBuyAmount, priceBuyToken, priceSellToken, 2)
+  return (executedBuyAmount - Math.floor((scaledSellAmount * buyAmount) / sellAmount)) * priceBuyToken
 }
 
 const closeAuction = async (instance) => {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -51,7 +51,7 @@ contract("StablecoinConverter", async (accounts) => {
       { sellToken: 0, buyToken: 1, sellAmount: feeAdded(20000), buyAmount: 10000, user: user_1 },
       { sellToken: 1, buyToken: 0, sellAmount: feeAdded(10000), buyAmount: feeSubtracted(10000) * 2, user: user_2 }
     ],
-    solution: { prices: [1, 2], owners: [user_1, user_2], volume: [10000, feeSubtracted(10000) * 2], tokenIdsForPrice: [0, 1] }
+    solution: { prices: [1, 2], owners: [user_1, user_2], volume: [10000, 20000], tokenIdsForPrice: [0, 1] }
   }
 
   describe("placeOrder()", () => {
@@ -228,7 +228,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = [10, 10]
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [10000, feeSubtracted(10000)]
+      const volume = [10000, 10000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
@@ -264,7 +264,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [10000, feeSubtracted(10000) * 2]
+      const volume = [10000, 20000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
@@ -305,7 +305,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [7000, feeSubtracted(7000) * 2]
+      const volume = [7000, 14000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
@@ -346,12 +346,12 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [7000, feeSubtracted(7000) * 2]
+      const volume = [7000, 14000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
-      const volume2 = [8000, feeSubtracted(8000) * 2]
+      const volume2 = [8000, 16000]
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
       const volume3 = basicTrade.solution.volume
@@ -434,7 +434,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [7000, feeSubtracted(7000) * 2]
+      const volume = [7000, 14000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
@@ -446,7 +446,7 @@ contract("StablecoinConverter", async (accounts) => {
 
       await waitForNSeconds(BATCH_TIME)
 
-      const volume2 = [2000, feeSubtracted(2000) * 2]
+      const volume2 = [2000, 4000]
       await stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
       assert.equal(
@@ -680,7 +680,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [basicTrade.solution.volume[0], basicTrade.solution.volume[1] - 1]
+      const volume = [basicTrade.solution.volume[0], basicTrade.solution.volume[1] - 21]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
 
@@ -856,11 +856,11 @@ contract("StablecoinConverter", async (accounts) => {
 
       const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
 
-      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 10000, feeAdded(10000), { from: user_1 })
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, true, batchIndex + 1, 10000, feeAdded(10000), { from: user_2 })
-      const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, true, batchIndex + 1, 10000, feeAdded(10000), { from: user_3 })
-      const orderId4 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, true, batchIndex + 1, 100000, feeAdded(100000), { from: user_2 })
-      const orderId5 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, true, batchIndex + 1, 100000, feeAdded(100000), { from: user_1 })
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, batchIndex + 1, 10000, feeAdded(10000), { from: user_1 })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 2, 1, batchIndex + 1, 10000, feeAdded(10000), { from: user_2 })
+      const orderId3 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 2, batchIndex + 1, 10000, feeAdded(10000), { from: user_3 })
+      const orderId4 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 0, 1, batchIndex + 1, 100000, feeAdded(100000), { from: user_2 })
+      const orderId5 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, 1, 0, batchIndex + 1, 100000, feeAdded(100000), { from: user_1 })
 
       await closeAuction(stablecoinConverter)
 
@@ -961,13 +961,13 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [7000, feeSubtracted(7000) * 2]
+      const volume = [7000, 14000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })
       assert.equal((await stablecoinConverter.getBalance.call(solutionSubmitter, feeToken.address)).toNumber(), (getSellVolume(volume[0], prices[0], prices[1]) - volume[1]) / 2, "fee was not granted correctly")
 
-      const volume2 = [8000, feeSubtracted(8000) * 2]
+      const volume2 = [8000, 16000]
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume2, prices, tokenIdsForPrice)
       assert.equal((await stablecoinConverter.getBalance.call(solutionSubmitter, feeToken.address)).toNumber(), 0, "fee was not reverted")
@@ -1062,7 +1062,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const buyVolume = [7000, feeSubtracted(7000) * 2]
+      const buyVolume = [7000, 14000]
       const sellVolume = [
         getExecutedSellAmount(buyVolume[0], prices[1], prices[0], 1),
         getExecutedSellAmount(buyVolume[1], prices[0], prices[1], 1),
@@ -1116,7 +1116,7 @@ contract("StablecoinConverter", async (accounts) => {
       const prices = basicTrade.solution.prices
       const owner = basicTrade.solution.owners
       const orderId = [orderId1, orderId2]
-      const volume = [7000, feeSubtracted(7000) * 2]
+      const volume = [7000, 14000]
       const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
 
       await stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter })

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -161,7 +161,7 @@ contract("StablecoinConverter", async (accounts) => {
     })
   })
   describe("submitSolution()", () => {
-    it("rejects trivial solution (the only solution with zero utility", async () => {
+    it("rejects trivial solution (the only solution with zero utility)", async () => {
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
       const erc20_2 = await MockContract.new()

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -435,10 +435,26 @@ contract("StablecoinConverter", async (accounts) => {
       const volume2 = [2000, feeSubtracted(2000) * 2]
       await stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - getSellVolume(volume[0] - volume2[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), volume[0] + volume2[0], "Bought tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1] - volume2[0], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), volume[1] + volume2[1], "Bought tokens were not adjusted correctly")
+      assert.equal(
+        basicTrade.deposits[0].amount - getSellVolume(volume[0] + volume2[0], prices[0], prices[1]),
+        (await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(),
+        "Sold tokens were not adjusted correctly"
+      )
+      assert.equal(
+        volume[0] + volume2[0],
+        (await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(),
+        "Bought tokens were not adjusted correctly"
+      )
+      assert.equal(
+        basicTrade.deposits[1].amount - getSellVolume(volume[1] + volume2[1], prices[1], prices[0]),
+        (await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(),
+        "Sold tokens were not adjusted correctly"
+      )
+      assert.equal(
+        volume[1] + volume2[1],
+        (await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(),
+        "Bought tokens were not adjusted correctly"
+      )
     })
     it("settles a ring trade between 3 tokens", async () => {
       const feeToken = await MockContract.new()

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -435,9 +435,9 @@ contract("StablecoinConverter", async (accounts) => {
       const volume2 = [2000, feeSubtracted(2000) * 2]
       await stablecoinConverter.submitSolution(batchIndex + 1, owner, orderId, volume2, prices, tokenIdsForPrice, { from: solutionSubmitter })
 
-      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - getSellVolume(volume[0], prices[0], prices[1]) - getSellVolume(volume2[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_1, feeToken.address)).toNumber(), basicTrade.deposits[0].amount - getSellVolume(volume[0] - volume2[0], prices[0], prices[1]), "Sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_1, erc20_2.address)).toNumber(), volume[0] + volume2[0], "Bought tokens were not adjusted correctly")
-      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1], prices[1], prices[0]) - getSellVolume(volume2[1], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
+      assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2.address)).toNumber(), basicTrade.deposits[1].amount - getSellVolume(volume[1] - volume2[0], prices[1], prices[0]), "Sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken.address)).toNumber(), volume[1] + volume2[1], "Bought tokens were not adjusted correctly")
     })
     it("settles a ring trade between 3 tokens", async () => {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1119,7 +1119,40 @@ contract("StablecoinConverter", async (accounts) => {
         "sellAmount too large"
       )
     })
+    it("reverts if max touched orders is exceeded", async () => {
+      const feeToken = await MockContract.new()
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
+      const erc20_2 = await MockContract.new()
 
+      await feeToken.givenAnyReturnBool(true)
+      await erc20_2.givenAnyReturnBool(true)
+
+      await stablecoinConverter.deposit(feeToken.address, basicTrade.deposits[0].amount, { from: basicTrade.deposits[0].user })
+      await stablecoinConverter.deposit(erc20_2.address, basicTrade.deposits[1].amount, { from: basicTrade.deposits[1].user })
+
+      await stablecoinConverter.addToken(erc20_2.address)
+      const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
+
+      const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, true, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
+
+      await closeAuction(stablecoinConverter)
+
+      const prices = basicTrade.solution.prices
+      const seedOwners = basicTrade.solution.owners
+      const seedVolumes = basicTrade.solution.volume
+      const tokenIdsForPrice = basicTrade.solution.tokenIdsForPrice
+
+      const halfNumTouched = 20
+      const owner = Array(halfNumTouched).fill(seedOwners[0]).concat(Array(halfNumTouched).fill(seedOwners[1]))
+      const orderId = Array(halfNumTouched).fill(orderId1).concat(Array(halfNumTouched).fill(orderId2))
+      const volume = Array(halfNumTouched).fill(seedVolumes[0] / halfNumTouched).concat(Array(halfNumTouched).fill(seedVolumes[1] / halfNumTouched))
+
+      await truffleAssert.reverts(
+        stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice),
+        "Solution exceeds MAX_TOUCHED_ORDERS"
+      )
+    })
   })
   describe("getEncodedAuctionElements()", async () => {
     it("returns all orders that are have ever been submitted", async () => {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1134,7 +1134,7 @@ contract("StablecoinConverter", async (accounts) => {
       const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
 
       const orderId1 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[0].buyToken, basicTrade.orders[0].sellToken, batchIndex + 1, basicTrade.orders[0].buyAmount, basicTrade.orders[0].sellAmount, { from: basicTrade.orders[0].user })
-      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, true, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
+      const orderId2 = await sendTxAndGetReturnValue(stablecoinConverter.placeOrder, basicTrade.orders[1].buyToken, basicTrade.orders[1].sellToken, batchIndex + 1, basicTrade.orders[1].buyAmount, basicTrade.orders[1].sellAmount, { from: basicTrade.orders[1].user })
 
       await closeAuction(stablecoinConverter)
 

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1233,8 +1233,9 @@ contract("StablecoinConverter", async (accounts) => {
   })
 })
 
-function getExecutedSellAmount(executedBuyAmount, buyTokenPrice, sellTokenPrice) {
-  return Math.floor(Math.floor((executedBuyAmount * buyTokenPrice) / (feeDenominator - 1)) * feeDenominator / sellTokenPrice)
+function getExecutedSellAmount(executedBuyAmount, buyTokenPrice, sellTokenPrice, scale) {
+  const scaledFee = scale * feeDenominator
+  return Math.floor(Math.floor((executedBuyAmount * buyTokenPrice) / (scaledFee - 1)) * scaledFee / sellTokenPrice)
 }
 
 function evaluateTradeUtility(buyAmount, sellAmount, executedBuyAmount, executedSellAmount, priceBuyToken, priceSellToken) {


### PR DESCRIPTION
This is the first of a two part PR. We introduce our Exchange "solution" objective function as the total utility achieved by order matching. This metric is a token independent measure of the trader's utility obtained by getting a better price than specified in the order. Heuristically, the utility of an executed order is 

```
Utility = ((execBuyAmt * order.sellAmt - adjustedSellAmount * order.buyAmt) * price.buyToken) / order.sellAmt
```

Note that the naive formula would evaluate to zero when the trader gets exactly their specified price. In order to nudge this above zero, the utility is calculated with `executedSellAmt` replaced by an adjusted version `adjustedSellAmount` which is computed with an adjustment factor on the feeDenominator. 

This is based on Equation (2) from https://github.com/gnosis/dex-contracts/issues/173#issuecomment-526163117 with the fee `phi` replaced by `phi/2`
That is, 

the usual executedSellAmount is defined by this relation,
```
execSellAmount * p[sellToken] * (1 - phi) == execBuyAmount * p[buyToken]
```
while the `adjustedSellAmount` is defined by using half the fee as
```
adjustedSellAmount * p[sellToken] * (1 - phi/2) == execBuyAmount * p[buyToken]
```

This "nudge" serves two purposes:

1. Circumvent the many solutions that would be ranked equally amongst trivial solution (having zero utility) and thus, the smart contract would reject perfectly valid non-trivial solutions.
2. To ensure that direct trades are preferred over long rings which try to exploit market orders.

Finally, be aware that some of the unit tests have been shifted (ever so slightly) to accommodate for the second part of this PR. I would be willing to revert these changes if it makes the understanding more clear.
