### PR TITLE
[Easy] View to fetch all orders by user

### DIFF
--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -324,7 +324,20 @@ contract StablecoinConverter is EpochTokenLocker {
         return IdToAddressBiMap.hasAddress(registeredTokens, addr);
     }
 
-    /** @dev View returning all currently stored, byte-encoded sell orders
+    /** @dev View returning all byte-encoded sell orders for specified user
+      * @param user address of user whose orders are being queried
+      * @return encoded bytes representing all orders
+      */
+    function getEncodedUserOrders(address user) public view returns (bytes memory elements) {
+        for (uint256 i = 0; i < orders[user].length; i++) {
+            elements = elements.concat(
+                encodeAuctionElement(user, getBalance(user, tokenIdToAddressMap(orders[user][i].sellToken)), orders[user][i])
+            );
+        }
+        return elements;
+    }
+
+    /** @dev View returning all byte-encoded sell orders
       * @return encoded bytes representing all orders ordered by (user, index)
       */
     function getEncodedAuctionElements() public view returns (bytes memory elements) {
@@ -332,14 +345,7 @@ contract StablecoinConverter is EpochTokenLocker {
             address user = allUsers.first();
             bool stop = false;
             while (!stop) {
-                for (uint256 i = 0; i < orders[user].length; i++) {
-                    Order memory order = orders[user][i];
-                    elements = elements.concat(encodeAuctionElement(
-                        user,
-                        getBalance(user, tokenIdToAddressMap(order.sellToken)),
-                        order
-                    ));
-                }
+                elements = elements.concat(getEncodedUserOrders(user));
                 if (user == allUsers.last) {
                     stop = true;
                 } else {

--- a/test/stablex/stablecoin_converter.js
+++ b/test/stablex/stablecoin_converter.js
@@ -1314,6 +1314,69 @@ contract("StablecoinConverter", async (accounts) => {
       }
     })
   })
+  describe("getEncodedUserOrders()", async () => {
+    it("returns null when there are no orders", async () => {
+      const stablecoinConverter = await setupGenericStableX()
+      const auctionElements = await stablecoinConverter.getEncodedAuctionElements()
+      assert.equal(auctionElements, null)
+    })
+    it("returns correct orders whether valid, canceled or freed", async () => {
+      const stablecoinConverter = await setupGenericStableX()
+
+      const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
+      const validOrderInfo = {
+        user: user_1.toLowerCase(),
+        sellTokenBalance: 0,
+        buyToken: 1,
+        sellToken: 0,
+        validFrom: batchIndex,
+        validUntil: batchIndex + 10,
+        priceNumerator: 20,
+        priceDenominator: 10,
+        remainingAmount: 10,
+      }
+      const canceledOrderInfo = {
+        user: user_1.toLowerCase(),
+        sellTokenBalance: 0,
+        buyToken: 1,
+        sellToken: 0,
+        validFrom: batchIndex,
+        validUntil: batchIndex - 1,
+        priceNumerator: 20,
+        priceDenominator: 10,
+        remainingAmount: 10,
+      }
+      const freedOrderInfo = {
+        user: user_1.toLowerCase(),
+        sellTokenBalance: 0,
+        buyToken: 0,
+        sellToken: 0,
+        validFrom: 0,
+        validUntil: 0,
+        priceNumerator: 0,
+        priceDenominator: 0,
+        remainingAmount: 0,
+      }
+      // Place 3 valid orders, cancel first two, wait one batch till and free storage of middle order
+      for (let i = 0; i < 3; i++) {
+        await stablecoinConverter.placeOrder(
+          validOrderInfo.buyToken,
+          validOrderInfo.sellToken,
+          validOrderInfo.validUntil,
+          validOrderInfo.priceNumerator,
+          validOrderInfo.priceDenominator
+        )
+      }
+      // 
+      await stablecoinConverter.cancelOrders([0, 1])
+      await waitForNSeconds(BATCH_TIME)
+      await stablecoinConverter.freeStorageOfOrder([1])
+
+
+      const auctionElements = decodeAuctionElements(await stablecoinConverter.getEncodedAuctionElements())
+      assert.deepEqual(auctionElements, [canceledOrderInfo, freedOrderInfo, validOrderInfo])
+    })
+  })
   describe("getEncodedAuctionElements()", async () => {
     it("returns all orders that are have ever been submitted", async () => {
       const stablecoinConverter = await setupGenericStableX(3)
@@ -1372,7 +1435,7 @@ contract("StablecoinConverter", async (accounts) => {
 
       const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
       await stablecoinConverter.placeOrder(1, 0, batchIndex + 10, 20, 10)
-      stablecoinConverter.cancelOrders([0])
+      await stablecoinConverter.cancelOrders([0])
 
       let auctionElements = decodeAuctionElements(await stablecoinConverter.getEncodedAuctionElements())
       assert.equal(auctionElements.length, 1)


### PR DESCRIPTION
As requested by the front end, we introduce a function `getEncodedUserOrders` to easily query for encoded orders by specific user account. These changes actually clean up the contract code for `getEncodedAuctionElements` which can now fetch user orders with this new view.

Please see unit test to know that `null` values are returned when there are no orders and that orders which have been "freed" from storage are **NOT** `null`

**Test Plan** Unit tests