### PR TITLE
Be more explicit about integer width

### DIFF
--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -12,26 +12,26 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
  *  @author @gnosis/dfusion-team <https://github.com/orgs/gnosis/teams/dfusion-team/members>
  */
 contract EpochTokenLocker {
-    using SafeMath for uint;
+    using SafeMath for uint256;
 
     event Deposit(
         address user,
         address token,
-        uint amount,
-        uint stateIndex
+        uint256 amount,
+        uint256 stateIndex
     );
 
     event WithdrawRequest(
         address user,
         address token,
-        uint amount,
-        uint stateIndex
+        uint256 amount,
+        uint256 stateIndex
     );
 
     event Withdraw(
         address user,
         address token,
-        uint amount
+        uint256 amount
     );
 
     uint32 constant public BATCH_TIME = 300;
@@ -39,7 +39,7 @@ contract EpochTokenLocker {
     mapping(address => mapping(address => BalanceState)) private balanceStates;
 
     // user => token => lastCreditBatchId
-    mapping(address => mapping (address => uint)) public lastCreditBatchId;
+    mapping(address => mapping (address => uint256)) public lastCreditBatchId;
 
     struct BalanceState {
         uint256 balance;
@@ -61,7 +61,7 @@ contract EpochTokenLocker {
       * Requirements:
       * - token transfer to contract is successfull
       */
-    function deposit(address token, uint amount) public {
+    function deposit(address token, uint256 amount) public {
         updateDepositsBalance(msg.sender, token);
         require(
             ERC20(token).transferFrom(msg.sender, address(this), amount),
@@ -79,7 +79,7 @@ contract EpochTokenLocker {
       *
       * Emits an {WithdrawRequest} event with relevent request information.
       */
-    function requestWithdraw(address token, uint amount) public {
+    function requestWithdraw(address token, uint256 amount) public {
         requestFutureWithdraw(token, amount, getCurrentBatchId());
     }
 
@@ -90,7 +90,7 @@ contract EpochTokenLocker {
       *
       * Emits an {WithdrawRequest} event with relevent request information.
       */
-    function requestFutureWithdraw(address token, uint amount, uint32 batchId) public {
+    function requestFutureWithdraw(address token, uint256 amount, uint32 batchId) public {
         // First process pendingWithdraw (if any), as otherwise balances might increase for currentBatchId - 1
         if (hasValidWithdrawRequest(msg.sender, token)) {
             withdraw(msg.sender, token);
@@ -120,7 +120,7 @@ contract EpochTokenLocker {
             lastCreditBatchId[msg.sender][token] < getCurrentBatchId(),
             "Withdraw not possible for token that is traded in the current auction"
         );
-        uint amount = Math.min(
+        uint256 amount = Math.min(
             balanceStates[user][token].balance,
             balanceStates[msg.sender][token].pendingWithdraws.amount
         );
@@ -140,7 +140,7 @@ contract EpochTokenLocker {
       * @param token address of ERC20 token
       * return amount of pending deposit if any (else 0)
       */
-    function getPendingDepositAmount(address user, address token) public view returns(uint) {
+    function getPendingDepositAmount(address user, address token) public view returns(uint256) {
         return balanceStates[user][token].pendingDeposits.amount;
     }
 
@@ -149,7 +149,7 @@ contract EpochTokenLocker {
       * @param token address of ERC20 token
       * return stateIndex of deposit's transfer
       */
-    function getPendingDepositBatchNumber(address user, address token) public view returns(uint) {
+    function getPendingDepositBatchNumber(address user, address token) public view returns(uint256) {
         return balanceStates[user][token].pendingDeposits.stateIndex;
     }
 
@@ -158,7 +158,7 @@ contract EpochTokenLocker {
       * @param token address of ERC20 token
       * return stateIndex when withdraw was requested
       */
-    function getPendingWithdrawAmount(address user, address token) public view returns(uint) {
+    function getPendingWithdrawAmount(address user, address token) public view returns(uint256) {
         return balanceStates[user][token].pendingWithdraws.amount;
     }
 
@@ -167,7 +167,7 @@ contract EpochTokenLocker {
       * @param token address of ERC20 token
       * return stateIndex at time of withdraw's request
       */
-    function getPendingWithdrawBatchNumber(address user, address token) public view returns(uint) {
+    function getPendingWithdrawBatchNumber(address user, address token) public view returns(uint256) {
         return balanceStates[user][token].pendingWithdraws.stateIndex;
     }
 
@@ -181,7 +181,7 @@ contract EpochTokenLocker {
     /** @dev used to determine how much time is left in a batch
       * return seconds remaining in current batch
       */
-    function getSecondsRemainingInBatch() public view returns(uint) {
+    function getSecondsRemainingInBatch() public view returns(uint256) {
         return BATCH_TIME - (now % BATCH_TIME);
     }
 
@@ -191,7 +191,7 @@ contract EpochTokenLocker {
       * return Current `token` balance of `user`'s account
       */
     function getBalance(address user, address token) public view returns(uint256) {
-        uint balance = balanceStates[user][token].balance;
+        uint256 balance = balanceStates[user][token].balance;
         if (balanceStates[user][token].pendingDeposits.stateIndex < getCurrentBatchId()) {
             balance = balance.add(balanceStates[user][token].pendingDeposits.amount);
         }
@@ -222,19 +222,19 @@ contract EpochTokenLocker {
      * by setting lastCreditBatchId to the current batchId and allow only withdraws in batches
      * with a higher batchId.
      */
-    function addBalanceAndBlockWithdrawForThisBatch(address user, address token, uint amount) internal {
+    function addBalanceAndBlockWithdrawForThisBatch(address user, address token, uint256 amount) internal {
         if (hasValidWithdrawRequest(user, token)) {
             lastCreditBatchId[user][token] = getCurrentBatchId();
         }
         addBalance(user, token, amount);
     }
 
-    function addBalance(address user, address token, uint amount) internal {
+    function addBalance(address user, address token, uint256 amount) internal {
         updateDepositsBalance(user, token);
         balanceStates[user][token].balance = balanceStates[user][token].balance.add(amount);
     }
 
-    function subtractBalance(address user, address token, uint amount) internal {
+    function subtractBalance(address user, address token, uint256 amount) internal {
         updateDepositsBalance(user, token);
         balanceStates[user][token].balance = balanceStates[user][token].balance.sub(amount);
     }

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -21,8 +21,6 @@ contract StablecoinConverter is EpochTokenLocker {
     using TokenConservation for uint16[];
     using IterableAppendOnlySet for IterableAppendOnlySet.Data;
 
-    uint128 constant private MAX_UINT128 = 2**128 - 1;
-
     // Iterable set of all users, required to collect auction information
     IterableAppendOnlySet.Data private allUsers;
     IdToAddressBiMap.Data private registeredTokens;

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -13,7 +13,7 @@ import "./libraries/TokenConservation.sol";
  *  @author @gnosis/dfusion-team <https://github.com/orgs/gnosis/teams/dfusion-team/members>
  */
 contract StablecoinConverter is EpochTokenLocker {
-    using SafeCast for uint;
+    using SafeCast for uint256;
     using SafeMath for uint128;
     using BytesLib for bytes32;
     using BytesLib for bytes;
@@ -21,21 +21,21 @@ contract StablecoinConverter is EpochTokenLocker {
     using TokenConservation for uint16[];
     using IterableAppendOnlySet for IterableAppendOnlySet.Data;
 
-    uint constant private MAX_UINT128 = 2**128 - 1;
+    uint128 constant private MAX_UINT128 = 2**128 - 1;
 
     // Iterable set of all users, required to collect auction information
     IterableAppendOnlySet.Data private allUsers;
     IdToAddressBiMap.Data private registeredTokens;
 
     /** @dev Maximum number of touched orders in auction (used in submitSolution) */
-    uint constant public MAX_TOUCHED_ORDERS = 25;
+    uint256 constant public MAX_TOUCHED_ORDERS = 25;
 
     /** @dev Fee charged for adding a token) */
-    uint constant public TOKEN_ADDITION_FEE_IN_OWL = 10 ether;
+    uint256 constant public TOKEN_ADDITION_FEE_IN_OWL = 10 ether;
 
     /** @dev maximum number of tokens that can be listed for exchange */
     // solhint-disable-next-line var-name-mixedcase
-    uint public MAX_TOKENS;
+    uint256 public MAX_TOKENS;
 
     /** @dev Current number of tokens listed/available for exchange */
     uint16 public numTokens;
@@ -61,7 +61,7 @@ contract StablecoinConverter is EpochTokenLocker {
         uint16[] tokenIdsForPrice;
         address solutionSubmitter;
         uint256 feeReward;
-        uint objectiveValue;
+        uint256 objectiveValue;
     }
 
     event OrderPlacement(
@@ -76,7 +76,7 @@ contract StablecoinConverter is EpochTokenLocker {
 
     event OrderCancelation(
         address owner,
-        uint id
+        uint256 id
     );
 
     struct Order {
@@ -100,7 +100,7 @@ contract StablecoinConverter is EpochTokenLocker {
       * @param _feeDenominator fee as a proportion is (1 / feeDenominator)
       * @param _feeToken Address of ERC20 fee token.
       */
-    constructor(uint maxTokens, uint128 _feeDenominator, address _feeToken) public {
+    constructor(uint256 maxTokens, uint128 _feeDenominator, address _feeToken) public {
         MAX_TOKENS = maxTokens;
         feeToken = TokenOWL(_feeToken);
         feeDenominator = _feeDenominator;
@@ -145,7 +145,7 @@ contract StablecoinConverter is EpochTokenLocker {
         uint32 validUntil,
         uint128 buyAmount,
         uint128 sellAmount
-    ) public returns (uint) {
+    ) public returns (uint256) {
         orders[msg.sender].push(Order({
             buyToken: buyToken,
             sellToken: sellToken,
@@ -184,7 +184,7 @@ contract StablecoinConverter is EpochTokenLocker {
         uint32 validUntil,
         uint128 buyAmount,
         uint128 sellAmount
-    ) public returns (uint) {
+    ) public returns (uint256) {
         return placeValidFromOrder(buyToken, sellToken, getCurrentBatchId(), validUntil, buyAmount, sellAmount);
     }
 
@@ -193,7 +193,7 @@ contract StablecoinConverter is EpochTokenLocker {
       *
       * Emits an {OrderCancelation} with sender's address and orderId
       */
-    function cancelOrder(uint id) public {
+    function cancelOrder(uint256 id) public {
         orders[msg.sender][id].validUntil = getCurrentBatchId() - 1;
         emit OrderCancelation(msg.sender, id);
     }
@@ -205,8 +205,8 @@ contract StablecoinConverter is EpochTokenLocker {
       * Requirements:
       * - Each requested order is expired
       */
-    function freeStorageOfOrder(uint[] memory ids) public {
-        for (uint i = 0; i < ids.length; i++) {
+    function freeStorageOfOrder(uint256[] memory ids) public {
+        for (uint256 i = 0; i < ids.length; i++) {
             require(orders[msg.sender][ids[i]].validUntil + 1 < getCurrentBatchId(), "Order is still valid");
             delete orders[msg.sender][ids[i]];
         }
@@ -250,8 +250,8 @@ contract StablecoinConverter is EpochTokenLocker {
         updateCurrentPrices(prices, tokenIdsForPrice);
         delete latestSolution.trades;
         int[] memory tokenConservation = new int[](prices.length);
-        uint utility = 0;
-        for (uint i = 0; i < owners.length; i++) {
+        uint256 utility = 0;
+        for (uint256 i = 0; i < owners.length; i++) {
             Order memory order = orders[owners[i]][orderIds[i]];
             require(checkOrderValidity(order, batchIndex), "Order is invalid");
             (uint128 executedBuyAmount, uint128 executedSellAmount) = getTradedAmounts(volumes[i], order);
@@ -275,7 +275,7 @@ contract StablecoinConverter is EpochTokenLocker {
             addBalanceAndBlockWithdrawForThisBatch(owners[i], tokenIdToAddressMap(order.buyToken), executedBuyAmount);
         }
         // doing all subtractions after all additions (in order to avoid negative values)
-        for (uint i = 0; i < owners.length; i++) {
+        for (uint256 i = 0; i < owners.length; i++) {
             (, uint128 executedSellAmount) = getTradedAmounts(
                 volumes[i],
                 orders[owners[i]][orderIds[i]]
@@ -286,13 +286,13 @@ contract StablecoinConverter is EpochTokenLocker {
                 executedSellAmount
             );
         }
-        uint disregardedUtility = 0;
-        for (uint i = 0; i < owners.length; i++) {
+        uint256 disregardedUtility = 0;
+        for (uint256 i = 0; i < owners.length; i++) {
             disregardedUtility = disregardedUtility.add(
                 evaluateDisregardedUtility(orders[owners[i]][orderIds[i]], owners[i])
             );
         }
-        uint burntFees = uint(tokenConservation[0]) / 2;
+        uint256 burntFees = uint256(tokenConservation[0]) / 2;
         require(utility + burntFees > disregardedUtility, "Solution must be better than trivial");
         // burntFees ensures direct trades (when available) yield better solutions than longer rings
         checkAndOverrideObjectiveValue(utility - disregardedUtility + burntFees);
@@ -328,7 +328,7 @@ contract StablecoinConverter is EpochTokenLocker {
             address user = allUsers.first();
             bool stop = false;
             while (!stop) {
-                for (uint i = 0; i < orders[user].length; i++) {
+                for (uint256 i = 0; i < orders[user].length; i++) {
                     Order memory order = orders[user][i];
                     elements = elements.concat(encodeAuctionElement(
                         user,
@@ -349,7 +349,7 @@ contract StablecoinConverter is EpochTokenLocker {
     /** @dev gets the objective value of currently winning solution.
       * @return objective function evaluation of the currently winning solution, or zero if no solution proposed.
       */
-    function getCurrentObjectiveValue() public view returns(uint) {
+    function getCurrentObjectiveValue() public view returns(uint256) {
         if (latestSolution.batchId == getCurrentBatchId() - 1) {
             return latestSolution.objectiveValue;
         } else {
@@ -363,7 +363,7 @@ contract StablecoinConverter is EpochTokenLocker {
     /** @dev called at the end of submitSolution with a value of tokenConservation / 2
       * @param feeReward amount to be rewarded to the solver
       */
-    function grantRewardToSolutionSubmitter(uint feeReward) internal {
+    function grantRewardToSolutionSubmitter(uint256 feeReward) internal {
         latestSolution.feeReward = feeReward;
         addBalanceAndBlockWithdrawForThisBatch(msg.sender, tokenIdToAddressMap(0), feeReward);
     }
@@ -376,10 +376,10 @@ contract StablecoinConverter is EpochTokenLocker {
         uint128[] memory prices,
         uint16[] memory tokenIdsForPrice
     ) internal {
-        for (uint i = 0; i < latestSolution.tokenIdsForPrice.length; i++) {
+        for (uint256 i = 0; i < latestSolution.tokenIdsForPrice.length; i++) {
             currentPrices[latestSolution.tokenIdsForPrice[i]] = 0;
         }
-        for (uint i = 0; i < tokenIdsForPrice.length; i++) {
+        for (uint256 i = 0; i < tokenIdsForPrice.length; i++) {
             currentPrices[tokenIdsForPrice[i]] = prices[i];
         }
     }
@@ -391,7 +391,7 @@ contract StablecoinConverter is EpochTokenLocker {
       */
     function updateRemainingOrder(
         address owner,
-        uint orderId,
+        uint256 orderId,
         uint128 executedAmount
     ) internal {
         orders[owner][orderId].remainingAmount = orders[owner][orderId].remainingAmount.sub(executedAmount).toUint128();
@@ -404,7 +404,7 @@ contract StablecoinConverter is EpochTokenLocker {
       */
     function revertRemainingOrder(
         address owner,
-        uint orderId,
+        uint256 orderId,
         uint128 executedAmount
     ) internal {
         orders[owner][orderId].remainingAmount = orders[owner][orderId].remainingAmount.add(executedAmount).toUint128();
@@ -425,7 +425,7 @@ contract StablecoinConverter is EpochTokenLocker {
         uint16[] memory tokenIdsForPrice
     ) internal {
         latestSolution.batchId = batchIndex;
-        for (uint i = 0; i < owners.length; i++) {
+        for (uint256 i = 0; i < owners.length; i++) {
             latestSolution.trades.push(TradeData({
                 owner: owners[i],
                 orderId: orderIds[i],
@@ -441,16 +441,16 @@ contract StablecoinConverter is EpochTokenLocker {
       */
     function undoCurrentSolution(uint32 batchIndex) internal {
         if (latestSolution.batchId == batchIndex) {
-            for (uint i = 0; i < latestSolution.trades.length; i++) {
+            for (uint256 i = 0; i < latestSolution.trades.length; i++) {
                 address owner = latestSolution.trades[i].owner;
-                uint orderId = latestSolution.trades[i].orderId;
+                uint256 orderId = latestSolution.trades[i].orderId;
                 Order memory order = orders[owner][orderId];
                 (, uint128 sellAmount) = getTradedAmounts(latestSolution.trades[i].volume, order);
                 addBalance(owner, tokenIdToAddressMap(order.sellToken), sellAmount);
             }
-            for (uint i = 0; i < latestSolution.trades.length; i++) {
+            for (uint256 i = 0; i < latestSolution.trades.length; i++) {
                 address owner = latestSolution.trades[i].owner;
-                uint orderId = latestSolution.trades[i].orderId;
+                uint256 orderId = latestSolution.trades[i].orderId;
                 Order memory order = orders[owner][orderId];
                 (uint128 buyAmount, uint128 sellAmount) = getTradedAmounts(latestSolution.trades[i].volume, order);
                 revertRemainingOrder(owner, orderId, sellAmount);
@@ -471,7 +471,7 @@ contract StablecoinConverter is EpochTokenLocker {
       * @param order the sell order whose utility is being evaluated
       * @return Utility = ((execBuy * order.sellAmt - execSell * order.buyAmt) * price.buyToken) / order.sellAmt
       */
-    function evaluateUtility(uint128 execBuy, Order memory order) internal view returns(uint128) {
+    function evaluateUtility(uint128 execBuy, Order memory order) internal view returns(uint256) {
         // Utility = ((execBuy * order.sellAmt - execSell * order.buyAmt) * price.buyToken) / order.sellAmt
         uint256 execSell = getExecutedSellAmount(
             execBuy,
@@ -479,7 +479,7 @@ contract StablecoinConverter is EpochTokenLocker {
             currentPrices[order.sellToken]
         );
         return execBuy.sub(execSell.mul(order.priceNumerator)
-            .div(order.priceDenominator)).mul(currentPrices[order.buyToken]).toUint128();
+            .div(order.priceDenominator)).mul(currentPrices[order.buyToken]);
     }
 
     /** @dev computes a measure of how much of an order was disregarded (only valid when limit price is respected)
@@ -493,14 +493,14 @@ contract StablecoinConverter is EpochTokenLocker {
       * Balances and orders have all been updated so: sellAmount - execSellAmt == order.remainingAmount.
       * For correctness, we take the minimum of this with the user's token balance.
       */
-    function evaluateDisregardedUtility(Order memory order, address user) internal view returns(uint128) {
+    function evaluateDisregardedUtility(Order memory order, address user) internal view returns(uint256) {
         uint256 leftoverSellAmount = Math.min(
             uint256(order.remainingAmount),
             getBalance(user, tokenIdToAddressMap(order.sellToken))
         );
         uint256 limitTerm = currentPrices[order.sellToken].mul(order.priceDenominator)
             .sub(currentPrices[order.buyToken].mul(order.priceNumerator));
-        return leftoverSellAmount.mul(limitTerm).div(order.priceDenominator).toUint128();
+        return leftoverSellAmount.mul(limitTerm).div(order.priceDenominator);
     }
 
     /** @dev Evaluates executedBuy amount based on prices and executedBuyAmout (fees included)
@@ -564,7 +564,7 @@ contract StablecoinConverter is EpochTokenLocker {
       * @param batchIndex auction index of validity
       * @return true if order is valid in auction batchIndex else false
       */
-    function checkOrderValidity(Order memory order, uint batchIndex) private pure returns (bool) {
+    function checkOrderValidity(Order memory order, uint256 batchIndex) private pure returns (bool) {
         return order.validFrom <= batchIndex && order.validUntil >= batchIndex;
     }
 


### PR DESCRIPTION
Using int instead of uint256 can be confusing (especially since we use different width generously in our smart contracts).

E.g. #277 noticed that we are downcasting a uint256 to u128 although the value it gets assigned to is of type uint.

This PR changes all uses of uint to uint256 and also removes the unnecessary downcast.

### Test Plan

CI