### PR TITLE
Event for trade volume calculation

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -116,22 +116,6 @@ contract BatchExchange is EpochTokenLocker {
      */
     event TradeRevertion(address indexed owner, uint256 indexed orderIds, uint256 executedSellAmount, uint256 executedBuyAmount);
 
-    struct Order {
-        uint16 buyToken;
-        uint16 sellToken;
-        uint32 validFrom; // order is valid from auction collection period: validFrom inclusive
-        uint32 validUntil; // order is valid till auction collection period: validUntil inclusive
-        uint128 priceNumerator;
-        uint128 priceDenominator;
-        uint128 usedAmount; // remainingAmount = priceDenominator - usedAmount
-    }
-
-    struct TradeData {
-        address owner;
-        uint128 volume;
-        uint16 orderId;
-    }
-
     /** @dev Constructor determines exchange parameters
       * @param maxTokens The maximum number of tokens that can be listed.
       * @param _feeDenominator fee as a proportion is (1 / feeDenominator)

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -114,7 +114,7 @@ contract BatchExchange is EpochTokenLocker {
 
     /** @dev Event emitted when an already exectued trade gets reverted
      */
-    event TradeRevertion(address indexed owner, uint256 indexed orderIds, uint256 executedSellAmount, uint256 executedBuyAmount);
+    event TradeReversion(address indexed owner, uint256 indexed orderIds, uint256 executedSellAmount, uint256 executedBuyAmount);
 
     /** @dev Constructor determines exchange parameters
       * @param maxTokens The maximum number of tokens that can be listed.
@@ -532,7 +532,7 @@ contract BatchExchange is EpochTokenLocker {
                 (uint128 buyAmount, uint128 sellAmount) = getTradedAmounts(latestSolution.trades[i].volume, order);
                 revertRemainingOrder(owner, orderId, sellAmount);
                 subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyAmount);
-                emit TradeRevertion(owner, orderId, sellAmount, buyAmount);
+                emit TradeReversion(owner, orderId, sellAmount, buyAmount);
             }
             // subtract granted fees:
             subtractBalance(latestSolution.solutionSubmitter, tokenIdToAddressMap(0), latestSolution.feeReward);

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -108,13 +108,11 @@ contract BatchExchange is EpochTokenLocker {
      */
     event OrderDeletion(address owner, uint256 id);
 
-    /** @dev Event emitted when a new settlement via submitSolution is received
-     *  This Event allows to calculate the volumes of each trade
+    /** @dev Event emitted when a new trade is settled
      */
     event Trade(address indexed owner, uint256 indexed orderIds, uint256 executedSellAmount, uint256 executedBuyAmount);
 
-    /** @dev Event emitted when a new settlement via submitSolution is received
-     *  This Event allows to calculate the volumes of each trade
+    /** @dev Event emitted when an already exectued trade gets reverted
      */
     event TradeRevertion(address indexed owner, uint256 indexed orderIds, uint256 executedSellAmount, uint256 executedBuyAmount);
 

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -92,6 +92,19 @@ contract BatchExchange is EpochTokenLocker {
      */
     event OrderDeletion(address owner, uint256 id);
 
+    /** @dev Event emitted when a new settlement via submitSolution is received
+     *  This Event allows to calculate the volumes of each trade
+     */
+    event NewSettlement(
+        uint32 batchIndex,
+        uint256 objectiveValue,
+        address[] owners,
+        uint16[] orderIds,
+        uint128[] buyVolumes,
+        uint128[] prices,
+        uint16[] tokenIdsForPrice
+    );
+
     struct Order {
         uint16 buyToken;
         uint16 sellToken;
@@ -328,6 +341,8 @@ contract BatchExchange is EpochTokenLocker {
         grantRewardToSolutionSubmitter(burntFees);
         tokenConservation.checkTokenConservation();
         documentTrades(batchIndex, owners, orderIds, buyVolumes, tokenIdsForPrice);
+
+        emit NewSettlement(batchIndex, objectiveValue, owners, orderIds, buyVolumes, prices, tokenIdsForPrice);
         return (objectiveValue);
     }
     /**

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -337,7 +337,6 @@ contract BatchExchange is EpochTokenLocker {
         grantRewardToSolutionSubmitter(burntFees);
         tokenConservation.checkTokenConservation();
         documentTrades(batchIndex, owners, orderIds, buyVolumes, tokenIdsForPrice);
-
         return (objectiveValue);
     }
     /**
@@ -549,7 +548,7 @@ contract BatchExchange is EpochTokenLocker {
         );
         latestSolution.objectiveValue = newObjectiveValue;
     }
-    
+
     // Private view
     /** @dev Evaluates utility of executed trade
       * @param execBuy represents proportion of order executed (in terms of buy amount)
@@ -628,17 +627,6 @@ contract BatchExchange is EpochTokenLocker {
         return latestSolution.batchId == getCurrentBatchId() - 1;
     }
 
-    /** @dev determines if value is better than currently and updates if it is.
-      * @param newObjectiveValue proposed value to be updated if a great enough improvement on the current objective value
-      */
-    function checkAndOverrideObjectiveValue(uint256 newObjectiveValue) private {
-        require(
-            isObjectiveValueSufficientlyImproved(newObjectiveValue),
-            "New objective doesn't sufficiently improve current solution"
-        );
-        latestSolution.objectiveValue = newObjectiveValue;
-    }
-    
     // Private view
     /** @dev Compute trade execution based on executedBuyAmount and relevant token prices
       * @param executedBuyAmount executed buy amount
@@ -702,8 +690,8 @@ contract BatchExchange is EpochTokenLocker {
         element = element.concat(abi.encodePacked(getRemainingAmount(order)));
         return element;
     }
-    
-     /** @dev determines if value is better than currently and updates if it is.
+
+    /** @dev determines if value is better than currently and updates if it is.
       * @param amounts array of values to be verified with AMOUNT_MINIMUM
       */
     function verifyAmountThreshold(uint128[] memory amounts) private pure returns (bool) {

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -648,7 +648,6 @@ contract BatchExchange is EpochTokenLocker {
     }
 
     // Private view
-
     /** @dev Compute trade execution based on executedBuyAmount and relevant token prices
       * @param executedBuyAmount executed buy amount
       * @param order contains relevant buy-sell token information
@@ -672,7 +671,6 @@ contract BatchExchange is EpochTokenLocker {
     }
 
     // Private pure
-
     /** @dev used to determine if an order is valid for specific auction/batch
       * @param order object whose validity is in question
       * @param batchIndex auction index of validity

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -549,7 +549,6 @@ contract BatchExchange is EpochTokenLocker {
                 revertRemainingOrder(owner, orderId, sellAmount);
                 subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyAmount);
                 emit TradeRevertion(owner, orderId, sellAmount, buyAmount);
-
             }
             // subtract granted fees:
             subtractBalance(latestSolution.solutionSubmitter, tokenIdToAddressMap(0), latestSolution.feeReward);


### PR DESCRIPTION
Anxo noted in his review:
Listing trades: This queries would be basic usage of the exchange


And we discussed later on that we want to emit Events such that we can calculate the trading volume of each order.
I created this event, which contains the  batch index and the objective value. Hence, we can filter for the settlement events with the highest objective value per batchIndex and then easily calculate the trading volumes used for settling a batch