### PR TITLE
[Easy] Naming consistency (owner<->user) and parameter ordering

### DIFF
--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -70,11 +70,11 @@ contract EpochTokenLocker {
         emit WithdrawRequest(msg.sender, token, amount, getCurrentBatchId());
     }
 
-    function withdraw(address token, address owner) public {
-        updateDepositsBalance(owner, token); // withdrawn amount might just be deposited before
+    function withdraw(address user, address token) public {
+        updateDepositsBalance(user, token); // withdrawn amount might just be deposited before
 
         require(
-            balanceStates[owner][token].pendingWithdraws.stateIndex < getCurrentBatchId(),
+            balanceStates[user][token].pendingWithdraws.stateIndex < getCurrentBatchId(),
             "withdraw was not registered previously"
         );
 
@@ -84,15 +84,15 @@ contract EpochTokenLocker {
         );
 
         uint amount = Math.min(
-            balanceStates[owner][token].balance,
+            balanceStates[user][token].balance,
             balanceStates[msg.sender][token].pendingWithdraws.amount
         );
 
-        balanceStates[owner][token].balance = balanceStates[owner][token].balance.sub(amount);
-        delete balanceStates[owner][token].pendingWithdraws;
+        balanceStates[user][token].balance = balanceStates[user][token].balance.sub(amount);
+        delete balanceStates[user][token].pendingWithdraws;
 
-        ERC20(token).transfer(owner, amount);
-        emit Withdraw(owner, token, amount);
+        ERC20(token).transfer(user, amount);
+        emit Withdraw(user, token, amount);
     }
 
     /**

--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -64,7 +64,7 @@ contract EpochTokenLocker {
     function requestWithdraw(address token, uint amount) public {
         // first process old pendingWithdraw, as otherwise balances might increase for currentBatchId - 1
         if (hasValidWithdrawRequest(msg.sender, token)) {
-            withdraw(token, msg.sender);
+            withdraw(msg.sender, token);
         }
         balanceStates[msg.sender][token].pendingWithdraws = PendingFlux({ amount: amount, stateIndex: getCurrentBatchId() });
         emit WithdrawRequest(msg.sender, token, amount, getCurrentBatchId());

--- a/scripts/stablex/claim_withdraw.js
+++ b/scripts/stablex/claim_withdraw.js
@@ -26,7 +26,7 @@ module.exports = async (callback) => {
     const token = await ERC20.at(token_address)
 
     const balance_before = await token.balanceOf(withdrawer)
-    await instance.withdraw(token_address, withdrawer, { from: withdrawer })
+    await instance.withdraw(withdrawer, token_address, { from: withdrawer })
     const balance_after = await token.balanceOf(withdrawer)
 
     console.log(`Success! Balance of token ${argv.tokenId} before claim: ${balance_before}, after claim: ${balance_after}`)

--- a/test/epoch_token_locker.js
+++ b/test/epoch_token_locker.js
@@ -97,7 +97,7 @@ contract("EpochTokenLocker", async (accounts) => {
 
       await epochTokenLocker.requestWithdraw(ERC20.address, 100)
       await waitForNSeconds(BATCH_TIME)
-      await epochTokenLocker.withdraw(ERC20.address, user_1)
+      await epochTokenLocker.withdraw(user_1, ERC20.address)
 
       assert.equal(await epochTokenLocker.getPendingWithdrawAmount(user_1, ERC20.address), 0)
       assert.equal(await epochTokenLocker.getPendingWithdrawBatchNumber(user_1, ERC20.address), 0)
@@ -116,7 +116,7 @@ contract("EpochTokenLocker", async (accounts) => {
       assert.equal(await epochTokenLocker.getBalance(user_1, ERC20.address), 100)
 
       await epochTokenLocker.requestWithdraw(ERC20.address, 100)
-      await truffleAssert.reverts(epochTokenLocker.withdraw(ERC20.address, user_1), "withdraw was not registered previously")
+      await truffleAssert.reverts(epochTokenLocker.withdraw(user_1, ERC20.address), "withdraw was not registered previously")
     })
     it("processes a withdraw request and withdraws only available amounts", async () => {
       const epochTokenLocker = await EpochTokenLocker.new()
@@ -129,7 +129,7 @@ contract("EpochTokenLocker", async (accounts) => {
 
       await epochTokenLocker.requestWithdraw(ERC20.address, 100)
       await waitForNSeconds(BATCH_TIME)
-      await epochTokenLocker.withdraw(ERC20.address, user_1)
+      await epochTokenLocker.withdraw(user_1, ERC20.address)
 
       const token = await ERC20Interface.new()
       const depositTransfer = token.contract.methods.transfer(accounts[0], 50).encodeABI()
@@ -147,7 +147,7 @@ contract("EpochTokenLocker", async (accounts) => {
       const batchId = await epochTokenLocker.getCurrentBatchId.call()
       assert.equal((await epochTokenLocker.lastCreditBatchId.call(user_1, ERC20.address)).toString(), batchId.toString())
       await truffleAssert.reverts(
-        epochTokenLocker.withdraw(ERC20.address, user_1),
+        epochTokenLocker.withdraw(user_1, ERC20.address),
         "Withdraw not possible for token that is traded in the current auction"
       )
     })

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -1002,7 +1002,7 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((await stablecoinConverter.lastCreditBatchId.call(basicTrade.orders[0].user, erc20_2.address)).toString(), (batchIndex + 1).toString())
 
       await truffleAssert.reverts(
-        stablecoinConverter.withdraw(erc20_2.address, basicTrade.deposits[0].user, { from: basicTrade.deposits[0].user }),
+        stablecoinConverter.withdraw(basicTrade.deposits[0].user, erc20_2.address, { from: basicTrade.deposits[0].user }),
         "Withdraw not possible for token that is traded in the current auction"
       )
     })
@@ -1036,7 +1036,7 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((await stablecoinConverter.lastCreditBatchId.call(solutionSubmitter, feeToken.address)).toString(), (batchIndex + 1).toString())
 
       await truffleAssert.reverts(
-        stablecoinConverter.withdraw(feeToken.address, solutionSubmitter, { from: solutionSubmitter }),
+        stablecoinConverter.withdraw(solutionSubmitter, feeToken.address, { from: solutionSubmitter }),
         "Withdraw not possible for token that is traded in the current auction"
       )
     })


### PR DESCRIPTION

These are changes related to the consistency of smart contract's naming conventions and parameter orderings. These changes consist of two items

1. Replace all occurrences of `owner` with `user` (since user appeared many more times than owner)

2. Switch withdraw parameters to user-token which lines up with all public view functions. 

Observe, the old `withdraw` function signature

https://github.com/gnosis/dex-contracts/blob/0f1995cc25ebd94daacdd5247bd843f194cf93ac/contracts/EpochTokenLocker.sol#L73

in comparison with all the public view functions:

https://github.com/gnosis/dex-contracts/blob/0f1995cc25ebd94daacdd5247bd843f194cf93ac/contracts/EpochTokenLocker.sol#L101-L115


Special **note** to @anxolin, as this change may affect the front end...