### PR TITLE
[Easy] Prevent same token orders

### DIFF
--- a/contracts/StablecoinConverter.sol
+++ b/contracts/StablecoinConverter.sol
@@ -385,6 +385,7 @@ contract StablecoinConverter is EpochTokenLocker {
         uint128 buyAmount,
         uint128 sellAmount
     ) internal returns (uint256) {
+        require(buyToken != sellToken, "Exchange tokens not distinct");
         require(validFrom >= getCurrentBatchId(), "Orders can't be placed in the past");
         orders[msg.sender].push(Order({
             buyToken: buyToken,

--- a/test/stablex/stablecoin_converter.js
+++ b/test/stablex/stablecoin_converter.js
@@ -148,6 +148,14 @@ contract("StablecoinConverter", async (accounts) => {
     })
   })
   describe("placeOrder()", () => {
+    it("rejects orders between same tokens", async () => {
+      const stablecoinConverter = await setupGenericStableX()
+      const currentBatch = (await stablecoinConverter.getCurrentBatchId()).toNumber()
+      await truffleAssert.reverts(
+        stablecoinConverter.placeValidFromOrders.call([0], [0], [currentBatch - 1], [1], [1], [1]),
+        "Exchange tokens not distinct"
+      )
+    })
     it("places order and verifys contract storage is updated correctly", async () => {
       const stablecoinConverter = await setupGenericStableX()
 


### PR DESCRIPTION
Add requirement on `placeOrder` preventing orders between identical tokens. 

**Test Plan:** Unit tests and coverage.