### PR TITLE
268/move checkPriceOrdering

### DIFF
--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -12,6 +12,7 @@ contract StablecoinConverter is EpochTokenLocker {
     using BytesLib for bytes32;
     using BytesLib for bytes;
     using TokenConservation for int[];
+    using TokenConservation for uint16[];
 
     uint constant private MAX_UINT128 = 2**128 - 1;
     uint constant public MAX_TOUCHED_ORDERS = 25;
@@ -174,7 +175,7 @@ contract StablecoinConverter is EpochTokenLocker {
     ) public {
         require(batchIndex == getCurrentBatchId() - 1, "Solutions are no longer accepted for this batch");
         require(tokenIdsForPrice[0] == 0, "fee token price has to be specified");
-        require(checkPriceOrdering(tokenIdsForPrice), "prices are not ordered by tokenId");
+        require(tokenIdsForPrice.checkPriceOrdering(), "prices are not ordered by tokenId");
         require(owners.length <= MAX_TOUCHED_ORDERS, "Solution exceeds MAX_TOUCHED_ORDERS");
         undoPreviousSolution(batchIndex);
         updateCurrentPrices(prices, tokenIdsForPrice);
@@ -389,15 +390,6 @@ contract StablecoinConverter is EpochTokenLocker {
 
     function checkOrderValidity(Order memory order, uint batchIndex) private pure returns (bool) {
         return order.validFrom <= batchIndex && order.validUntil >= batchIndex;
-    }
-
-    function checkPriceOrdering(uint16[] memory tokenIdsForPrice) private pure returns (bool) {
-        for (uint i = 1; i < tokenIdsForPrice.length; i++) {
-            if (tokenIdsForPrice[i] <= tokenIdsForPrice[i - 1]) {
-                return false;
-            }
-        }
-        return true;
     }
 
     function encodeAuctionElement(

--- a/contracts/libraries/TokenConservation.sol
+++ b/contracts/libraries/TokenConservation.sol
@@ -28,6 +28,15 @@ library TokenConservation {
         }
     }
 
+    function checkPriceOrdering(uint16[] memory self) internal pure returns (bool) {
+        for (uint i = 1; i < self.length; i++) {
+            if (self[i] <= self[i - 1]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     function findPriceIndex(uint16 index, uint16[] memory tokenIdForPrice) private pure returns (uint) {
         // binary search for the other tokens
         uint leftValue = 0;

--- a/contracts/test/TokenConservationWrapper.sol
+++ b/contracts/test/TokenConservationWrapper.sol
@@ -5,6 +5,7 @@ import "../libraries/TokenConservation.sol";
 
 contract TokenConservationWrapper {
     using TokenConservation for int[];
+    using TokenConservation for uint16[];
 
     function updateTokenConservationTest(
         int[] memory testInstance,
@@ -28,5 +29,11 @@ contract TokenConservationWrapper {
         int[] memory testInstance
     ) public pure {
         testInstance.checkTokenConservation();
+    }
+
+    function checkPriceOrdering(
+        uint16[] memory self
+    ) public pure returns(bool) {
+        return self.checkPriceOrdering();
     }
 }

--- a/test/stablex_token_checker.js
+++ b/test/stablex_token_checker.js
@@ -20,6 +20,25 @@ contract("TokenConservation", async () => {
     })
   })
 
+  describe("checkPriceOrdering()", () => {
+    it("returns false when unordered", async () => {
+      const tokenConservation = await TokenConservationWrapper.new()
+      assert.equal(await tokenConservation.checkPriceOrdering([1, 0]), false, "Failed on [1, 0]")
+      assert.equal(await tokenConservation.checkPriceOrdering([1, 3, 2]), false, "Failed on [1, 3, 2]")
+    })
+    it("returns false when not unique", async () => {
+      const tokenConservation = await TokenConservationWrapper.new()
+      assert.equal(await tokenConservation.checkPriceOrdering([1, 1]), false, "Failed on [1, 1]")
+    })
+    it("returns true when ordered", async () => {
+      const tokenConservation = await TokenConservationWrapper.new()
+      assert.equal(await tokenConservation.checkPriceOrdering([0, 1]), true, "Failed on [0, 1]")
+      assert.equal(await tokenConservation.checkPriceOrdering([1, 2, 3]), true, "Failed on [1, 2, 3]")
+    })
+
+
+  })
+
   describe("updateTokenConservation()", () => {
     it("calculates the updated tokenConservation array", async () => {
       const tokenConservation = await TokenConservationWrapper.new()


### PR DESCRIPTION
This started, at first, as a simply moving the `checkPriceOrdering` into the appropriate/relevant library where it is used but I soon realized that there was a bug involving non-uniqueness of tokens. ~This was easily fixed by making the weak inequality into a strict one and the world was at peace!~

Sorry that inequality was not changed, it was already ensuring non-uniqueness.

Closes #268

