### PR TITLE
Function signature:internal->private, public->external

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -137,7 +137,7 @@ contract BatchExchange is EpochTokenLocker {
       * Emits an {OrderPlacement} event with all relevant order details.
       */
     function placeOrder(uint16 buyToken, uint16 sellToken, uint32 validUntil, uint128 buyAmount, uint128 sellAmount)
-        external
+        public
         returns (uint256)
     {
         return placeOrderInternal(buyToken, sellToken, getCurrentBatchId(), validUntil, buyAmount, sellAmount);
@@ -163,7 +163,7 @@ contract BatchExchange is EpochTokenLocker {
         uint32[] calldata validUntils,
         uint128[] calldata buyAmounts,
         uint128[] calldata sellAmounts
-    ) external returns (uint256[] memory orderIds) {
+    ) public returns (uint256[] memory orderIds) {
         cancelOrders(cancellations);
         return placeValidFromOrders(buyTokens, sellTokens, validFroms, validUntils, buyAmounts, sellAmounts);
     }

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -126,6 +126,48 @@ contract BatchExchange is EpochTokenLocker {
         addToken(_feeToken); // feeToken will always have the token index 0
     }
 
+    /** @dev A user facing function used to place limit sell orders in auction with expiry defined by batchId
+      * @param buyToken id of token to be bought
+      * @param sellToken id of token to be sold
+      * @param validUntil batchId represnting order's expiry
+      * @param buyAmount relative minimum amount of requested buy amount
+      * @param sellAmount maximum amount of sell token to be exchanged
+      * @return orderId as index of user's current orders
+      *
+      * Emits an {OrderPlacement} event with all relevant order details.
+      */
+    function placeOrder(uint16 buyToken, uint16 sellToken, uint32 validUntil, uint128 buyAmount, uint128 sellAmount)
+        external
+        returns (uint256)
+    {
+        return placeOrderInternal(buyToken, sellToken, getCurrentBatchId(), validUntil, buyAmount, sellAmount);
+    }
+
+    /** @dev A user facing wrapper to cancel and place new orders in the same transaction.
+      * @param cancellations ids of orders to be cancelled
+      * @param buyTokens ids of tokens to be bought in new orders
+      * @param sellTokens ids of tokens to be sold in new orders
+      * @param validFroms batchIds representing order's validity start time in new orders
+      * @param validUntils batchIds represnnting order's expiry in new orders
+      * @param buyAmounts relative minimum amount of requested buy amounts in new orders
+      * @param sellAmounts maximum amounts of sell token to be exchanged in new orders
+      * @return `orderIds` an array of indices in which `msg.sender`'s new orders are included
+      *
+      * Emits {OrderCancelation} events for all cancelled orders and {OrderPlacement} events with all relevant new order details.
+      */
+    function replaceOrders(
+        uint256[] calldata cancellations,
+        uint16[] calldata buyTokens,
+        uint16[] calldata sellTokens,
+        uint32[] calldata validFroms,
+        uint32[] calldata validUntils,
+        uint128[] calldata buyAmounts,
+        uint128[] calldata sellAmounts
+    ) external returns (uint256[] memory orderIds) {
+        cancelOrders(cancellations);
+        return placeValidFromOrders(buyTokens, sellTokens, validFroms, validUntils, buyAmounts, sellAmounts);
+    }
+
     /** @dev Used to list a new token on the contract: Hence, making it available for exchange in an auction.
       * @param token ERC20 token to be listed.
       *
@@ -176,23 +218,6 @@ contract BatchExchange is EpochTokenLocker {
         }
     }
 
-    /** @dev A user facing function used to place limit sell orders in auction with expiry defined by batchId
-      * @param buyToken id of token to be bought
-      * @param sellToken id of token to be sold
-      * @param validUntil batchId represnting order's expiry
-      * @param buyAmount relative minimum amount of requested buy amount
-      * @param sellAmount maximum amount of sell token to be exchanged
-      * @return orderId as index of user's current orders
-      *
-      * Emits an {OrderPlacement} event with all relevant order details.
-      */
-    function placeOrder(uint16 buyToken, uint16 sellToken, uint32 validUntil, uint128 buyAmount, uint128 sellAmount)
-        public
-        returns (uint256)
-    {
-        return placeOrderInternal(buyToken, sellToken, getCurrentBatchId(), validUntil, buyAmount, sellAmount);
-    }
-
     /** @dev a user facing function used to cancel orders. If the order is valid for the batch that is currently
       * being solved, it sets order expiry to that batchId. Otherwise it removes it from storage. Can be called
       * multiple times (e.g. to eventually free storage once order is expired).
@@ -211,31 +236,6 @@ contract BatchExchange is EpochTokenLocker {
                 emit OrderCancelation(msg.sender, ids[i]);
             }
         }
-    }
-
-    /** @dev A user facing wrapper to cancel and place new orders in the same transaction.
-      * @param cancellations ids of orders to be cancelled
-      * @param buyTokens ids of tokens to be bought in new orders
-      * @param sellTokens ids of tokens to be sold in new orders
-      * @param validFroms batchIds representing order's validity start time in new orders
-      * @param validUntils batchIds represnnting order's expiry in new orders
-      * @param buyAmounts relative minimum amount of requested buy amounts in new orders
-      * @param sellAmounts maximum amounts of sell token to be exchanged in new orders
-      * @return `orderIds` an array of indices in which `msg.sender`'s new orders are included
-      *
-      * Emits {OrderCancelation} events for all cancelled orders and {OrderPlacement} events with all relevant new order details.
-      */
-    function replaceOrders(
-        uint256[] memory cancellations,
-        uint16[] memory buyTokens,
-        uint16[] memory sellTokens,
-        uint32[] memory validFroms,
-        uint32[] memory validUntils,
-        uint128[] memory buyAmounts,
-        uint128[] memory sellAmounts
-    ) public returns (uint256[] memory orderIds) {
-        cancelOrders(cancellations);
-        return placeValidFromOrders(buyTokens, sellTokens, validFroms, validUntils, buyAmounts, sellAmounts);
     }
 
     /** @dev a solver facing function called for auction settlement
@@ -405,7 +405,7 @@ contract BatchExchange is EpochTokenLocker {
         }
     }
     /**
-     * Internal Functions
+     * Private Functions
      */
 
     function placeOrderInternal(
@@ -415,7 +415,7 @@ contract BatchExchange is EpochTokenLocker {
         uint32 validUntil,
         uint128 buyAmount,
         uint128 sellAmount
-    ) internal returns (uint256) {
+    ) private returns (uint256) {
         require(buyToken != sellToken, "Exchange tokens not distinct");
         require(validFrom >= getCurrentBatchId(), "Orders can't be placed in the past");
         orders[msg.sender].push(
@@ -438,14 +438,14 @@ contract BatchExchange is EpochTokenLocker {
     /** @dev called at the end of submitSolution with a value of tokenConservation / 2
       * @param feeReward amount to be rewarded to the solver
       */
-    function grantRewardToSolutionSubmitter(uint256 feeReward) internal {
+    function grantRewardToSolutionSubmitter(uint256 feeReward) private {
         latestSolution.feeReward = feeReward;
         addBalanceAndBlockWithdrawForThisBatch(msg.sender, tokenIdToAddressMap(0), feeReward);
     }
 
     /** @dev called during solution submission to burn fees from previous auction
       */
-    function burnPreviousAuctionFees() internal {
+    function burnPreviousAuctionFees() private {
         if (!currentBatchHasSolution()) {
             feeToken.burnOWL(address(this), latestSolution.feeReward);
         }
@@ -455,7 +455,7 @@ contract BatchExchange is EpochTokenLocker {
       * @param prices list of prices for touched tokens only, first price is always fee token price
       * @param tokenIdsForPrice price[i] is the price for the token with tokenID tokenIdsForPrice[i]
       */
-    function updateCurrentPrices(uint128[] memory prices, uint16[] memory tokenIdsForPrice) internal {
+    function updateCurrentPrices(uint128[] memory prices, uint16[] memory tokenIdsForPrice) private {
         for (uint256 i = 0; i < latestSolution.tokenIdsForPrice.length; i++) {
             currentPrices[latestSolution.tokenIdsForPrice[i]] = 0;
         }
@@ -469,7 +469,7 @@ contract BatchExchange is EpochTokenLocker {
       * @param orderId index of order in list of owner's orders
       * @param executedAmount proportion of order's requested sellAmount that was filled.
       */
-    function updateRemainingOrder(address owner, uint256 orderId, uint128 executedAmount) internal {
+    function updateRemainingOrder(address owner, uint256 orderId, uint128 executedAmount) private {
         orders[owner][orderId].usedAmount = orders[owner][orderId].usedAmount.add(executedAmount).toUint128();
     }
 
@@ -478,7 +478,7 @@ contract BatchExchange is EpochTokenLocker {
       * @param orderId index of order in list of owner's orders
       * @param executedAmount proportion of order's requested sellAmount that was filled.
       */
-    function revertRemainingOrder(address owner, uint256 orderId, uint128 executedAmount) internal {
+    function revertRemainingOrder(address owner, uint256 orderId, uint128 executedAmount) private {
         orders[owner][orderId].usedAmount = orders[owner][orderId].usedAmount.sub(executedAmount).toUint128();
     }
 
@@ -495,7 +495,7 @@ contract BatchExchange is EpochTokenLocker {
         uint16[] memory orderIds,
         uint128[] memory volumes,
         uint16[] memory tokenIdsForPrice
-    ) internal {
+    ) private {
         latestSolution.batchId = batchIndex;
         for (uint256 i = 0; i < owners.length; i++) {
             latestSolution.trades.push(TradeData({owner: owners[i], orderId: orderIds[i], volume: volumes[i]}));
@@ -506,7 +506,7 @@ contract BatchExchange is EpochTokenLocker {
 
     /** @dev reverts all relevant contract storage relating to an overwritten auction solution.
       */
-    function undoCurrentSolution() internal {
+    function undoCurrentSolution() private {
         if (currentBatchHasSolution()) {
             for (uint256 i = 0; i < latestSolution.trades.length; i++) {
                 address owner = latestSolution.trades[i].owner;
@@ -527,14 +527,38 @@ contract BatchExchange is EpochTokenLocker {
             subtractBalance(latestSolution.solutionSubmitter, tokenIdToAddressMap(0), latestSolution.feeReward);
         }
     }
-    // Internal view
+
+    /** @dev determines if value is better than currently and updates if it is.
+      * @param newObjectiveValue proposed value to be updated if a great enough improvement on the current objective value
+      */
+    function checkAndOverrideObjectiveValue(uint256 newObjectiveValue) private {
+        require(
+            isObjectiveValueSufficientlyImproved(newObjectiveValue),
+            "New objective doesn't sufficiently improve current solution"
+        );
+        latestSolution.objectiveValue = newObjectiveValue;
+    }
+
+    /** @dev determines if value is better than currently and updates if it is.
+      * @param amounts array of values to be verified with AMOUNT_MINIMUM
+      */
+    function verifyAmountThreshold(uint128[] memory amounts) private pure returns (bool) {
+        for (uint256 i = 0; i < amounts.length; i++) {
+            if (amounts[i] < AMOUNT_MINIMUM) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // Private view
 
     /** @dev Evaluates utility of executed trade
       * @param execBuy represents proportion of order executed (in terms of buy amount)
       * @param order the sell order whose utility is being evaluated
       * @return Utility = ((execBuy * order.sellAmt - execSell * order.buyAmt) * price.buyToken) / order.sellAmt
       */
-    function evaluateUtility(uint128 execBuy, Order memory order) internal view returns (uint256) {
+    function evaluateUtility(uint128 execBuy, Order memory order) private view returns (uint256) {
         // Utility = ((execBuy * order.sellAmt - execSell * order.buyAmt) * price.buyToken) / order.sellAmt
         uint256 execSellTimesBuy = getExecutedSellAmount(execBuy, currentPrices[order.buyToken], currentPrices[order.sellToken])
             .mul(order.priceNumerator);
@@ -557,7 +581,7 @@ contract BatchExchange is EpochTokenLocker {
       * Balances and orders have all been updated so: sellAmount - execSellAmt == remainingAmount(order).
       * For correctness, we take the minimum of this with the user's token balance.
       */
-    function evaluateDisregardedUtility(Order memory order, address user) internal view returns (uint256) {
+    function evaluateDisregardedUtility(Order memory order, address user) private view returns (uint256) {
         uint256 leftoverSellAmount = Math.min(getRemainingAmount(order), getBalance(user, tokenIdToAddressMap(order.sellToken)));
         uint256 limitTermLeft = currentPrices[order.sellToken].mul(order.priceDenominator);
         uint256 limitTermRight = order.priceNumerator.mul(currentPrices[order.buyToken]).mul(feeDenominator).div(
@@ -586,7 +610,7 @@ contract BatchExchange is EpochTokenLocker {
       *                = ((executedBuyAmount * buyTokenPrice) / (feeDenominator - 1)) * feeDenominator) / sellTokenPrice
       */
     function getExecutedSellAmount(uint128 executedBuyAmount, uint128 buyTokenPrice, uint128 sellTokenPrice)
-        internal
+        private
         view
         returns (uint128)
     {
@@ -598,9 +622,6 @@ contract BatchExchange is EpochTokenLocker {
                 .div(sellTokenPrice)
                 .toUint128();
     }
-    /**
-     * Private Functions
-     */
 
     /** @dev used to determine if solution if first provided in current batch
       * @return true if `latestSolution` is storing a solution for current batch, else false
@@ -608,31 +629,6 @@ contract BatchExchange is EpochTokenLocker {
     function currentBatchHasSolution() private view returns (bool) {
         return latestSolution.batchId == getCurrentBatchId() - 1;
     }
-
-    /** @dev determines if value is better than currently and updates if it is.
-      * @param newObjectiveValue proposed value to be updated if a great enough improvement on the current objective value
-      */
-    function checkAndOverrideObjectiveValue(uint256 newObjectiveValue) private {
-        require(
-            isObjectiveValueSufficientlyImproved(newObjectiveValue),
-            "New objective doesn't sufficiently improve current solution"
-        );
-        latestSolution.objectiveValue = newObjectiveValue;
-    }
-
-    /** @dev determines if value is better than currently and updates if it is.
-      * @param amounts array of values to be verified with AMOUNT_MINIMUM
-      */
-    function verifyAmountThreshold(uint128[] memory amounts) private pure returns (bool) {
-        for (uint256 i = 0; i < amounts.length; i++) {
-            if (amounts[i] < AMOUNT_MINIMUM) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    // Private view
 
     /** @dev Compute trade execution based on executedBuyAmount and relevant token prices
       * @param executedBuyAmount executed buy amount

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -226,13 +226,13 @@ contract BatchExchange is EpochTokenLocker {
       * Emits {OrderCancelation} events for all cancelled orders and {OrderPlacement} events with all relevant new order details.
       */
     function replaceOrders(
-        uint256[] calldata cancellations,
-        uint16[] calldata buyTokens,
-        uint16[] calldata sellTokens,
-        uint32[] calldata validFroms,
-        uint32[] calldata validUntils,
-        uint128[] calldata buyAmounts,
-        uint128[] calldata sellAmounts
+        uint256[] memory cancellations,
+        uint16[] memory buyTokens,
+        uint16[] memory sellTokens,
+        uint32[] memory validFroms,
+        uint32[] memory validUntils,
+        uint128[] memory buyAmounts,
+        uint128[] memory sellAmounts
     ) public returns (uint256[] memory orderIds) {
         cancelOrders(cancellations);
         return placeValidFromOrders(buyTokens, sellTokens, validFroms, validUntils, buyAmounts, sellAmounts);
@@ -550,7 +550,6 @@ contract BatchExchange is EpochTokenLocker {
         }
         return true;
     }
-
     // Private view
 
     /** @dev Evaluates utility of executed trade

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -126,48 +126,6 @@ contract BatchExchange is EpochTokenLocker {
         addToken(_feeToken); // feeToken will always have the token index 0
     }
 
-    /** @dev A user facing function used to place limit sell orders in auction with expiry defined by batchId
-      * @param buyToken id of token to be bought
-      * @param sellToken id of token to be sold
-      * @param validUntil batchId represnting order's expiry
-      * @param buyAmount relative minimum amount of requested buy amount
-      * @param sellAmount maximum amount of sell token to be exchanged
-      * @return orderId as index of user's current orders
-      *
-      * Emits an {OrderPlacement} event with all relevant order details.
-      */
-    function placeOrder(uint16 buyToken, uint16 sellToken, uint32 validUntil, uint128 buyAmount, uint128 sellAmount)
-        public
-        returns (uint256)
-    {
-        return placeOrderInternal(buyToken, sellToken, getCurrentBatchId(), validUntil, buyAmount, sellAmount);
-    }
-
-    /** @dev A user facing wrapper to cancel and place new orders in the same transaction.
-      * @param cancellations ids of orders to be cancelled
-      * @param buyTokens ids of tokens to be bought in new orders
-      * @param sellTokens ids of tokens to be sold in new orders
-      * @param validFroms batchIds representing order's validity start time in new orders
-      * @param validUntils batchIds represnnting order's expiry in new orders
-      * @param buyAmounts relative minimum amount of requested buy amounts in new orders
-      * @param sellAmounts maximum amounts of sell token to be exchanged in new orders
-      * @return `orderIds` an array of indices in which `msg.sender`'s new orders are included
-      *
-      * Emits {OrderCancelation} events for all cancelled orders and {OrderPlacement} events with all relevant new order details.
-      */
-    function replaceOrders(
-        uint256[] calldata cancellations,
-        uint16[] calldata buyTokens,
-        uint16[] calldata sellTokens,
-        uint32[] calldata validFroms,
-        uint32[] calldata validUntils,
-        uint128[] calldata buyAmounts,
-        uint128[] calldata sellAmounts
-    ) public returns (uint256[] memory orderIds) {
-        cancelOrders(cancellations);
-        return placeValidFromOrders(buyTokens, sellTokens, validFroms, validUntils, buyAmounts, sellAmounts);
-    }
-
     /** @dev Used to list a new token on the contract: Hence, making it available for exchange in an auction.
       * @param token ERC20 token to be listed.
       *
@@ -183,6 +141,23 @@ contract BatchExchange is EpochTokenLocker {
         }
         require(IdToAddressBiMap.insert(registeredTokens, numTokens, token), "Token already registered");
         numTokens++;
+    }
+
+    /** @dev A user facing function used to place limit sell orders in auction with expiry defined by batchId
+      * @param buyToken id of token to be bought
+      * @param sellToken id of token to be sold
+      * @param validUntil batchId represnting order's expiry
+      * @param buyAmount relative minimum amount of requested buy amount
+      * @param sellAmount maximum amount of sell token to be exchanged
+      * @return orderId as index of user's current orders
+      *
+      * Emits an {OrderPlacement} event with all relevant order details.
+      */
+    function placeOrder(uint16 buyToken, uint16 sellToken, uint32 validUntil, uint128 buyAmount, uint128 sellAmount)
+        public
+        returns (uint256)
+    {
+        return placeOrderInternal(buyToken, sellToken, getCurrentBatchId(), validUntil, buyAmount, sellAmount);
     }
 
     /** @dev A user facing function used to place limit sell orders in auction with expiry defined by batchId
@@ -236,6 +211,31 @@ contract BatchExchange is EpochTokenLocker {
                 emit OrderCancelation(msg.sender, ids[i]);
             }
         }
+    }
+
+    /** @dev A user facing wrapper to cancel and place new orders in the same transaction.
+      * @param cancellations ids of orders to be cancelled
+      * @param buyTokens ids of tokens to be bought in new orders
+      * @param sellTokens ids of tokens to be sold in new orders
+      * @param validFroms batchIds representing order's validity start time in new orders
+      * @param validUntils batchIds represnnting order's expiry in new orders
+      * @param buyAmounts relative minimum amount of requested buy amounts in new orders
+      * @param sellAmounts maximum amounts of sell token to be exchanged in new orders
+      * @return `orderIds` an array of indices in which `msg.sender`'s new orders are included
+      *
+      * Emits {OrderCancelation} events for all cancelled orders and {OrderPlacement} events with all relevant new order details.
+      */
+    function replaceOrders(
+        uint256[] calldata cancellations,
+        uint16[] calldata buyTokens,
+        uint16[] calldata sellTokens,
+        uint32[] calldata validFroms,
+        uint32[] calldata validUntils,
+        uint128[] calldata buyAmounts,
+        uint128[] calldata sellAmounts
+    ) public returns (uint256[] memory orderIds) {
+        cancelOrders(cancellations);
+        return placeValidFromOrders(buyTokens, sellTokens, validFroms, validUntils, buyAmounts, sellAmounts);
     }
 
     /** @dev a solver facing function called for auction settlement


### PR DESCRIPTION
As discussed with anxo, I checked all the function signatures.

We used internal as a function signature a lot, although it would only be required for inheritance.

I would love to make submitSolution as external, but then I am running into stack-too-deep errors, as then the arrays: prices, tokenIdsForPrice are declared as calldata and memory, and hence use more space in the stack

---
testplan: test suite only