### PR TITLE
Using user in withdraw

### DIFF
--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -104,10 +104,10 @@ contract EpochTokenLocker {
             "withdraw was not registered previously"
         );
         require(
-            lastCreditBatchId[msg.sender][token] < getCurrentBatchId(),
+            lastCreditBatchId[user][token] < getCurrentBatchId(),
             "Withdraw not possible for token that is traded in the current auction"
         );
-        uint256 amount = Math.min(balanceStates[user][token].balance, balanceStates[msg.sender][token].pendingWithdraws.amount);
+        uint256 amount = Math.min(balanceStates[user][token].balance, balanceStates[user][token].pendingWithdraws.amount);
 
         balanceStates[user][token].balance = balanceStates[user][token].balance.sub(amount);
         delete balanceStates[user][token].pendingWithdraws;

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -1323,7 +1323,7 @@ contract("BatchExchange", async accounts => {
         "Last credited batch for touched buy token should be current batch"
       )
       await truffleAssert.reverts(
-        batchExchange.withdraw(relevantUser, buyToken, { from: relevantUser }),
+        batchExchange.withdraw(relevantUser, buyToken),
         "Withdraw not possible for token that is traded in the current auction"
       )
     })
@@ -1353,7 +1353,7 @@ contract("BatchExchange", async accounts => {
 
       assert.equal(batchIndex + 1, (await batchExchange.lastCreditBatchId.call(solver, feeToken)).toString())
       await truffleAssert.reverts(
-        batchExchange.withdraw(solver, feeToken, { from: solver }),
+        batchExchange.withdraw(solver, feeToken),
         "Withdraw not possible for token that is traded in the current auction"
       )
     })


### PR DESCRIPTION
In the function withdraw, we used `msg.sender` and the variable `user`.

Bug found by Adam.

I changed the tests, so that they would spot it.

---

How could this happen? Analysis:
The relevant change was made in this PR:
https://github.com/gnosis/dex-contracts/pull/233

First, I implemented the fix only with msg.sender and without any use of the "user", it got approved. And then I did the merge with master. Unfortunately, I did not pay enough attention to this merge and... the "user" was introduced in withdraw, but not in the new lines of withdraw().

What can we learn about?
- being more careful with merges - definitively
- approving after merges? - this is not practical, I guess.
 