### PR TITLE
Burn half the fees after auction settles

### DIFF
--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -391,6 +391,8 @@ contract StablecoinConverter is EpochTokenLocker {
       * @param feeReward amount to be rewarded to the solver
       */
     function grantRewardToSolutionSubmitter(uint256 feeReward) internal {
+        // Burn the difference from previous solution
+        feeToken.burnOWL(address(this), feeReward - latestSolution.feeReward);
         latestSolution.feeReward = feeReward;
         addBalanceAndBlockWithdrawForThisBatch(msg.sender, tokenIdToAddressMap(0), feeReward);
     }

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -238,12 +238,12 @@ contract StablecoinConverter is EpochTokenLocker {
         uint16[] memory tokenIdsForPrice
     ) public returns (uint256) {
         require(acceptingSolutions(batchIndex), "Solutions are no longer accepted for this batch");
-        burnPreviousAuctionFees();
         require(claimedObjectiveValue > getCurrentObjectiveValue(), "Claimed objective is not more than current solution");
         require(tokenIdsForPrice[0] == 0, "fee token price has to be specified");
         require(prices[0] == 1 ether, "fee token price must be 10^18");
         require(tokenIdsForPrice.checkPriceOrdering(), "prices are not ordered by tokenId");
         require(owners.length <= MAX_TOUCHED_ORDERS, "Solution exceeds MAX_TOUCHED_ORDERS");
+        burnPreviousAuctionFees();
         undoCurrentSolution();
         updateCurrentPrices(prices, tokenIdsForPrice);
         delete latestSolution.trades;

--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -386,12 +386,12 @@ contract StablecoinConverter is EpochTokenLocker {
         allUsers.insert(msg.sender);
         return orders[msg.sender].length - 1;
     }
-
     /** @dev called at the end of submitSolution with a value of tokenConservation / 2
       * @param feeReward amount to be rewarded to the solver
       */
     function grantRewardToSolutionSubmitter(uint256 feeReward) internal {
-        // Burn the difference from previous solution
+        // Burn the difference from previous solution and this.
+        feeToken.approve(address(this), feeReward - latestSolution.feeReward);
         feeToken.burnOWL(address(this), feeReward - latestSolution.feeReward);
         latestSolution.feeReward = feeReward;
         addBalanceAndBlockWithdrawForThisBatch(msg.sender, tokenIdToAddressMap(0), feeReward);

--- a/test/resources/math.js
+++ b/test/resources/math.js
@@ -216,7 +216,7 @@ function solutionObjectiveValueComputation(orders, solution, strict = true) {
   if (strict) {
     assert(!tokenConservation[0].isNeg(), "fee token conservation is negative")
     tokenConservation.slice(1).forEach(
-      (conservation, i) => assert(conservation.isZero(), `token conservation not respected for token ${i+1}`)
+      (conservation, i) => assert(conservation.isZero(), `token conservation not respected for token ${i + 1}`)
     )
     touchedOrders.forEach(([, id], i) => {
       assert(!utilities[i].isNeg(), `utility for order ${id} is negative`)

--- a/test/stablex/stablecoin_converter.js
+++ b/test/stablex/stablecoin_converter.js
@@ -1307,11 +1307,6 @@ contract("StablecoinConverter", async (accounts) => {
     })
   })
   describe("getEncodedAuctionElements()", async () => {
-    it("returns null when no orders.", async () => {
-      const stablecoinConverter = await setupGenericStableX(3)
-      const auctionElements = await stablecoinConverter.getEncodedAuctionElements()
-      assert(auctionElements === null)
-    })
     it("returns all orders that are have ever been submitted", async () => {
       const stablecoinConverter = await setupGenericStableX(3)
 

--- a/test/stablex/stablecoin_converter.js
+++ b/test/stablex/stablecoin_converter.js
@@ -114,11 +114,11 @@ contract("StablecoinConverter", async (accounts) => {
       const stablecoinConverter = await StablecoinConverter.new(2, feeDenominator, owlProxy.address)
       const token = await ERC20.new()
       await owlProxy.approve(stablecoinConverter.address, owlAmount)
-      assert(owlAmount.eq(await owlProxy.balanceOf.call(user_1)))
-      assert(owlAmount.eq(await owlProxy.allowance.call(user_1, stablecoinConverter.address)))
+      assert(owlAmount.eq(await owlProxy.balanceOf(user_1)))
+      assert(owlAmount.eq(await owlProxy.allowance(user_1, stablecoinConverter.address)))
 
       await stablecoinConverter.addToken(token.address, { from: user_1 })
-      assert(await owlProxy.balanceOf.call(user_1).eq(new BN(0)))
+      assert(await owlProxy.balanceOf(user_1).eq(new BN(0)))
     })
 
     it("throws, if fees are not burned", async () => {

--- a/test/stablex/stablecoin_converter.js
+++ b/test/stablex/stablecoin_converter.js
@@ -496,8 +496,11 @@ contract("StablecoinConverter", async (accounts) => {
       const orderIds = await placeOrders(stablecoinConverter, accounts, basicTrade.orders, batchIndex + 1)
       await closeAuction(stablecoinConverter)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
-      await stablecoinConverter.submitSolution(batchIndex, solution.objectiveValue, solution.owners, solution.touchedOrderIds, solution.volumes, solution.prices, solution.tokenIdsForPrice, { from: solver })
+      const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIds)
+      await stablecoinConverter.submitSolution(batchIndex, partialSolution.objectiveValue, partialSolution.owners, partialSolution.touchedOrderIds, partialSolution.volumes, partialSolution.prices, partialSolution.tokenIdsForPrice, { from: solver })
+
+      const fullSolution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      await stablecoinConverter.submitSolution(batchIndex, fullSolution.objectiveValue, fullSolution.owners, fullSolution.touchedOrderIds, fullSolution.volumes, fullSolution.prices, fullSolution.tokenIdsForPrice, { from: solver })
       await closeAuction(stablecoinConverter)
 
       // Second Auction

--- a/test/stablex/stablecoin_converter.js
+++ b/test/stablex/stablecoin_converter.js
@@ -64,7 +64,6 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((await stablecoinConverter.tokenAddressToIdMap.call(feeToken.address)).toNumber(), 0)
       assert.equal(await stablecoinConverter.tokenIdToAddressMap.call(0), feeToken.address)
     })
-
     it("Anyone can add tokens", async () => {
       const feeToken = await MockContract.new()
       await feeToken.givenAnyReturnBool(true)
@@ -81,7 +80,6 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((await stablecoinConverter.tokenAddressToIdMap.call(token_2.address)).toNumber(), 2)
       assert.equal(await stablecoinConverter.tokenIdToAddressMap.call(2), token_2.address)
     })
-
     it("Rejects same token added twice", async () => {
       const feeToken = await MockContract.new()
       await feeToken.givenAnyReturnBool(true)
@@ -90,7 +88,6 @@ contract("StablecoinConverter", async (accounts) => {
       await stablecoinConverter.addToken(token.address)
       await truffleAssert.reverts(stablecoinConverter.addToken(token.address), "Token already registered")
     })
-
     it("No exceed max tokens", async () => {
       const feeToken = await MockContract.new()
       await feeToken.givenAnyReturnBool(true)
@@ -100,7 +97,6 @@ contract("StablecoinConverter", async (accounts) => {
 
       await truffleAssert.reverts(stablecoinConverter.addToken((await ERC20.new()).address), "Max tokens reached")
     })
-
     it("Burns 10 OWL when adding token", async () => {
       const TokenOWLProxy = artifacts.require("../node_modules/@gnosis.pm/owl-token/build/contracts/TokenOWLProxy")
       const owlToken = await TokenOWL.new()
@@ -118,9 +114,8 @@ contract("StablecoinConverter", async (accounts) => {
       assert(owlAmount.eq(await owlProxy.allowance(user_1, stablecoinConverter.address)))
 
       await stablecoinConverter.addToken(token.address, { from: user_1 })
-      assert(await owlProxy.balanceOf(user_1).eq(new BN(0)))
+      assert((await owlProxy.balanceOf(user_1)).eq(new BN(0)))
     })
-
     it("throws, if fees are not burned", async () => {
       const TokenOWLProxy = artifacts.require("../node_modules/@gnosis.pm/owl-token/build/contracts/TokenOWLProxy")
       const owlToken = await TokenOWL.new()
@@ -137,7 +132,6 @@ contract("StablecoinConverter", async (accounts) => {
       // reverts as owl balance is not sufficient
       await truffleAssert.reverts(stablecoinConverter.addToken(token.address, { from: user_1 }))
     })
-
   })
   describe("placeOrder()", () => {
     it("places order and verifys contract storage is updated correctly", async () => {

--- a/test/stablex/stablecoin_converter.js
+++ b/test/stablex/stablecoin_converter.js
@@ -466,7 +466,7 @@ contract("StablecoinConverter", async (accounts) => {
       assert.equal((await stablecoinConverter.getBalance.call(user_2, erc20_2)).toString(), basicTrade.deposits[1].amount.sub(getExecutedSellAmount(fullBuyVolumes[1], prices[0], prices[1])).toString(), "Sold tokens were not adjusted correctly")
       assert.equal((await stablecoinConverter.getBalance.call(user_2, feeToken)), fullBuyVolumes[1].toString(), "Bought tokens were not adjusted correctly")
     })
-    it("Ensure fee token is burnt as expected", async () => {
+    it("ensures half of the token imbalance (fees) is burned", async () => {
       // Fee token can't be a Mock here.
       const TokenOWLProxy = artifacts.require("../node_modules/@gnosis.pm/owl-token/build/contracts/TokenOWLProxy")
       const owlToken = await TokenOWL.new()

--- a/test/stablex/stablex_utils.js
+++ b/test/stablex/stablex_utils.js
@@ -23,8 +23,9 @@ const {
  */
 const setupGenericStableX = async function (numTokens = 2, maxTokens = 2 ** 16 - 1, feeDenominator = 1000) {
   const feeToken = await MockContract.new()
-  const instance = await StablecoinConverter.new(maxTokens, feeDenominator, feeToken.address)
   await feeToken.givenAnyReturnBool(true)
+
+  const instance = await StablecoinConverter.new(maxTokens, feeDenominator, feeToken.address)
   const tokens = [feeToken]
   for (let i = 0; i < numTokens - 1; i++) {
     const token = await MockContract.new()


### PR DESCRIPTION
 As described in the specification, the auction should burn half of the fee token conservation while rewarding the solver with the other half. This PR implements exactly that. Particularly, the fees are recorded in the solution data, and upon the submission of the next solution (only in a future batch), if the burnable fees from the previous auction have not yet been burnt, they are.

**Test Plan:** See the new unit test which goes through the entire process. That is, 

- One auction passes with a non-trivial solution (`basicTrade`)
- Orders are placed for a later auction and another, valid, non-trivial solution is submitted. 
- burntFees from previous auction are indeed burnt.