### PR TITLE
[Easy] Update CI to Use Node v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '8'
+  - 10
 before_install:
   - rm -rf build
   - rm -rf node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
 before_install:
   - rm -rf build
   - rm -rf node_modules
+  - npm install -g npm@6.13
   - npm install -g ganache-cli
 before_script:
   - ganache-cli --defaultBalanceEther 500000000 > /dev/null &


### PR DESCRIPTION
In the dex-services [README](https://github.com/gnosis/dex-services/blob/master/README.md) we suggest using Node ^11.0, since starting v12 there are packages that no longer work that we need. This PR changes the CI to use Node v10 as it was the last LTS Node release before v12.

### Test Plan

CI