### PR TITLE
[PoC] `submitSolution` should return the computed objective value

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -15,7 +15,7 @@
         ],
         "function-max-lines": [
             "error",
-            60
+            57
         ],
         "max-states-count": [
             "error",

--- a/.solhint.json
+++ b/.solhint.json
@@ -15,7 +15,7 @@
         ],
         "function-max-lines": [
             "error",
-            57
+            60
         ],
         "max-states-count": [
             "error",

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -293,11 +293,12 @@ contract StablecoinConverter is EpochTokenLocker {
         uint256 burntFees = uint256(tokenConservation[0]) / 2;
         require(utility + burntFees > disregardedUtility, "Solution must be better than trivial");
         // burntFees ensures direct trades (when available) yield better solutions than longer rings
-        checkAndOverrideObjectiveValue(utility - disregardedUtility + burntFees);
+        uint256 objectiveValue = utility - disregardedUtility + burntFees;
+        checkAndOverrideObjectiveValue(objectiveValue);
         grantRewardToSolutionSubmitter(burntFees);
         tokenConservation.checkTokenConservation();
         documentTrades(batchIndex, owners, orderIds, volumes, tokenIdsForPrice);
-        return (latestSolution.objectiveValue);
+        return (objectiveValue);
     }
     /**
      * Public View Methods

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -291,7 +291,7 @@ contract StablecoinConverter is EpochTokenLocker {
             disregardedUtility = disregardedUtility.add(evaluateDisregardedUtility(orders[owners[i]][orderIds[i]], owners[i]));
         }
         uint256 burntFees = uint256(tokenConservation[0]) / 2;
-        require(utility + burntFees > disregardedUtility, "Solution must be better than trivial");
+        require(utility.add(burntFees) > disregardedUtility, "Solution must be better than trivial");
         // burntFees ensures direct trades (when available) yield better solutions than longer rings
         uint256 objectiveValue = utility - disregardedUtility + burntFees;
         checkAndOverrideObjectiveValue(objectiveValue);

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -219,6 +219,7 @@ contract StablecoinConverter is EpochTokenLocker {
       * @param volumes executed buy amounts for each order identified by index of owner-orderId arrays
       * @param prices list of prices for touched tokens indexed by next parameter
       * @param tokenIdsForPrice price[i] is the price for the token with tokenID tokenIdsForPrice[i]
+      * @return the computed objective value of the solution
       *
       * Requirements:
       * - Solutions for this `batchIndex` are currently being accepted.
@@ -242,7 +243,7 @@ contract StablecoinConverter is EpochTokenLocker {
         uint128[] memory volumes,
         uint128[] memory prices,
         uint16[] memory tokenIdsForPrice
-    ) public {
+    ) public returns (uint256) {
         require(acceptingSolutions(batchIndex), "Solutions are no longer accepted for this batch");
         require(claimedObjectiveValue > getCurrentObjectiveValue(), "Claimed objective is not more than current solution");
         require(tokenIdsForPrice[0] == 0, "fee token price has to be specified");
@@ -296,6 +297,7 @@ contract StablecoinConverter is EpochTokenLocker {
         grantRewardToSolutionSubmitter(burntFees);
         tokenConservation.checkTokenConservation();
         documentTrades(batchIndex, owners, orderIds, volumes, tokenIdsForPrice);
+        return (latestSolution.objectiveValue);
     }
     /**
      * Public View Methods

--- a/test/epoch_token_locker.js
+++ b/test/epoch_token_locker.js
@@ -16,7 +16,7 @@ contract("EpochTokenLocker", async (accounts) => {
     BATCH_TIME = (await instance.BATCH_TIME.call()).toNumber()
   })
 
-  describe("deposit", () => {
+  describe("deposit()", () => {
     it("processes a deposit and stores it in the pendingDeposits", async () => {
       const epochTokenLocker = await EpochTokenLocker.new()
       const ERC20 = await MockContract.new()
@@ -62,7 +62,7 @@ contract("EpochTokenLocker", async (accounts) => {
       assert.equal((await epochTokenLocker.getPendingDepositBatchNumber(user_1, ERC20.address)).toNumber(), currentStateIndex.toNumber())
     })
   })
-  describe("requestWithdraw", () => {
+  describe("requestWithdraw()", () => {
     it("processes a withdraw request", async () => {
       const epochTokenLocker = await EpochTokenLocker.new()
       const ERC20 = await MockContract.new()
@@ -110,7 +110,7 @@ contract("EpochTokenLocker", async (accounts) => {
       assert.equal((await epochTokenLocker.getPendingWithdrawBatchNumber(user_1, ERC20.address)).toNumber(), currentStateIndex + 1)
     })
   })
-  describe("withdraw", () => {
+  describe("withdraw()", () => {
     it("processes a deposit, then processes a withdraw request and withdraws in next stateIndex", async () => {
       const epochTokenLocker = await EpochTokenLocker.new()
       const ERC20 = await MockContract.new()
@@ -177,7 +177,7 @@ contract("EpochTokenLocker", async (accounts) => {
       )
     })
   })
-  describe("getBalance", () => {
+  describe("getBalance()", () => {
     it("returns just the balance, if there are no pending deposits and withdraws", async () => {
       const epochTokenLocker = await EpochTokenLocker.new()
       const ERC20 = await MockContract.new()
@@ -235,7 +235,7 @@ contract("EpochTokenLocker", async (accounts) => {
       assert.equal(await epochTokenLocker.getBalance.call(user_1, ERC20.address), 100)
     })
   })
-  describe("addBalance", () => {
+  describe("addBalance()", () => {
     it("modifies the balance by adding", async () => {
       const epochTokenLocker = await EpochTokenLockerTestInterface.new()
       const ERC20 = await MockContract.new()
@@ -245,7 +245,7 @@ contract("EpochTokenLocker", async (accounts) => {
       assert.equal(await epochTokenLocker.getBalance(user_1, ERC20.address), 100)
     })
   })
-  describe("addBalanceAndBlockWithdrawForThisBatch", () => {
+  describe("addBalanceAndBlockWithdrawForThisBatch()", () => {
     it("does not postpone a withdrawRequest for a future epoch", async () => {
       const epochTokenLocker = await EpochTokenLockerTestInterface.new()
       const ERC20 = await MockContract.new()
@@ -271,7 +271,7 @@ contract("EpochTokenLocker", async (accounts) => {
       assert.equal((await epochTokenLocker.getPendingWithdrawBatchNumber(user_1, ERC20.address)).toNumber(), currentStateIndex.toString(), "PendingWithdrawBatchNumber not set correctly")
     })
   })
-  describe("subtractBalance", () => {
+  describe("subtractBalance()", () => {
     it("modifies the balance by subtraction", async () => {
       const epochTokenLocker = await EpochTokenLockerTestInterface.new()
       const ERC20 = await MockContract.new()

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -331,7 +331,7 @@ contract("StablecoinConverter", async (accounts) => {
 
       assert(objectiveValue > 0, "the computed objective value is greater than 0")
       assert.equal(objectiveValue, solution.objectiveValue.toString())
-   })
+    })
     it("[Basic Trade] places two orders and matches them in a solution with Utility > 0", async () => {
       const feeToken = await MockContract.new()
       const stablecoinConverter = await StablecoinConverter.new(2 ** 16 - 1, feeDenominator, feeToken.address)

--- a/test/stablecoin_converter.js
+++ b/test/stablecoin_converter.js
@@ -318,22 +318,19 @@ contract("StablecoinConverter", async (accounts) => {
       await closeAuction(stablecoinConverter)
 
       const solution = basicTradeCase.solutions[0]
-      const volume = solution.buyVolumes
-      const prices = solution.prices
-      const tokenIdsForPrice = solution.tokenIdsForPrice
-
-      await stablecoinConverter.submitSolution.call(
+      const objectiveValue = await stablecoinConverter.submitSolution.call(
         batchIndex,
         solution.objectiveValue,
         solution.owners.map(x => accounts[x]),
         orderIds,
-        volume,
-        prices,
-        tokenIdsForPrice,
+        solution.buyVolumes,
+        solution.prices,
+        solution.tokenIdsForPrice,
         { from: solver }
       )
 
       assert(objectiveValue > 0, "the computed objective value is greater than 0")
+      assert.equal(objectiveValue, solution.objectiveValue.toString())
    })
     it("[Basic Trade] places two orders and matches them in a solution with Utility > 0", async () => {
       const feeToken = await MockContract.new()


### PR DESCRIPTION
Change `submitSolution` to return computed objective value for a given solution. This allows callers to validate solutions without spending gas and compute objective value to be used with the actual submit solution. The new solution submission should look something like this now:
1. call `submitSolution` to get objective value
  - if it reverts, abort solution submission
2. send `submitSolution` transaction to actually commit the solution with objective value from 1
  - contract checks objective value to the latest objective value and reverts right away if it is not good enough (separate PR #221)
3. profit?

closes #286

### Test Plan
CI, new test case added to verify that objective value is being computed and returned.