### PR TITLE
Fixing migration flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,19 @@
 [![Build Status](https://travis-ci.org/gnosis/dex-contracts.svg?branch=master)](https://travis-ci.org/gnosis/dex-contracts?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/gnosis/dex-contracts/badge.svg?branch=master)](https://coveralls.io/github/gnosis/dex-contracts?branch=master)
 
-
-
 # dFusion - Smart Contracts
 
 The **dFusion Exchange** is a fully decentralized trading protocol which facilitates ring trades via discrete auction between several [ERC20](https://github.com/ethereum/EIPs/blob/master/EIPS/eip-20.md) token pairs.
 
 It uses a batch auction for arbitrage-free exchanges while maximizing trader surplus to facilitate the development of a fairer Web3 ecosystem for everyone.
 
-
 # Documentation
+
 Checkout the [Formal Specification](https://github.com/gnosis/dex-research/blob/master/dFusion/dFusion.rst).
 
 # CLI Examples
 
 Checkout our [wiki](https://github.com/gnosis/dex-contracts/wiki/Script-Usage-Examples)
-
 
 # Deployment Process
 
@@ -25,6 +22,7 @@ For the deployment of the contracts into an official network, follow this steps:
 1. Make sure that all depended contracts and libraries - e.g. BytesLib - has been deployed to the intended network and that their network information is available in the npm modules
 
 2. Run the following commands
+
 ```sh
 npm install                         // This installs all dependencies
 npx truffle build                   // This builds the contracts
@@ -32,13 +30,23 @@ npx truffle migrate --network $NETWORKNAME --reset
 npm run networks-extract            // extracts deployed addresses to networks.json
 ```
 
+In case only the StableX or only the SnappAuction should be deployed, you can add the flags `--onlyMigrateStableX` or `--onlyMigrateSnappAuction` to the deployment command.
+
+E.g:
+
+```
+ npx truffle migrate --onlyMigrateStableX=true
+```
+
 3. Verify the contracts for some cool Etherscan.io goodies (see below for more help)
+
 ```sh
 npx truffle run verify SnappAuction --network $NETWORKNAME
 npx truffle run verify StablecoinConverter --network $NETWORKNAME
 ```
 
 4. List some default tokens on the StableX exchange
+
 ```sh
 npx truffle exec scripts/stablex/add_token_list.js --network $NETWORKNAME
 ```
@@ -46,12 +54,14 @@ npx truffle exec scripts/stablex/add_token_list.js --network $NETWORKNAME
 ## Verifying Contracts
 
 In order to verify a contract on Etherscan.io, you need to first creat an account and an API key
+
 1. Navigate to https://etherscan.io/myapikey
 2. Login or create an account
 3. Generate a new API key
 4. Add `export MY_ETHERSCAN_API_KEY="..."` to your `~/.zshrc`, `~/.bash_profile`, or similar
 
 Note, if you have a specific contract address in mind (i.e. one which is not specified in `networks.json`) it may be referred to by address as
+
 ```sh
 npx truffle run verify $CONTRACT_NAME@$CONTRACT_ADDRESS --network $NETWORKNAME
 ```
@@ -61,16 +71,19 @@ npx truffle run verify $CONTRACT_NAME@$CONTRACT_ADDRESS --network $NETWORKNAME
 In order to use the previously deployed contracts, which are documented in the network.json file, the following steps are necessary:
 
 1. Build the contracts:
+
 ```
 npx truffle compile
 ```
 
 2. Inject address from network.json into the builds:
+
 ```
-npm run networks-inject 
+npm run networks-inject
 ```
 
 # Contributions
+
 Our continuous integration is running several linters which must pass in order to make a contribution to this repo. For your convenience there is a `pre-commit` hook file contained in the project's root directory. You can make your life easier by executing the following command after cloning this project (it will ensure your changes pass linting before allowing commits).
 
 ```bash

--- a/migrations/3_batch_auction.js
+++ b/migrations/3_batch_auction.js
@@ -1,7 +1,12 @@
 const migrateSnappAuction = require("../src/migration_scripts_snappAuction/migrate_snapp_auction")
-const argv = require("../src/migration_utilities")
+const argv = require("yargs")
+  .option("onlyMigrateStableX", {
+    describe: "Allows to restrict the migration only to StableX"
+  })
+  .help(false)
+  .version(false).argv
 
-module.exports = async function (deployer, network) {
+module.exports = async function(deployer, network) {
   if (!argv.onlyMigrateStableX) {
     return migrateSnappAuction({
       artifacts,

--- a/migrations/4_stablecoin_converter.js
+++ b/migrations/4_stablecoin_converter.js
@@ -1,7 +1,12 @@
-const argv = require("../src/migration_utilities")
 const migrateStablecoinConverter = require("../src/migration_scripts_stablecoinConverter/migrate_PoC_dfusion")
+const argv = require("yargs")
+  .option("onlyMigrateSnappAuction", {
+    describe: "Allows to restrict the migration only to SnappAuction"
+  })
+  .help(false)
+  .version(false).argv
 
-module.exports = async function (deployer, network, accounts, web3) {
+module.exports = async function(deployer, network, accounts, web3) {
   if (!argv.onlyMigrateSnappAuction) {
     return migrateStablecoinConverter({
       artifacts,

--- a/src/migration_utilities.js
+++ b/src/migration_utilities.js
@@ -1,14 +1,3 @@
-const argv = require("yargs")
-  .option("onlyMigrateStableX", {
-    describe: "Allows to restrict the migration only to StableX"
-  })
-  .option("onlyMigrateSnappAuction", {
-    describe: "Allows to restrict the migration only to SnappAuction"
-  })
-  .help(false)
-  .version(false)
-  .argv
-
 function getDependency(artifacts, network, deployer, path) {
   let Contract
 
@@ -25,11 +14,14 @@ function getDependency(artifacts, network, deployer, path) {
 }
 
 function isDevelopmentNetwork(network) {
-  return (network === "development" || network === "coverage" || network === "developmentdocker")
+  return (
+    network === "development" ||
+    network === "coverage" ||
+    network === "developmentdocker"
+  )
 }
 
 module.exports = {
-  argv,
   getDependency,
   isDevelopmentNetwork
 }


### PR DESCRIPTION
Closes #320 

For some reason the way I exported argv was wrong. I really prefer to have argv out of the utilities.js, (as I am doing it in this PR) for easier readability.

---

testplan:
```
 npx truffle migrate --onlyMigrateStableX=true
```
And check that only stableX gets migrated