### PR TITLE
[Easy] Reordering variable declarations

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -21,10 +21,6 @@ contract BatchExchange is EpochTokenLocker {
     using TokenConservation for uint16[];
     using IterableAppendOnlySet for IterableAppendOnlySet.Data;
 
-    // Iterable set of all users, required to collect auction information
-    IterableAppendOnlySet.Data private allUsers;
-    IdToAddressBiMap.Data private registeredTokens;
-
     /** @dev Maximum number of touched orders in auction (used in submitSolution) */
     uint256 public constant MAX_TOUCHED_ORDERS = 25;
 
@@ -33,6 +29,11 @@ contract BatchExchange is EpochTokenLocker {
 
     /** @dev minimum allowed value (in WEI) of any prices or executed trade amounts */
     uint256 public constant AMOUNT_MINIMUM = 10**4;
+
+    /** Corresponds to percentage that competing solution must improve on current
+      * (p = IMPROVEMENT_DENOMINATOR + 1 / IMPROVEMENT_DENOMINATOR)
+      */
+    uint256 public constant IMPROVEMENT_DENOMINATOR = 100; // 1%
 
     /** @dev maximum number of tokens that can be listed for exchange */
     // solhint-disable-next-line var-name-mixedcase
@@ -43,11 +44,6 @@ contract BatchExchange is EpochTokenLocker {
 
     /** @dev A fixed integer used to evaluate fees as a fraction of trade execution 1/feeDenominator */
     uint128 public feeDenominator;
-
-    /** Corresponds to percentage that competing solution must improve on current
-      * (p = IMPROVEMENT_DENOMINATOR + 1 / IMPROVEMENT_DENOMINATOR)
-      */
-    uint256 public constant IMPROVEMENT_DENOMINATOR = 100; // 1%
 
     /** @dev The feeToken of the exchange will be the OWL Token */
     TokenOWL public feeToken;
@@ -60,6 +56,26 @@ contract BatchExchange is EpochTokenLocker {
 
     /** @dev Sufficient information for current winning auction solution */
     SolutionData public latestSolution;
+
+    // Iterable set of all users, required to collect auction information
+    IterableAppendOnlySet.Data private allUsers;
+    IdToAddressBiMap.Data private registeredTokens;
+
+    struct Order {
+        uint16 buyToken;
+        uint16 sellToken;
+        uint32 validFrom; // order is valid from auction collection period: validFrom inclusive
+        uint32 validUntil; // order is valid till auction collection period: validUntil inclusive
+        uint128 priceNumerator;
+        uint128 priceDenominator;
+        uint128 usedAmount; // remainingAmount = priceDenominator - usedAmount
+    }
+
+    struct TradeData {
+        address owner;
+        uint128 volume;
+        uint16 orderId;
+    }
 
     struct SolutionData {
         uint32 batchId;
@@ -90,22 +106,6 @@ contract BatchExchange is EpochTokenLocker {
     /** @dev Event emitted when an order is removed from storage.
      */
     event OrderDeletion(address owner, uint256 id);
-
-    struct Order {
-        uint16 buyToken;
-        uint16 sellToken;
-        uint32 validFrom; // order is valid from auction collection period: validFrom inclusive
-        uint32 validUntil; // order is valid till auction collection period: validUntil inclusive
-        uint128 priceNumerator;
-        uint128 priceDenominator;
-        uint128 usedAmount; // remainingAmount = priceDenominator - usedAmount
-    }
-
-    struct TradeData {
-        address owner;
-        uint128 volume;
-        uint16 orderId;
-    }
 
     /** @dev Constructor determines exchange parameters
       * @param maxTokens The maximum number of tokens that can be listed.

--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -14,13 +14,9 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 contract EpochTokenLocker {
     using SafeMath for uint256;
 
-    event Deposit(address user, address token, uint256 amount, uint256 stateIndex);
-
-    event WithdrawRequest(address user, address token, uint256 amount, uint256 stateIndex);
-
-    event Withdraw(address user, address token, uint256 amount);
-
+    /** @dev Number of seconds a batch is lasting*/
     uint32 public constant BATCH_TIME = 300;
+
     // User => Token => BalanceState
     mapping(address => mapping(address => BalanceState)) private balanceStates;
 
@@ -37,6 +33,12 @@ contract EpochTokenLocker {
         uint256 amount;
         uint32 stateIndex;
     }
+
+    event Deposit(address user, address token, uint256 amount, uint256 stateIndex);
+
+    event WithdrawRequest(address user, address token, uint256 amount, uint256 stateIndex);
+
+    event Withdraw(address user, address token, uint256 amount);
 
     /** @dev credits user with deposit amount on next epoch (given by getCurrentBatchId)
       * @param token address of token to be deposited


### PR DESCRIPTION
Anxo's comment about the order of variables and events:

I changed the ordering, such that constant variables are declared first, then they are followed by mutable variables and events
