### PR TITLE
[Easy] Put staged files argument in quotation

### DIFF
--- a/pre-commit
+++ b/pre-commit
@@ -23,14 +23,14 @@ if [[ ("$STAGED_JS_FILES" = "") && ("$STAGED_SOL_FILES" = "") ]]; then
 fi
 
 printf "\nValidating Javascript:\n"
-validate $STAGED_JS_FILES "npx eslint" "ESLint"
-validate $STAGED_JS_FILES "npx prettier --check" "Prettier"
+validate "$STAGED_JS_FILES" "npx eslint" "ESLint"
+validate "$STAGED_JS_FILES" "npx prettier --check" "Prettier"
 printf "\nJavascript validation completed!\n"
 
 printf "\nValidating Solidity:\n"
-validate $STAGED_SOL_FILES "npx solhint" "Solhint"
-validate $STAGED_SOL_FILES "npx solium --file" "Solium"
-validate $STAGED_SOL_FILES "npx prettier --check" "Prettier"
+validate "$STAGED_SOL_FILES" "npx solhint" "Solhint"
+validate "$STAGED_SOL_FILES" "npx solium --file" "Solium"
+validate "$STAGED_SOL_FILES" "npx prettier --check" "Prettier"
 printf "\nSolidity validation completed!\n"
 
 if ! $PASS; then


### PR DESCRIPTION
Otherwise when we have multiple staged files, each one will count as it's own argument. Thus the validate function might have many more than 3 arguments and thus the command

```
$2 "$FILE"
```

will fail as $2 is no longer the command but instead the second staged file.

### Test Plan

commit on #372 