### PR TITLE
[Easy] rename "previous" to "current" Solution

### DIFF
--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -146,9 +146,9 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     mapping (uint16 => uint128) public currentPrices;
-    CurrentSolutionData public currentSolution;
+    SolutionData public currentSolution;
 
-    struct CurrentSolutionData {
+    struct SolutionData {
         uint32 batchId;
         TradeData[] trades;
         uint16[] tokenIdsForPrice;

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -146,9 +146,9 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     mapping (uint16 => uint128) public currentPrices;
-    PreviousSolutionData public previousSolution;
+    CurrentSolutionData public currentSolution;
 
-    struct PreviousSolutionData {
+    struct CurrentSolutionData {
         uint32 batchId;
         TradeData[] trades;
         uint16[] tokenIdsForPrice;
@@ -176,9 +176,9 @@ contract StablecoinConverter is EpochTokenLocker {
         require(tokenIdsForPrice[0] == 0, "fee token price has to be specified");
         require(checkPriceOrdering(tokenIdsForPrice), "prices are not ordered by tokenId");
         require(owners.length <= MAX_TOUCHED_ORDERS, "Solution exceeds MAX_TOUCHED_ORDERS");
-        undoPreviousSolution(batchIndex);
+        undoCurrentSolution(batchIndex);
         updateCurrentPrices(prices, tokenIdsForPrice);
-        delete previousSolution.trades;
+        delete currentSolution.trades;
         int[] memory tokenConservation = new int[](prices.length);
         uint utility = 0;
         for (uint i = 0; i < owners.length; i++) {
@@ -232,8 +232,8 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     function getCurrentObjectiveValue() public view returns(uint) {
-        if (previousSolution.batchId == getCurrentBatchId() - 1) {
-            return previousSolution.objectiveValue;
+        if (currentSolution.batchId == getCurrentBatchId() - 1) {
+            return currentSolution.objectiveValue;
         } else {
             return 0;
         }
@@ -269,7 +269,7 @@ contract StablecoinConverter is EpochTokenLocker {
     }
 
     function grantRewardToSolutionSubmitter(uint feeReward) internal {
-        previousSolution.feeReward = feeReward;
+        currentSolution.feeReward = feeReward;
         addBalanceAndBlockWithdrawForThisBatch(msg.sender, tokenIdToAddressMap(0), feeReward);
     }
 
@@ -277,8 +277,8 @@ contract StablecoinConverter is EpochTokenLocker {
         uint128[] memory prices,          // list of prices for touched tokens only, frist price is fee token price
         uint16[] memory tokenIdsForPrice  // price[i] is the price for the token with tokenID tokenIdsForPrice[i]
     ) internal {
-        for (uint i = 0; i < previousSolution.tokenIdsForPrice.length; i++) {
-            currentPrices[previousSolution.tokenIdsForPrice[i]] = 0;
+        for (uint i = 0; i < currentSolution.tokenIdsForPrice.length; i++) {
+            currentPrices[currentSolution.tokenIdsForPrice[i]] = 0;
         }
         for (uint i = 0; i < tokenIdsForPrice.length; i++) {
             currentPrices[tokenIdsForPrice[i]] = prices[i];
@@ -330,40 +330,40 @@ contract StablecoinConverter is EpochTokenLocker {
         uint128[] memory volumes,
         uint16[] memory tokenIdsForPrice
     ) internal {
-        previousSolution.batchId = batchIndex;
+        currentSolution.batchId = batchIndex;
         for (uint i = 0; i < owners.length; i++) {
-            previousSolution.trades.push(TradeData({
+            currentSolution.trades.push(TradeData({
                 owner: owners[i],
                 orderId: orderIds[i],
                 volume: volumes[i]
             }));
         }
-        previousSolution.tokenIdsForPrice = tokenIdsForPrice;
-        previousSolution.solutionSubmitter = msg.sender;
+        currentSolution.tokenIdsForPrice = tokenIdsForPrice;
+        currentSolution.solutionSubmitter = msg.sender;
     }
 
-    function undoPreviousSolution(uint32 batchIndex) internal {
-        if (previousSolution.batchId == batchIndex) {
-            for (uint i = 0; i < previousSolution.trades.length; i++) {
-                address owner = previousSolution.trades[i].owner;
-                uint orderId = previousSolution.trades[i].orderId;
+    function undoCurrentSolution(uint32 batchIndex) internal {
+        if (currentSolution.batchId == batchIndex) {
+            for (uint i = 0; i < currentSolution.trades.length; i++) {
+                address owner = currentSolution.trades[i].owner;
+                uint orderId = currentSolution.trades[i].orderId;
                 Order memory order = orders[owner][orderId];
-                (, uint128 sellAmount) = getTradedAmounts(previousSolution.trades[i].volume, order);
+                (, uint128 sellAmount) = getTradedAmounts(currentSolution.trades[i].volume, order);
                 addBalance(owner, tokenIdToAddressMap(order.sellToken), sellAmount);
             }
-            for (uint i = 0; i < previousSolution.trades.length; i++) {
-                address owner = previousSolution.trades[i].owner;
-                uint orderId = previousSolution.trades[i].orderId;
+            for (uint i = 0; i < currentSolution.trades.length; i++) {
+                address owner = currentSolution.trades[i].owner;
+                uint orderId = currentSolution.trades[i].orderId;
                 Order memory order = orders[owner][orderId];
-                (uint128 buyAmount, uint128 sellAmount) = getTradedAmounts(previousSolution.trades[i].volume, order);
+                (uint128 buyAmount, uint128 sellAmount) = getTradedAmounts(currentSolution.trades[i].volume, order);
                 revertRemainingOrder(owner, orderId, sellAmount);
                 subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyAmount);
             }
             // subtract granted fees:
             subtractBalance(
-                previousSolution.solutionSubmitter,
+                currentSolution.solutionSubmitter,
                 tokenIdToAddressMap(0),
-                previousSolution.feeReward
+                currentSolution.feeReward
             );
         }
     }
@@ -371,9 +371,9 @@ contract StablecoinConverter is EpochTokenLocker {
     function checkAndOverrideObjectiveValue(uint256 newObjectiveValue) private {
         require(
             newObjectiveValue > getCurrentObjectiveValue(),
-            "Solution does not have a higher objective value than a previous solution"
+            "Solution must have a higher objective value than current solution"
         );
-        previousSolution.objectiveValue = newObjectiveValue;
+        currentSolution.objectiveValue = newObjectiveValue;
     }
 
     function getTradedAmounts(uint128 volume, Order memory order) private view returns (uint128, uint128) {

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -408,7 +408,7 @@ contract("StablecoinConverter", async (accounts) => {
       // Now reverting should not throw due to temporarily negative balances, only later due to objective value criteria
       await truffleAssert.reverts(
         stablecoinConverter.submitSolution(batchIndex, owner, orderId, volume, prices, tokenIdsForPrice, { from: solutionSubmitter }),
-        "Solution does not have a higher objective value than a previous solution"
+        "Solution must have a higher objective value than current solution"
       )
     })
     it("checks that trades documented from a previous trade are deleted and not considered for a new batchIndex", async () => {


### PR DESCRIPTION
After providing doc strings to the smart contract, it because apparent that `previousSolution` as a `PreviousSolutionStruct` might be the wrong word to use (since it actually represents the current solution).

For example, 

The most logical @dev documentation to use would be

```js
/** @dev stores sufficient information for current winning auction solution */
PreviousSolutionData public previousSolution;
``` 

Another good example of this is in `getCurrentObjetiveValue()` which may be somewhat misleading when it returns values based on `previousSolution`.

https://github.com/gnosis/dex-contracts/blob/0f1995cc25ebd94daacdd5247bd843f194cf93ac/contracts/StablecoinConverter.sol#L234-L240