### PR TITLE
331/no fee price

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -8,6 +8,7 @@ import "openzeppelin-solidity/contracts/utils/SafeCast.sol";
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 import "./libraries/TokenConservation.sol";
 
+
 /** @title Stable Coin Converter - A decentralized exchange for stable tokens as a batch auciton.
  *  @author @gnosis/dfusion-team <https://github.com/orgs/gnosis/teams/dfusion-team/members>
  */

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -8,7 +8,6 @@ import "openzeppelin-solidity/contracts/utils/SafeCast.sol";
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 import "./libraries/TokenConservation.sol";
 
-
 /** @title Stable Coin Converter - A decentralized exchange for stable tokens as a batch auciton.
  *  @author @gnosis/dfusion-team <https://github.com/orgs/gnosis/teams/dfusion-team/members>
  */

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -104,6 +104,7 @@ contract BatchExchange is EpochTokenLocker {
       * @param _feeToken Address of ERC20 fee token.
       */
     constructor(uint256 maxTokens, uint128 _feeDenominator, address _feeToken) public {
+        currentPrices[0] = 1 ether;
         MAX_TOKENS = maxTokens;
         feeToken = TokenOWL(_feeToken);
         feeToken.approve(address(this), uint256(-1));
@@ -242,15 +243,14 @@ contract BatchExchange is EpochTokenLocker {
             "Claimed objective doesn't sufficiently improve current solution"
         );
         require(verifyAmountThreshold(prices), "At least one price lower than AMOUNT_MINIMUM");
-        require(tokenIdsForPrice[0] == 0, "fee token price has to be specified");
-        require(prices[0] == 1 ether, "fee token price must be 10^18");
+        require(tokenIdsForPrice[0] != 0, "Fee token has fixed price!");
         require(tokenIdsForPrice.checkPriceOrdering(), "prices are not ordered by tokenId");
         require(owners.length <= MAX_TOUCHED_ORDERS, "Solution exceeds MAX_TOUCHED_ORDERS");
         burnPreviousAuctionFees();
         undoCurrentSolution();
         updateCurrentPrices(prices, tokenIdsForPrice);
         delete latestSolution.trades;
-        int256[] memory tokenConservation = new int256[](prices.length);
+        int256[] memory tokenConservation = new int256[](prices.length + 1);
         uint256 utility = 0;
         for (uint256 i = 0; i < owners.length; i++) {
             Order memory order = orders[owners[i]][orderIds[i]];

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -250,7 +250,7 @@ contract BatchExchange is EpochTokenLocker {
         undoCurrentSolution();
         updateCurrentPrices(prices, tokenIdsForPrice);
         delete latestSolution.trades;
-        int256[] memory tokenConservation = new int256[](prices.length + 1);
+        int256[] memory tokenConservation = TokenConservation.init(tokenIdsForPrice);
         uint256 utility = 0;
         for (uint256 i = 0; i < owners.length; i++) {
             Order memory order = orders[owners[i]][orderIds[i]];
@@ -287,7 +287,7 @@ contract BatchExchange is EpochTokenLocker {
         for (uint256 i = 0; i < owners.length; i++) {
             disregardedUtility = disregardedUtility.add(evaluateDisregardedUtility(orders[owners[i]][orderIds[i]], owners[i]));
         }
-        uint256 burntFees = uint256(tokenConservation[0]) / 2;
+        uint256 burntFees = uint256(tokenConservation.feeTokenImbalance()) / 2;
         require(utility.add(burntFees) > disregardedUtility, "Solution must be better than trivial");
         // burntFees ensures direct trades (when available) yield better solutions than longer rings
         uint256 objectiveValue = utility.add(burntFees).sub(disregardedUtility);

--- a/contracts/libraries/TokenConservation.sol
+++ b/contracts/libraries/TokenConservation.sol
@@ -62,12 +62,15 @@ library TokenConservation {
       */
     function findPriceIndex(uint16 tokenId, uint16[] memory tokenIdsForPrice) private pure returns (uint256) {
         // binary search for the other tokens
+        if (tokenId == 0) {
+            return 0;
+        }
         uint256 leftValue = 0;
         uint256 rightValue = tokenIdsForPrice.length - 1;
         while (rightValue >= leftValue) {
             uint256 middleValue = leftValue + (rightValue - leftValue) / 2;
             if (tokenIdsForPrice[middleValue] == tokenId) {
-                return middleValue;
+                return middleValue + 1;
             } else if (tokenIdsForPrice[middleValue] < tokenId) {
                 leftValue = middleValue + 1;
             } else {

--- a/contracts/libraries/TokenConservation.sol
+++ b/contracts/libraries/TokenConservation.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.0;
 
 import "openzeppelin-solidity/contracts/drafts/SignedSafeMath.sol";
 
+
 /** @title Token Conservation
  *  A library for updating and verifying the tokenConservation contraint for BatchExchange's batch auction
  *  @author @gnosis/dfusion-team <https://github.com/orgs/gnosis/teams/dfusion-team/members>

--- a/contracts/libraries/TokenConservation.sol
+++ b/contracts/libraries/TokenConservation.sol
@@ -14,7 +14,7 @@ library TokenConservation {
       * @param tokenIdsForPrice sorted list of tokenIds for which token conservation should be checked
       */
     function init(uint16[] memory tokenIdsForPrice) internal pure returns (int256[] memory) {
-        return new int256[](tokenIdsForPrice.length + 1);   
+        return new int256[](tokenIdsForPrice.length + 1);
     }
 
     /** @dev returns the token imbalance of the fee token

--- a/contracts/libraries/TokenConservation.sol
+++ b/contracts/libraries/TokenConservation.sol
@@ -9,8 +9,22 @@ import "openzeppelin-solidity/contracts/drafts/SignedSafeMath.sol";
 library TokenConservation {
     using SignedSafeMath for int256;
 
+    /** @dev initialize the token conservation data structure
+      * @param tokenIdsForPrice sorted list of tokenIds for which token conservation should be checked
+      */
+    function init(uint16[] memory tokenIdsForPrice) internal pure returns (int256[] memory) {
+        return new int256[](tokenIdsForPrice.length + 1);   
+    }
+
+    /** @dev returns the token imbalance of the fee token
+      * @param self internal datastructure created by TokenConservation.init()
+      */
+    function feeTokenImbalance(int256[] memory self) internal pure returns (int256) {
+        return self[0];
+    }
+
     /** @dev updated token conservation array.
-      * @param self list of token imbalances
+      * @param self internal datastructure created by TokenConservation.init()
       * @param buyToken id of token whose imbalance should be subtracted from
       * @param sellToken id of token whose imbalance should be added to
       * @param tokenIdsForPrice sorted list of tokenIds
@@ -32,7 +46,7 @@ library TokenConservation {
     }
 
     /** @dev Ensures all array's elements are zero except the first.
-      * @param self list of token imbalances
+      * @param self internal datastructure created by TokenConservation.init()
       * @return true if all, but first element of self are zero else false
       */
     function checkTokenConservation(int256[] memory self) internal pure {
@@ -61,15 +75,17 @@ library TokenConservation {
       * @return `index` in `tokenIdsForPrice` where `tokenId` appears (reverts if not found).
       */
     function findPriceIndex(uint16 tokenId, uint16[] memory tokenIdsForPrice) private pure returns (uint256) {
-        // binary search for the other tokens
+        // Fee token is not included in tokenIdsForPrice
         if (tokenId == 0) {
             return 0;
         }
+        // binary search for the other tokens
         uint256 leftValue = 0;
         uint256 rightValue = tokenIdsForPrice.length - 1;
         while (rightValue >= leftValue) {
             uint256 middleValue = leftValue + (rightValue - leftValue) / 2;
             if (tokenIdsForPrice[middleValue] == tokenId) {
+                // shifted one to the right to account for fee token at index 0
                 return middleValue + 1;
             } else if (tokenIdsForPrice[middleValue] < tokenId) {
                 leftValue = middleValue + 1;

--- a/contracts/libraries/TokenConservation.sol
+++ b/contracts/libraries/TokenConservation.sol
@@ -2,7 +2,6 @@ pragma solidity ^0.5.0;
 
 import "openzeppelin-solidity/contracts/drafts/SignedSafeMath.sol";
 
-
 /** @title Token Conservation
  *  A library for updating and verifying the tokenConservation contraint for BatchExchange's batch auction
  *  @author @gnosis/dfusion-team <https://github.com/orgs/gnosis/teams/dfusion-team/members>

--- a/pre-commit
+++ b/pre-commit
@@ -12,12 +12,6 @@ PASS=true
 
 printf "\nValidating Javascript:\n"
 
-# Check for eslint
-if [[ ! -x "$ESLINT" ]]; then
-  printf "\t\033[41mPlease install ESlint\033[0m (npm i --save-dev eslint)"
-  exit 1
-fi
-
 for FILE in $STAGED_JS_FILES
 do
   "$ESLINT" "$FILE"

--- a/test/resources/examples/generate.js
+++ b/test/resources/examples/generate.js
@@ -93,13 +93,13 @@ function generateTestCase(input, strict = true, debug = false) {
           solution.buyVolumes[i].isZero()
             ? null
             : {
-              idx: i,
-              user: o.user,
-              buy: solution.buyVolumes[i],
-              sell: getExecutedSellAmount(solution.buyVolumes[i], solution.prices[o.buyToken], solution.prices[o.sellToken]),
-              utility: objectiveValue.utilities[i],
-              disregardedUtility: objectiveValue.disregardedUtilities[i],
-            }
+                idx: i,
+                user: o.user,
+                buy: solution.buyVolumes[i],
+                sell: getExecutedSellAmount(solution.buyVolumes[i], solution.prices[o.buyToken], solution.prices[o.sellToken]),
+                utility: objectiveValue.utilities[i],
+                disregardedUtility: objectiveValue.disregardedUtilities[i],
+              }
         )
         .filter(o => !!o)
       return {

--- a/test/resources/examples/generate.js
+++ b/test/resources/examples/generate.js
@@ -93,13 +93,13 @@ function generateTestCase(input, strict = true, debug = false) {
           solution.buyVolumes[i].isZero()
             ? null
             : {
-                idx: i,
-                user: o.user,
-                buy: solution.buyVolumes[i],
-                sell: getExecutedSellAmount(solution.buyVolumes[i], solution.prices[o.buyToken], solution.prices[o.sellToken]),
-                utility: objectiveValue.utilities[i],
-                disregardedUtility: objectiveValue.disregardedUtilities[i],
-              }
+              idx: i,
+              user: o.user,
+              buy: solution.buyVolumes[i],
+              sell: getExecutedSellAmount(solution.buyVolumes[i], solution.prices[o.buyToken], solution.prices[o.sellToken]),
+              utility: objectiveValue.utilities[i],
+              disregardedUtility: objectiveValue.disregardedUtilities[i],
+            }
         )
         .filter(o => !!o)
       return {
@@ -214,8 +214,8 @@ function solutionSubmissionParams(solution, accounts, orderIds) {
     owners: solution.orders.map(o => accounts[o.user]),
     touchedOrderIds: solution.orders.map(o => orderIds[o.idx]),
     volumes: solution.orders.map(o => o.buy),
-    prices: solution.tokens.map(t => t.price),
-    tokenIdsForPrice: solution.tokens.map(t => t.id),
+    prices: solution.tokens.slice(1).map(t => t.price),
+    tokenIdsForPrice: solution.tokens.slice(1).map(t => t.id),
   }
 }
 

--- a/test/resources/examples/index.js
+++ b/test/resources/examples/index.js
@@ -24,6 +24,24 @@ const basicTrade = generateTestCase({
   ],
 })
 
+const tradeWithoutFeeToken = generateTestCase(
+  {
+    name: "Basic Trade",
+    orders: [
+      { sellToken: 1, buyToken: 2, sellAmount: feeAdded(toETH(20)).add(ERROR_EPSILON), buyAmount: toETH(10), user: 0 },
+      { sellToken: 2, buyToken: 1, sellAmount: toETH(10), buyAmount: feeSubtracted(toETH(20)).sub(ERROR_EPSILON), user: 1 },
+    ],
+    solutions: [
+      {
+        name: "Full Solution",
+        prices: [1, 1, 2].map(toETH),
+        buyVolumes: [toETH(10), feeSubtracted(toETH(20))],
+      },
+    ],
+  },
+  false
+)
+
 const advancedTrade = generateTestCase({
   name: "Advanced Trade",
   orders: [
@@ -243,6 +261,7 @@ module.exports = Object.assign(
     smallExample,
     stableXExample,
     marginalTrade,
+    tradeWithoutFeeToken,
   },
   require("./generate")
 )

--- a/test/resources/examples/index.js
+++ b/test/resources/examples/index.js
@@ -24,24 +24,6 @@ const basicTrade = generateTestCase({
   ],
 })
 
-const tradeWithoutFeeToken = generateTestCase(
-  {
-    name: "Basic Trade",
-    orders: [
-      { sellToken: 1, buyToken: 2, sellAmount: feeAdded(toETH(20)).add(ERROR_EPSILON), buyAmount: toETH(10), user: 0 },
-      { sellToken: 2, buyToken: 1, sellAmount: toETH(10), buyAmount: feeSubtracted(toETH(20)).sub(ERROR_EPSILON), user: 1 },
-    ],
-    solutions: [
-      {
-        name: "Full Solution",
-        prices: [1, 1, 2].map(toETH),
-        buyVolumes: [toETH(10), feeSubtracted(toETH(20))],
-      },
-    ],
-  },
-  false
-)
-
 const advancedTrade = generateTestCase({
   name: "Advanced Trade",
   orders: [
@@ -261,7 +243,6 @@ module.exports = Object.assign(
     smallExample,
     stableXExample,
     marginalTrade,
-    tradeWithoutFeeToken,
   },
   require("./generate")
 )

--- a/test/resources/math.js
+++ b/test/resources/math.js
@@ -187,10 +187,6 @@ function solutionObjectiveValueComputation(orders, solution, strict = true) {
   assert(tokenCount === solution.prices.length, "solution prices does not include all tokens")
   assert(toETH(1).eq(solution.prices[0]), "fee token price is not 1 ether")
 
-  const feeTokenTouched =
-    orders.findIndex((o, i) => !solution.buyVolumes[i].isZero() && (o.buyToken === 0 || o.sellToken === 0)) !== -1
-  assert(feeTokenTouched, "fee token is not touched")
-
   const touchedOrders = orders.map((o, i) => (solution.buyVolumes[i].isZero() ? null : [o, i])).filter(pair => !!pair)
 
   const orderExecutedAmounts = orders.map(() => new BN(0))
@@ -220,6 +216,9 @@ function solutionObjectiveValueComputation(orders, solution, strict = true) {
   }
 
   if (strict) {
+    const feeTokenTouched =
+      orders.findIndex((o, i) => !solution.buyVolumes[i].isZero() && (o.buyToken === 0 || o.sellToken === 0)) !== -1
+    assert(feeTokenTouched, "fee token is not touched")
     assert(!tokenConservation[0].isNeg(), "fee token conservation is negative")
     tokenConservation
       .slice(1)

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -286,7 +286,7 @@ contract("BatchExchange", async accounts => {
       await closeAuction(batchExchange)
       const fakeClaimedObjective = 1
       await truffleAssert.reverts(
-        batchExchange.submitSolution(batchIndex, fakeClaimedObjective, [], [], [], [toETH(1)], [0], { from: solver }),
+        batchExchange.submitSolution(batchIndex, fakeClaimedObjective, [], [], [], [toETH(1)], [1], { from: solver }),
         "Solution must be better than trivial"
       )
     })
@@ -1088,7 +1088,7 @@ contract("BatchExchange", async accounts => {
           solution.touchedOrderIds,
           solution.volumes,
           solution.prices.slice(1),
-          [0, 1, 1],
+          [1, 1],
           { from: solver }
         ),
         "prices are not ordered by tokenId"
@@ -1101,7 +1101,7 @@ contract("BatchExchange", async accounts => {
           solution.touchedOrderIds,
           solution.volumes,
           solution.prices.slice(1),
-          [0, 2, 1],
+          [2, 1],
           { from: solver }
         ),
         "prices are not ordered by tokenId"
@@ -1148,8 +1148,8 @@ contract("BatchExchange", async accounts => {
           accounts.slice(0, 2),
           orderIds,
           [tenThousand, tenThousand],
-          [1, 0.9].map(toETH),
-          [0, 1],
+          [toETH(0.9)],
+          [1],
           { from: solver }
         ),
         "sell amount less than AMOUNT_MINIMUM"
@@ -1165,16 +1165,9 @@ contract("BatchExchange", async accounts => {
 
       const tooSmallBuyAmounts = [10000, 9990].map(val => new BN(val))
       await truffleAssert.reverts(
-        batchExchange.submitSolution(
-          batchIndex,
-          1,
-          accounts.slice(0, 2),
-          orderIds,
-          tooSmallBuyAmounts,
-          [1, 1].map(toETH),
-          [0, 1],
-          { from: solver }
-        ),
+        batchExchange.submitSolution(batchIndex, 1, accounts.slice(0, 2), orderIds, tooSmallBuyAmounts, [toETH(1)], [1], {
+          from: solver,
+        }),
         "buy amount less than AMOUNT_MINIMUM"
       )
     })
@@ -1194,8 +1187,8 @@ contract("BatchExchange", async accounts => {
         solution.owners,
         solution.touchedOrderIds,
         solution.volumes,
-        [1, 2, 3, 4].map(toETH),
-        [0, 1, 2, 3],
+        [2, 3, 4].map(toETH),
+        [1, 2, 3],
         { from: solver }
       )
     })
@@ -1390,7 +1383,7 @@ contract("BatchExchange", async accounts => {
 
       const tooManyOwners = Array(maxTouchedOrders + 1).fill(user_1)
       await truffleAssert.reverts(
-        batchExchange.submitSolution(batchIndex - 1, 1, tooManyOwners, [], [], [toETH(1)], [0]),
+        batchExchange.submitSolution(batchIndex - 1, 1, tooManyOwners, [], [], [toETH(1)], [1]),
         "Solution exceeds MAX_TOUCHED_ORDERS"
       )
     })

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -339,8 +339,8 @@ contract("BatchExchange", async accounts => {
       await truffleAssert.reverts(
         batchExchange.submitSolution(
           batchIndex,
-          1, /* objective value */
-          [accounts[0], accounts[1]], /* user ids */
+          1 /* objective value */,
+          [accounts[0], accounts[1]] /* user ids */,
           orderIds,
           solution.buyVolumes,
           solution.prices.slice(1),
@@ -1448,7 +1448,11 @@ contract("BatchExchange", async accounts => {
         const buyTokenBalance = await batchExchange.getBalance.call(relevantUser, buyToken)
 
         const expectedSellBalance = deposit.amount.sub(
-          getExecutedSellAmount(volumes[i], basicRingTrade.solutions[0].tokens[order.buyToken].price, basicRingTrade.solutions[0].tokens[order.buyToken].price)
+          getExecutedSellAmount(
+            volumes[i],
+            basicRingTrade.solutions[0].tokens[order.buyToken].price,
+            basicRingTrade.solutions[0].tokens[order.buyToken].price
+          )
         )
         assert(sellTokenBalance.eq(expectedSellBalance), `Sold tokens were not adjusted correctly at order index ${i}`)
         assert(buyTokenBalance.eq(volumes[i]), `Bought tokens were not adjusted correctly at order index ${i}`)
@@ -1526,9 +1530,7 @@ contract("BatchExchange", async accounts => {
       )
       assert.equal(
         (await batchExchange.getBalance.call(accounts[0], feeToken)).toString(),
-        smallExample.deposits[0].amount
-          .sub(getExecutedSellAmount(solution.volumes[0], toETH(1), solution.prices[0]))
-          .toString(),
+        smallExample.deposits[0].amount.sub(getExecutedSellAmount(solution.volumes[0], toETH(1), solution.prices[0])).toString(),
         "Sold tokens were not adjusted correctly"
       )
       // User 1
@@ -1546,9 +1548,7 @@ contract("BatchExchange", async accounts => {
       )
       assert.equal(
         (await batchExchange.getBalance.call(accounts[2], otherToken)).toString(),
-        smallExample.deposits[3].amount
-          .sub(getExecutedSellAmount(solution.volumes[3], solution.prices[0], toETH(1)))
-          .toString(),
+        smallExample.deposits[3].amount.sub(getExecutedSellAmount(solution.volumes[3], solution.prices[0], toETH(1))).toString(),
         "Sold tokens were not adjusted correctly"
       )
       // Now reverting should not throw due to temporarily negative balances, only later due to objective value criteria
@@ -1595,18 +1595,9 @@ contract("BatchExchange", async accounts => {
       // Fill essentially the remaining amount in
       const remainingBuyVolumes = [toETH(1), new BN("1998000000000000000")]
       // Note: The claimed objective value here is actually incorrect (but irrelevant for this test)
-      batchExchange.submitSolution(
-        batchIndex + 1,
-        1,
-        owners,
-        touchedOrderIds,
-        remainingBuyVolumes,
-        prices,
-        tokenIdsForPrice,
-        {
-          from: solver,
-        }
-      )
+      batchExchange.submitSolution(batchIndex + 1, 1, owners, touchedOrderIds, remainingBuyVolumes, prices, tokenIdsForPrice, {
+        from: solver,
+      })
 
       assert(basicTrade.orders.length == basicTrade.deposits.length)
       for (let i = 0; i < basicTrade.orders.length; i++) {
@@ -1623,7 +1614,13 @@ contract("BatchExchange", async accounts => {
 
         assert.equal(
           deposit.amount
-            .sub(getExecutedSellAmount(totalExecutedBuy, basicTrade.solutions[1].tokens[order.buyToken].price, basicTrade.solutions[1].tokens[order.sellToken].price))
+            .sub(
+              getExecutedSellAmount(
+                totalExecutedBuy,
+                basicTrade.solutions[1].tokens[order.buyToken].price,
+                basicTrade.solutions[1].tokens[order.sellToken].price
+              )
+            )
             .toString(),
           sellTokenBalance.toString(),
           `Sold tokens were not adjusted correctly ${i}`

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -338,6 +338,16 @@ contract("BatchExchange", async accounts => {
         "Token conservation at 0 must be positive"
       )
     })
+    it("rejects solutions attempting to set fee token price", async () => {
+      const batchExchange = await setupGenericStableX()
+
+      const batchIndex = (await batchExchange.getCurrentBatchId.call()).toNumber()
+      await closeAuction(batchExchange)
+      await truffleAssert.reverts(
+        batchExchange.submitSolution(batchIndex, 1, [], [], [], [10000], [0]),
+        "Fee token has fixed price!"
+      )
+    })
     it("rejects acclaimed marginally improved solutions", async () => {
       const stablecoinConverter = await setupGenericStableX()
 

--- a/test/stablex/token_conservation.js
+++ b/test/stablex/token_conservation.js
@@ -26,7 +26,6 @@ contract("TokenConservation", async () => {
       )
     })
   })
-
   describe("checkPriceOrdering()", () => {
     it("returns false when unordered", async () => {
       const tokenConservation = await TokenConservationWrapper.new()
@@ -43,13 +42,12 @@ contract("TokenConservation", async () => {
       assert.equal(await tokenConservation.checkPriceOrdering([1, 2, 3]), true, "Failed on [1, 2, 3]")
     })
   })
-
   describe("updateTokenConservation()", () => {
     it("calculates the updated tokenConservation array", async () => {
       const tokenConservation = await TokenConservationWrapper.new()
 
       const testArray = [0, 0, 0]
-      const tokenIdsForPrice = [0, 1, 2]
+      const tokenIdsForPrice = [1, 2]
       const buyToken = 2
       const sellToken = 1
       const buyAmount = 10

--- a/test/stablex/token_conservation.js
+++ b/test/stablex/token_conservation.js
@@ -46,8 +46,8 @@ contract("TokenConservation", async () => {
     it("calculates the updated tokenConservation array", async () => {
       const tokenConservation = await TokenConservationWrapper.new()
 
-      const testArray = [0, 0, 0]
-      const tokenIdsForPrice = [1, 2]
+      const testArray = [0, 0, 0, 0]
+      const tokenIdsForPrice = [1, 2, 3]
       const buyToken = 2
       const sellToken = 1
       const buyAmount = 10
@@ -63,8 +63,13 @@ contract("TokenConservation", async () => {
           sellAmount
         )
       ).map(a => a.toNumber())
-      const expectedArray = [0, 3, -10]
+      const expectedArray = [0, 3, -10, 0]
       assert.deepEqual(updatedArray, expectedArray)
+
+      const secondUpdatedArray = (
+        await tokenConservation.updateTokenConservationTest.call(testArray, 2, 3, tokenIdsForPrice, 1, 2)
+      ).map(a => a.toNumber())
+      assert.deepEqual([0, 0, -1, 2], secondUpdatedArray)
     })
     it("throws, if findPriceIndex does not find the token, as it is not supplied", async () => {
       const tokenConservation = await TokenConservationWrapper.new()


### PR DESCRIPTION
Closes #331 - but should not be merged until related PR (https://github.com/gnosis/dex-services/pull/315)  is also fully operational.

### Points to observe regarding changes here:
- There was a small adjustment to the binary search which still need to return a value for when token in question is the fee token (so results of binary search were all shifted in index by 1)
- an extra slot (for fee token) was made in `tokenConservation` vector upon initialization
- `currentPrices[0]` is initialized to 1 ether in the smart contract's constructor.
- `require(tokenIdsForPrice[0] != 0, "Fee token has fixed price!");` ensures that fee token price can not be manipulated.


### Special notes:
- Slicing the solution parameters when needed was necessary in order to keep the validation integrity of `generate.js` which evaluates things like solution utility.
- We may also want to check that specifying the fee token price fails with "Fee token has fixed price!"
- Price Scaling Hack is no longer an issue or concern. 
- `tokenConservation[0]` now ensures that the fee token was touched!