### PR TITLE
[Easy] Use `closeAuction` In `EpochTokenLocker` Tests

### DIFF
--- a/test/stablex/epoch_token_locker.js
+++ b/test/stablex/epoch_token_locker.js
@@ -4,17 +4,10 @@ const MockContract = artifacts.require("MockContract")
 const ERC20Interface = artifacts.require("ERC20")
 
 const truffleAssert = require("truffle-assertions")
-const { waitForNSeconds } = require("../utilities")
-
+const { closeAuction } = require("../../scripts/stablex/utilities")
 
 contract("EpochTokenLocker", async (accounts) => {
   const [user_1, user_2] = accounts
-
-  let BATCH_TIME
-  before(async () => {
-    const instance = await EpochTokenLocker.new()
-    BATCH_TIME = (await instance.BATCH_TIME.call()).toNumber()
-  })
 
   describe("deposit()", () => {
     it("processes a deposit and stores it in the pendingDeposits", async () => {
@@ -48,15 +41,14 @@ contract("EpochTokenLocker", async (accounts) => {
       assert.equal((await epochTokenLocker.getPendingDepositAmount(user_1, ERC20.address)).toNumber(), 200)
     })
 
-    it("does not consolidates two deposits, if they are not deposited during same stateIndex", async () => {
+    it("does not consolidate two deposits, if they are not deposited during same stateIndex", async () => {
       const epochTokenLocker = await EpochTokenLocker.new()
       const ERC20 = await MockContract.new()
       await ERC20.givenAnyReturnBool(true)
       await epochTokenLocker.deposit(ERC20.address, 100)
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
       await epochTokenLocker.deposit(ERC20.address, 200)
       const currentStateIndex = await epochTokenLocker.getCurrentBatchId.call()
-
 
       assert.equal(await epochTokenLocker.getPendingDepositAmount(user_1, ERC20.address), 200)
       assert.equal((await epochTokenLocker.getPendingDepositBatchNumber(user_1, ERC20.address)).toNumber(), currentStateIndex.toNumber())
@@ -79,7 +71,7 @@ contract("EpochTokenLocker", async (accounts) => {
       await ERC20.givenAnyReturnBool(true)
 
       await epochTokenLocker.requestWithdraw(ERC20.address, 100)
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
       await epochTokenLocker.requestWithdraw(ERC20.address, 100)
       // checking that the transfer in withdraw was called
       const token = await ERC20Interface.new()
@@ -117,11 +109,11 @@ contract("EpochTokenLocker", async (accounts) => {
       await ERC20.givenAnyReturnBool(true)
 
       await epochTokenLocker.deposit(ERC20.address, 100)
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
       assert.equal(await epochTokenLocker.getBalance.call(user_1, ERC20.address), 100)
 
       await epochTokenLocker.requestWithdraw(ERC20.address, 100)
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
       await epochTokenLocker.withdraw(user_1, ERC20.address)
 
       assert.equal(await epochTokenLocker.getPendingWithdrawAmount(user_1, ERC20.address), 0)
@@ -137,7 +129,7 @@ contract("EpochTokenLocker", async (accounts) => {
       await ERC20.givenAnyReturnBool(true)
 
       await epochTokenLocker.deposit(ERC20.address, 100)
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
       assert.equal(await epochTokenLocker.getBalance(user_1, ERC20.address), 100)
 
       await epochTokenLocker.requestWithdraw(ERC20.address, 100)
@@ -150,10 +142,10 @@ contract("EpochTokenLocker", async (accounts) => {
 
 
       await epochTokenLocker.deposit(ERC20.address, 50)
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
 
       await epochTokenLocker.requestWithdraw(ERC20.address, 100)
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
       await epochTokenLocker.withdraw(user_1, ERC20.address)
 
       const token = await ERC20Interface.new()
@@ -166,7 +158,7 @@ contract("EpochTokenLocker", async (accounts) => {
       await ERC20.givenAnyReturnBool(true)
 
       await epochTokenLocker.requestWithdraw(ERC20.address, 100, { from: user_1 })
-      await waitForNSeconds(BATCH_TIME + 1)
+      await closeAuction(epochTokenLocker)
       await epochTokenLocker.addBalanceAndBlockWithdrawForThisBatchTest(user_1, ERC20.address, 100)
 
       const batchId = await epochTokenLocker.getCurrentBatchId.call()
@@ -184,7 +176,7 @@ contract("EpochTokenLocker", async (accounts) => {
       await ERC20.givenAnyReturnBool(true)
 
       await epochTokenLocker.deposit(ERC20.address, 100)
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
       assert.equal((await epochTokenLocker.getBalance.call(user_1, ERC20.address)).toNumber(), 100)
     })
     it("returns just the balance, if there are no pending deposit from a previous time and no withdraws", async () => {
@@ -201,7 +193,7 @@ contract("EpochTokenLocker", async (accounts) => {
       await ERC20.givenAnyReturnBool(true)
 
       await epochTokenLocker.deposit(ERC20.address, 100)
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
       assert.equal(await epochTokenLocker.getBalance.call(user_1, ERC20.address), 100)
     })
     it("returns just the balance + pending deposit - depending withdraws", async () => {
@@ -211,7 +203,7 @@ contract("EpochTokenLocker", async (accounts) => {
 
       await epochTokenLocker.deposit(ERC20.address, 100)
       await epochTokenLocker.requestWithdraw(ERC20.address, 50)
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
       assert.equal(await epochTokenLocker.getBalance.call(user_1, ERC20.address), 50)
     })
     it("returns just the balance + pending deposit - depending withdraws and protects overflows", async () => {
@@ -221,7 +213,7 @@ contract("EpochTokenLocker", async (accounts) => {
 
       await epochTokenLocker.deposit(ERC20.address, 100)
       await epochTokenLocker.requestWithdraw(ERC20.address, 150)
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
       assert.equal(await epochTokenLocker.getBalance.call(user_1, ERC20.address), 0)
     })
     it("returns just the balance + pending deposit if withdraw was made in same stateIndex", async () => {
@@ -230,7 +222,7 @@ contract("EpochTokenLocker", async (accounts) => {
       await ERC20.givenAnyReturnBool(true)
 
       await epochTokenLocker.deposit(ERC20.address, 100)
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
       await epochTokenLocker.requestWithdraw(ERC20.address, 150)
       assert.equal(await epochTokenLocker.getBalance.call(user_1, ERC20.address), 100)
     })
@@ -262,7 +254,7 @@ contract("EpochTokenLocker", async (accounts) => {
 
       const currentStateIndex = await epochTokenLocker.getCurrentBatchId.call()
       await epochTokenLocker.requestWithdraw(ERC20.address, 100, { from: user_1 })
-      await waitForNSeconds(BATCH_TIME + 1)
+      await closeAuction(epochTokenLocker)
       await epochTokenLocker.addBalanceAndBlockWithdrawForThisBatchTest(user_1, ERC20.address, 100)
 
       const batchId = await epochTokenLocker.getCurrentBatchId.call()
@@ -287,7 +279,7 @@ contract("EpochTokenLocker", async (accounts) => {
       await ERC20.givenAnyReturnBool(true)
 
       await epochTokenLocker.deposit(ERC20.address, 100, { from: user_2 })
-      await waitForNSeconds(BATCH_TIME)
+      await closeAuction(epochTokenLocker)
       await epochTokenLocker.subtractBalanceTest(user_2, ERC20.address, 50)
 
       assert.equal(await epochTokenLocker.getBalance(user_2, ERC20.address), 50)


### PR DESCRIPTION
Recently master was briefly red because of a failed `EpochTokenLocker` test. The test is failrly straightforward and does not involve much code and it looks like it was failing because of unlucky (or lucky, depending on how you look at it :smiley:) timing where the new balance was being added right before the end of an epoch, which caused the following withdraw to succeed since it was in a new epoch.

This is an attempt to fix this issue by using `closeAcution` to fast-forward to the beginning of the next epoch leading to more stable unit tests.

Link to broken build and failing test: https://travis-ci.org/gnosis/dex-contracts/builds/617735468#L1596

### Test Plan

CI