### PR TITLE
[Easy] allow specified batchId on withdraw requests

### DIFF
--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -62,12 +62,17 @@ contract EpochTokenLocker {
     }
 
     function requestWithdraw(address token, uint amount) public {
+        requestFutureWithdraw(token, amount, getCurrentBatchId());
+    }
+
+    function requestFutureWithdraw(address token, uint amount, uint batchId) public {
         // first process old pendingWithdraw, as otherwise balances might increase for currentBatchId - 1
         if (hasValidWithdrawRequest(msg.sender, token)) {
             withdraw(msg.sender, token);
         }
-        balanceStates[msg.sender][token].pendingWithdraws = PendingFlux({ amount: amount, stateIndex: getCurrentBatchId() });
-        emit WithdrawRequest(msg.sender, token, amount, getCurrentBatchId());
+        require(batchId >= getCurrentBatchId(), "Request cannot be made in the past");
+        balanceStates[msg.sender][token].pendingWithdraws = PendingFlux({ amount: amount, stateIndex: batchId });
+        emit WithdrawRequest(msg.sender, token, amount, batchId);
     }
 
     function withdraw(address user, address token) public {

--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -65,7 +65,7 @@ contract EpochTokenLocker {
         requestFutureWithdraw(token, amount, getCurrentBatchId());
     }
 
-    function requestFutureWithdraw(address token, uint amount, uint batchId) public {
+    function requestFutureWithdraw(address token, uint amount, uint32 batchId) public {
         // first process old pendingWithdraw, as otherwise balances might increase for currentBatchId - 1
         if (hasValidWithdrawRequest(msg.sender, token)) {
             withdraw(msg.sender, token);


### PR DESCRIPTION
User can now specify withdraw requests for a future batch. This would/could be useful when trying to execute a sequence of `deposit, placeOrder, requestWithdraw` in a single transaction.

Note that, for backwards compatibility, the originial `requestWithdraw` function remains with its original parameters, but now (internally) makes a call to `requestFutureWithdraw` with `batchId = getCurrentBatchId()`

Closes #260 

**TestPlan** Unit tests.