### PR TITLE
[Easy] Allow for specified validFrom on order placement

### DIFF
--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -72,9 +72,10 @@ contract StablecoinConverter is EpochTokenLocker {
         numTokens++;
     }
 
-    function placeOrder(
+    function placeValidFromOrder(
         uint16 buyToken,
         uint16 sellToken,
+        uint32 validFrom,
         uint32 validUntil,
         uint128 buyAmount,
         uint128 sellAmount
@@ -82,7 +83,7 @@ contract StablecoinConverter is EpochTokenLocker {
         orders[msg.sender].push(Order({
             buyToken: buyToken,
             sellToken: sellToken,
-            validFrom: getCurrentBatchId(),
+            validFrom: validFrom,
             validUntil: validUntil,
             priceNumerator: buyAmount,
             priceDenominator: sellAmount,
@@ -92,13 +93,23 @@ contract StablecoinConverter is EpochTokenLocker {
             msg.sender,
             buyToken,
             sellToken,
-            getCurrentBatchId(),
+            validFrom,
             validUntil,
             buyAmount,
             sellAmount
         );
         allUsers.insert(msg.sender);
         return orders[msg.sender].length - 1;
+    }
+
+    function placeOrder(
+        uint16 buyToken,
+        uint16 sellToken,
+        uint32 validUntil,
+        uint128 buyAmount,
+        uint128 sellAmount
+    ) public returns (uint) {
+        return placeValidFromOrder(buyToken, sellToken, getCurrentBatchId(), validUntil, buyAmount, sellAmount);
     }
 
     function cancelOrder(

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -71,6 +71,23 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((orderResult.validUntil).toNumber(), 3, "validUntil was stored incorrectly")
     })
   })
+  describe("placeValidFromOrder()", () => {
+    it("places order with sepcified validFrom", async () => {
+      const feeToken = await MockContract.new()
+      const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)
+
+      const id = await stablecoinConverter.placeValidFromOrder.call(0, 1, 20, 3, 10, 20, { from: user_1 })
+      await stablecoinConverter.placeValidFromOrder(0, 1, 20, 3, 10, 20, { from: user_1 })
+      const orderResult = (await stablecoinConverter.orders.call(user_1, id))
+      assert.equal((orderResult.priceDenominator).toNumber(), 20, "priceDenominator was stored incorrectly")
+      assert.equal((orderResult.priceNumerator).toNumber(), 10, "priceNumerator was stored incorrectly")
+      assert.equal((orderResult.sellToken).toNumber(), 1, "sellToken was stored incorrectly")
+      assert.equal((orderResult.buyToken).toNumber(), 0, "buyToken was stored incorrectly")
+      // Note that this order will be stored, but never valid. However, this can not affect the exchange in any maliciouis way!
+      assert.equal((orderResult.validFrom).toNumber(), 20, "validFrom was stored incorrectly")
+      assert.equal((orderResult.validUntil).toNumber(), 3, "validUntil was stored incorrectly")
+    })
+  })
   describe("cancelOrder()", () => {
     it("places orders, then cancels it and orders status", async () => {
       const feeToken = await MockContract.new()


### PR DESCRIPTION
Introduced new function with the following signature
```js
    function placeValidFromOrder(
        uint16 buyToken,
        uint16 sellToken,
        uint32 validFrom,  <------NOTE: this is new!
        uint32 validUntil,
        uint128 buyAmount,
        uint128 sellAmount
    ) public returns (uint) {
```
while keeping the old  `placeOrder` which is now simplified to call `placeValidFromOrder` with `validFrom = getCurrentBatchId()`.

Closes #262


**Test plan** Unit tests.