### PR TITLE
[Easy] Fixes Minor Issue In `decodeAuctionElements`

### DIFF
--- a/test/stablex/stablecoin_converter.js
+++ b/test/stablex/stablecoin_converter.js
@@ -1389,40 +1389,44 @@ contract("StablecoinConverter", async (accounts) => {
     })
     it("returns correct orders whether valid, canceled or freed", async () => {
       const stablecoinConverter = await setupGenericStableX()
+      const zeroBN = new BN(0)
+      const oneBN = new BN(1)
+      const tenBN = new BN(10)
+      const twentyBN = new BN(20)
 
-      const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
+      const batchIndex = await stablecoinConverter.getCurrentBatchId.call()
       const validOrderInfo = {
         user: user_1.toLowerCase(),
-        sellTokenBalance: 0,
-        buyToken: 1,
-        sellToken: 0,
+        sellTokenBalance: zeroBN,
+        buyToken: oneBN,
+        sellToken: zeroBN,
         validFrom: batchIndex,
-        validUntil: batchIndex + 10,
-        priceNumerator: 20,
-        priceDenominator: 10,
-        remainingAmount: 10,
+        validUntil: batchIndex.add(tenBN),
+        priceNumerator: twentyBN,
+        priceDenominator: tenBN,
+        remainingAmount: tenBN,
       }
       const canceledOrderInfo = {
         user: user_1.toLowerCase(),
-        sellTokenBalance: 0,
-        buyToken: 1,
-        sellToken: 0,
+        sellTokenBalance: zeroBN,
+        buyToken: oneBN,
+        sellToken: zeroBN,
         validFrom: batchIndex,
-        validUntil: batchIndex - 1,
-        priceNumerator: 20,
-        priceDenominator: 10,
-        remainingAmount: 10,
+        validUntil: batchIndex.sub(oneBN),
+        priceNumerator: twentyBN,
+        priceDenominator: tenBN,
+        remainingAmount: tenBN,
       }
       const freedOrderInfo = {
         user: user_1.toLowerCase(),
-        sellTokenBalance: 0,
-        buyToken: 0,
-        sellToken: 0,
-        validFrom: 0,
-        validUntil: 0,
-        priceNumerator: 0,
-        priceDenominator: 0,
-        remainingAmount: 0,
+        sellTokenBalance: zeroBN,
+        buyToken: zeroBN,
+        sellToken: zeroBN,
+        validFrom: zeroBN,
+        validUntil: zeroBN,
+        priceNumerator: zeroBN,
+        priceDenominator: zeroBN,
+        remainingAmount: zeroBN,
       }
       // Place 3 valid orders, cancel first two, wait one batch till and free storage of middle order
       for (let i = 0; i < 3; i++) {
@@ -1434,49 +1438,53 @@ contract("StablecoinConverter", async (accounts) => {
           validOrderInfo.priceDenominator
         )
       }
-      // 
+
       await stablecoinConverter.cancelOrders([0, 1])
       await waitForNSeconds(BATCH_TIME)
       await stablecoinConverter.freeStorageOfOrder([1])
 
-
       const auctionElements = decodeAuctionElements(await stablecoinConverter.getEncodedAuctionElements())
-      assert.deepEqual(auctionElements, [canceledOrderInfo, freedOrderInfo, validOrderInfo])
+      assert.equal(JSON.stringify(auctionElements), JSON.stringify([canceledOrderInfo, freedOrderInfo, validOrderInfo]))
     })
   })
   describe("getEncodedAuctionElements()", async () => {
     it("returns all orders that are have ever been submitted", async () => {
       const stablecoinConverter = await setupGenericStableX(3)
 
-      const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
+      const batchIndex = await stablecoinConverter.getCurrentBatchId.call()
 
+      const zeroBN = new BN(0)
+      const oneBN = new BN(1)
+      const tenBN = new BN(10)
+      const twentyBN = new BN(20)
+      const orderInfo = [
+        {
+          user: user_1.toLowerCase(),
+          sellTokenBalance: zeroBN,
+          buyToken: oneBN,
+          sellToken: zeroBN,
+          validFrom: batchIndex,
+          validUntil: batchIndex,
+          priceNumerator: twentyBN,
+          priceDenominator: tenBN,
+          remainingAmount: tenBN,
+        }, {
+          user: user_2.toLowerCase(),
+          sellTokenBalance: zeroBN,
+          buyToken: zeroBN,
+          sellToken: oneBN,
+          validFrom: batchIndex,
+          validUntil: batchIndex,
+          priceNumerator: new BN(500),
+          priceDenominator: new BN(400),
+          remainingAmount: new BN(400),
+        }]
       await stablecoinConverter.placeOrder(1, 0, batchIndex, 20, 10, { from: user_1 })
-      await stablecoinConverter.placeOrder(0, 1, batchIndex + 10, 500, 400, { from: user_2 })
+      await stablecoinConverter.placeOrder(0, 1, batchIndex, 500, 400, { from: user_2 })
 
       const auctionElements = decodeAuctionElements(await stablecoinConverter.getEncodedAuctionElements())
       assert.equal(auctionElements.length, 2)
-      assert.deepEqual(auctionElements[0], {
-        user: user_1.toLowerCase(),
-        sellTokenBalance: 0,
-        buyToken: 1,
-        sellToken: 0,
-        validFrom: batchIndex,
-        validUntil: batchIndex,
-        priceNumerator: 20,
-        priceDenominator: 10,
-        remainingAmount: 10,
-      })
-      assert.deepEqual(auctionElements[1], {
-        user: user_2.toLowerCase(),
-        sellTokenBalance: 0,
-        buyToken: 0,
-        sellToken: 1,
-        validFrom: batchIndex,
-        validUntil: batchIndex + 10,
-        priceNumerator: 500,
-        priceDenominator: 400,
-        remainingAmount: 400,
-      })
+      assert.equal(JSON.stringify(auctionElements), JSON.stringify(orderInfo))
     })
     it("credits balance when it's valid", async () => {
       const stablecoinConverter = await setupGenericStableX(3)

--- a/test/stablex/stablecoin_converter.js
+++ b/test/stablex/stablecoin_converter.js
@@ -1390,18 +1390,17 @@ contract("StablecoinConverter", async (accounts) => {
     it("returns correct orders whether valid, canceled or freed", async () => {
       const stablecoinConverter = await setupGenericStableX()
       const zeroBN = new BN(0)
-      const oneBN = new BN(1)
       const tenBN = new BN(10)
       const twentyBN = new BN(20)
 
-      const batchIndex = await stablecoinConverter.getCurrentBatchId.call()
+      const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
       const validOrderInfo = {
         user: user_1.toLowerCase(),
         sellTokenBalance: zeroBN,
-        buyToken: oneBN,
-        sellToken: zeroBN,
+        buyToken: 1,
+        sellToken: 0,
         validFrom: batchIndex,
-        validUntil: batchIndex.add(tenBN),
+        validUntil: batchIndex + 10,
         priceNumerator: twentyBN,
         priceDenominator: tenBN,
         remainingAmount: tenBN,
@@ -1409,10 +1408,10 @@ contract("StablecoinConverter", async (accounts) => {
       const canceledOrderInfo = {
         user: user_1.toLowerCase(),
         sellTokenBalance: zeroBN,
-        buyToken: oneBN,
-        sellToken: zeroBN,
+        buyToken: 1,
+        sellToken: 0,
         validFrom: batchIndex,
-        validUntil: batchIndex.sub(oneBN),
+        validUntil: batchIndex - 1,
         priceNumerator: twentyBN,
         priceDenominator: tenBN,
         remainingAmount: tenBN,
@@ -1420,10 +1419,10 @@ contract("StablecoinConverter", async (accounts) => {
       const freedOrderInfo = {
         user: user_1.toLowerCase(),
         sellTokenBalance: zeroBN,
-        buyToken: zeroBN,
-        sellToken: zeroBN,
-        validFrom: zeroBN,
-        validUntil: zeroBN,
+        buyToken: 0,
+        sellToken: 0,
+        validFrom: 0,
+        validUntil: 0,
         priceNumerator: zeroBN,
         priceDenominator: zeroBN,
         remainingAmount: zeroBN,
@@ -1450,29 +1449,26 @@ contract("StablecoinConverter", async (accounts) => {
   describe("getEncodedAuctionElements()", async () => {
     it("returns all orders that are have ever been submitted", async () => {
       const stablecoinConverter = await setupGenericStableX(3)
-
-      const batchIndex = await stablecoinConverter.getCurrentBatchId.call()
+      const batchIndex = (await stablecoinConverter.getCurrentBatchId.call()).toNumber()
 
       const zeroBN = new BN(0)
-      const oneBN = new BN(1)
       const tenBN = new BN(10)
-      const twentyBN = new BN(20)
       const orderInfo = [
         {
           user: user_1.toLowerCase(),
           sellTokenBalance: zeroBN,
-          buyToken: oneBN,
-          sellToken: zeroBN,
+          buyToken: 1,
+          sellToken: 0,
           validFrom: batchIndex,
           validUntil: batchIndex,
-          priceNumerator: twentyBN,
+          priceNumerator: new BN(20),
           priceDenominator: tenBN,
           remainingAmount: tenBN,
         }, {
           user: user_2.toLowerCase(),
           sellTokenBalance: zeroBN,
-          buyToken: zeroBN,
-          sellToken: oneBN,
+          buyToken: 0,
+          sellToken: 1,
           validFrom: batchIndex,
           validUntil: batchIndex,
           priceNumerator: new BN(500),
@@ -1483,7 +1479,6 @@ contract("StablecoinConverter", async (accounts) => {
       await stablecoinConverter.placeOrder(0, 1, batchIndex, 500, 400, { from: user_2 })
 
       const auctionElements = decodeAuctionElements(await stablecoinConverter.getEncodedAuctionElements())
-      assert.equal(auctionElements.length, 2)
       assert.equal(JSON.stringify(auctionElements), JSON.stringify(orderInfo))
     })
     it("credits balance when it's valid", async () => {

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -183,7 +183,7 @@ const UINT128_WIDTH = 16 * 2
 
 function decodeAuctionElements(bytes) {
   if (!bytes) {
-    return [];
+    return []
   }
   const result = []
   bytes = bytes.slice(2) // cutting of 0x

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -193,10 +193,10 @@ function decodeAuctionElements(bytes) {
     result.push({
       user: "0x" + element.splice(0, ADDRESS_WIDTH).join(""), // address is only 20 bytes
       sellTokenBalance: new BN(element.splice(0, UINT256_WIDTH).join(""), 16),
-      buyToken: new BN(element.splice(0, UINT16_WIDTH).join(""), 16),
-      sellToken: new BN(element.splice(0, UINT16_WIDTH).join(""), 16),
-      validFrom: new BN(element.splice(0, UINT32_WIDTH).join(""), 16),
-      validUntil: new BN(element.splice(0, UINT32_WIDTH).join(""), 16),
+      buyToken: parseInt(element.splice(0, UINT16_WIDTH).join(""), 16),
+      sellToken: parseInt(element.splice(0, UINT16_WIDTH).join(""), 16),
+      validFrom: parseInt(element.splice(0, UINT32_WIDTH).join(""), 16),
+      validUntil: parseInt(element.splice(0, UINT32_WIDTH).join(""), 16),
       priceNumerator: new BN(element.splice(0, UINT128_WIDTH).join(""), 16),
       priceDenominator: new BN(element.splice(0, UINT128_WIDTH).join(""), 16),
       remainingAmount: new BN(element.splice(0, UINT128_WIDTH).join(""), 16),

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -2,6 +2,7 @@
 const { sha256 } = require("ethereumjs-util")
 const memoize = require("fast-memoize")
 const MerkleTree = require("merkletreejs")
+const BN = require("bn.js")
 
 /**
  * funds accounts with specified value for Mintable Token
@@ -181,6 +182,9 @@ const UINT32_WIDTH = 4 * 2
 const UINT128_WIDTH = 16 * 2
 
 function decodeAuctionElements(bytes) {
+  if (!bytes) {
+    return [];
+  }
   const result = []
   bytes = bytes.slice(2) // cutting of 0x
   while (bytes.length > 0) {
@@ -188,14 +192,14 @@ function decodeAuctionElements(bytes) {
     bytes = bytes.slice(112 * 2)
     result.push({
       user: "0x" + element.splice(0, ADDRESS_WIDTH).join(""), // address is only 20 bytes
-      sellTokenBalance: parseInt(element.splice(0, UINT256_WIDTH).join(""), 16),
-      buyToken: parseInt(element.splice(0, UINT16_WIDTH).join(""), 16),
-      sellToken: parseInt(element.splice(0, UINT16_WIDTH).join(""), 16),
-      validFrom: parseInt(element.splice(0, UINT32_WIDTH).join(""), 16),
-      validUntil: parseInt(element.splice(0, UINT32_WIDTH).join(""), 16),
-      priceNumerator: parseInt(element.splice(0, UINT128_WIDTH).join(""), 16),
-      priceDenominator: parseInt(element.splice(0, UINT128_WIDTH).join(""), 16),
-      remainingAmount: parseInt(element.splice(0, UINT128_WIDTH).join(""), 16),
+      sellTokenBalance: new BN(element.splice(0, UINT256_WIDTH).join(""), 16),
+      buyToken: new BN(element.splice(0, UINT16_WIDTH).join(""), 16),
+      sellToken: new BN(element.splice(0, UINT16_WIDTH).join(""), 16),
+      validFrom: new BN(element.splice(0, UINT32_WIDTH).join(""), 16),
+      validUntil: new BN(element.splice(0, UINT32_WIDTH).join(""), 16),
+      priceNumerator: new BN(element.splice(0, UINT128_WIDTH).join(""), 16),
+      priceDenominator: new BN(element.splice(0, UINT128_WIDTH).join(""), 16),
+      remainingAmount: new BN(element.splice(0, UINT128_WIDTH).join(""), 16),
     })
   }
   return result


### PR DESCRIPTION
Fixed an issue where decoding on empty bytes does not throw and changed to use `bn.js` to avoid overflow issues.

### Test Plan

Try out `npx truffle exec get_auction_elements.js` for large orders that can't be represented by a double precision floating point number.