### PR TITLE
[Easy] Node Version update?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '8'
+  - '12'
 before_install:
   - rm -rf build
   - rm -rf node_modules


### PR DESCRIPTION
Trying to get ride of these ugly warnings by upgrading node version of the project.

```
You can improve web3's peformance when running Node.js versions older than 10.5.0 
by installing the (deprecated) scrypt package in your project
```

Would also be will to try installing the (deprecated) scrypt package
