### PR TITLE
better orderIndexManagement

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -4,7 +4,7 @@
     "indent": ["error", 4],
     "quotes": ["error", "double"],
     "max-line-length": ["error", 129],
-    "function-max-lines": ["error", 60],
+    "function-max-lines": ["error", 61],
     "max-states-count": ["error", 18],
     "compiler-fixed": true,
     "no-simple-event-func-name": true,

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -210,24 +210,24 @@ contract BatchExchange is EpochTokenLocker {
       * being solved, it sets order expiry to that batchId. Otherwise it removes it from storage. Can be called
       * multiple times (e.g. to eventually free storage once order is expired).
       *
-      * @param ids referencing the index of user's order to be canceled
+      * @param indices referencing the index of user's order to be canceled
       *
       * Emits an {OrderCancelation} or {OrderDeletion} with sender's address and orderIndex
       */
-    function cancelOrders(uint256[] memory ids) public {
-        for (uint256 i = 0; i < ids.length; i++) {
-            if (!checkOrderValidity(orders[msg.sender][ids[i]], getCurrentBatchId() - 1)) {
-                delete orders[msg.sender][ids[i]];
-                emit OrderDeletion(msg.sender, ids[i]);
+    function cancelOrders(uint256[] memory indices) public {
+        for (uint256 i = 0; i < indices.length; i++) {
+            if (!checkOrderValidity(orders[msg.sender][indices[i]], getCurrentBatchId() - 1)) {
+                delete orders[msg.sender][indices[i]];
+                emit OrderDeletion(msg.sender, indices[i]);
             } else {
-                orders[msg.sender][ids[i]].validUntil = getCurrentBatchId() - 1;
-                emit OrderCancelation(msg.sender, ids[i]);
+                orders[msg.sender][indices[i]].validUntil = getCurrentBatchId() - 1;
+                emit OrderCancelation(msg.sender, indices[i]);
             }
         }
     }
 
     /** @dev A user facing wrapper to cancel and place new orders in the same transaction.
-      * @param cancellations ids of orders to be cancelled
+      * @param cancellations indices of orders to be cancelled
       * @param buyTokens ids of tokens to be bought in new orders
       * @param sellTokens ids of tokens to be sold in new orders
       * @param validFroms batchIds representing order's validity start time in new orders
@@ -254,7 +254,7 @@ contract BatchExchange is EpochTokenLocker {
     /** @dev a solver facing function called for auction settlement
       * @param batchId index of auction solution is referring to
       * @param owners array of addresses corresponding to touched orders
-      * @param orderIndices array of order ids used in parallel with owners to identify touched order
+      * @param orderIndices array of order indices used in parallel with owners to identify touched order
       * @param buyVolumes executed buy amounts for each order identified by index of owner-orderIndex arrays
       * @param prices list of prices for touched tokens indexed by next parameter
       * @param tokenIdsForPrice price[i] is the price for the token with tokenID tokenIdsForPrice[i]
@@ -501,7 +501,7 @@ contract BatchExchange is EpochTokenLocker {
     /** @dev This function writes solution information into contract storage
       * @param batchId index of referenced auction
       * @param owners array of addresses corresponding to touched orders
-      * @param orderIndices array of order ids used in parallel with owners to identify touched order
+      * @param orderIndices array of order indices used in parallel with owners to identify touched order
       * @param volumes executed buy amounts for each order identified by index of owner-orderIndex arrays
       * @param tokenIdsForPrice price[i] is the price for the token with tokenID tokenIdsForPrice[i]
       */

--- a/scripts/stablex/cancel_order.js
+++ b/scripts/stablex/cancel_order.js
@@ -3,7 +3,7 @@ const argv = require("yargs")
   .option("accountId", {
     describe: "Account index of the order placer",
   })
-  .demand(["accountId", "orderId"])
+  .demand(["accountId", "orderIndex"])
   .help(false)
   .version(false).argv
 
@@ -11,9 +11,9 @@ module.exports = async callback => {
   try {
     const accounts = await web3.eth.getAccounts()
     const instance = await BatchExchange.deployed()
-    await instance.cancelOrders([argv.orderId], { from: accounts[argv.accountId] })
+    await instance.cancelOrders([argv.orderIndex], { from: accounts[argv.accountId] })
 
-    console.log(`Successfully cancelled order with ID ${argv.orderId}`)
+    console.log(`Successfully cancelled order with ID ${argv.orderIndex}`)
     callback()
   } catch (error) {
     callback(error)

--- a/test/resources/examples/generate.js
+++ b/test/resources/examples/generate.js
@@ -126,7 +126,7 @@ function generateTestCase(input, strict = true, debug = false) {
 /**
  * Prints debug information for a test case.
  * @param {TestCase} testCase The test case
- * @param {BN[]|number[]} [orderIndices] The optional order ids for display, defaults to [0...]
+ * @param {BN[]|number[]} [orderIndices] The optional order indices for display, defaults to [0...]
  * @param {string[]} [accounts] The optional accounts for display, defaults to [1...]
  */
 function debugTestCase(testCase, orderIndices, accounts) {
@@ -183,7 +183,7 @@ function debugTestCase(testCase, orderIndices, accounts) {
  * @type {object}
  * @property {BN} objectiveValue The computed objective value for the solution
  * @property {string[]} owners The account addresses for thr order orners
- * @property {string[]} touchedOrderIndices The ids of touched orders
+ * @property {string[]} touchedOrderIndices The indices of touched orders
  * @property {BN[]} volumes The buy volumes
  * @property {BN[]} prices The prices of touched tokens
  * @property {number[]} tokenIdsForPrice The ids of the touched tokens
@@ -191,10 +191,10 @@ function debugTestCase(testCase, orderIndices, accounts) {
 
 /**
  * Generates `submitSolution` parameters for a given computed solution. Note
- * that this requires order ids as they are not known until runtime.
+ * that this requires order indices as they are not known until runtime.
  * @param {ComputedSolution} solution The computed solution
- * @param {string[]} accounts The order ids as they are on the contract
- * @param {BN[]|number[]} orderIndices The order ids as they are on the contract
+ * @param {string[]} accounts The order indices as they are on the contract
+ * @param {BN[]|number[]} orderIndices The order indices as they are on the contract
  * @return {SolutionParams} The parameters to submit the solution
  */
 function solutionSubmissionParams(solution, accounts, orderIndices) {

--- a/test/resources/examples/generate.js
+++ b/test/resources/examples/generate.js
@@ -183,7 +183,7 @@ function debugTestCase(testCase, orderIndices, accounts) {
  * @type {object}
  * @property {BN} objectiveValue The computed objective value for the solution
  * @property {string[]} owners The account addresses for thr order orners
- * @property {string[]} touchedOrderIds The ids of touched orders
+ * @property {string[]} touchedOrderIndices The ids of touched orders
  * @property {BN[]} volumes The buy volumes
  * @property {BN[]} prices The prices of touched tokens
  * @property {number[]} tokenIdsForPrice The ids of the touched tokens
@@ -212,7 +212,7 @@ function solutionSubmissionParams(solution, accounts, orderIndices) {
   return {
     objectiveValue: solution.objectiveValue,
     owners: solution.orders.map(o => accounts[o.user]),
-    touchedOrderIds: solution.orders.map(o => orderIndices[o.idx]),
+    touchedOrderIndices: solution.orders.map(o => orderIndices[o.idx]),
     volumes: solution.orders.map(o => o.buy),
     prices: solution.tokens.slice(1).map(t => t.price),
     tokenIdsForPrice: solution.tokens.slice(1).map(t => t.id),

--- a/test/resources/examples/generate.js
+++ b/test/resources/examples/generate.js
@@ -126,15 +126,15 @@ function generateTestCase(input, strict = true, debug = false) {
 /**
  * Prints debug information for a test case.
  * @param {TestCase} testCase The test case
- * @param {BN[]|number[]} [orderIds] The optional order ids for display, defaults to [0...]
+ * @param {BN[]|number[]} [orderIndices] The optional order ids for display, defaults to [0...]
  * @param {string[]} [accounts] The optional accounts for display, defaults to [1...]
  */
-function debugTestCase(testCase, orderIds, accounts) {
-  assert(orderIds === undefined || Array.isArray(orderIds), "orderIds is not an array")
+function debugTestCase(testCase, orderIndices, accounts) {
+  assert(orderIndices === undefined || Array.isArray(orderIndices), "orderIndices is not an array")
   assert(accounts === undefined || Array.isArray(accounts), "accounts is not an array")
 
   const userCount = Math.max(...testCase.orders.map(o => o.user)) + 1
-  orderIds = orderIds || testCase.orders.map((_, i) => i)
+  orderIndices = orderIndices || testCase.orders.map((_, i) => i)
   accounts =
     accounts ||
     (() => {
@@ -145,10 +145,10 @@ function debugTestCase(testCase, orderIds, accounts) {
       return accounts
     })()
 
-  assert(testCase.orders.length === orderIds.length, "missing orders in orderIds")
+  assert(testCase.orders.length === orderIndices.length, "missing orders in orderIndices")
   assert(userCount <= accounts.length, "missing users in accounts")
 
-  orderIds.forEach((o, i) => assert(BN.isBN(o) || Number.isInteger(o), `invalid order id at index ${i}`))
+  orderIndices.forEach((o, i) => assert(BN.isBN(o) || Number.isInteger(o), `invalid order id at index ${i}`))
   accounts.forEach((a, i) => assert(typeof a === "string", `invalid account at index ${i}`))
 
   const usernames = accounts.map(a => (a.length > 8 ? `${a.substr(0, 5)}…${a.substr(a.length - 3)}` : a))
@@ -156,7 +156,7 @@ function debugTestCase(testCase, orderIds, accounts) {
   formatHeader("Orders")
   formatTable([
     ["Id", "User", "Buy Token", "Buy Amount", "Sell Token", "Sell Amount"],
-    ...testCase.orders.map((o, i) => [orderIds[i], usernames[o.user], o.buyToken, o.buyAmount, o.sellToken, o.sellAmount]),
+    ...testCase.orders.map((o, i) => [orderIndices[i], usernames[o.user], o.buyToken, o.buyAmount, o.sellToken, o.sellAmount]),
   ])
   formatHeader("Solutions")
   for (const solution of testCase.solutions) {
@@ -167,7 +167,7 @@ function debugTestCase(testCase, orderIds, accounts) {
     ])
     formatTable([
       ["   Executed Orders:          ", "Id", "User", "Buy Amount", "Sell Amount", "Utility", "Disregarded Utility"],
-      ...solution.orders.map(o => ["", orderIds[o.idx], usernames[o.user], o.buy, o.sell, o.utility, o.disregardedUtility]),
+      ...solution.orders.map(o => ["", orderIndices[o.idx], usernames[o.user], o.buy, o.sell, o.utility, o.disregardedUtility]),
     ])
     formatTable([
       ["   Total Utility:", solution.totalUtility],
@@ -194,25 +194,25 @@ function debugTestCase(testCase, orderIds, accounts) {
  * that this requires order ids as they are not known until runtime.
  * @param {ComputedSolution} solution The computed solution
  * @param {string[]} accounts The order ids as they are on the contract
- * @param {BN[]|number[]} orderIds The order ids as they are on the contract
+ * @param {BN[]|number[]} orderIndices The order ids as they are on the contract
  * @return {SolutionParams} The parameters to submit the solution
  */
-function solutionSubmissionParams(solution, accounts, orderIds) {
-  assert(Array.isArray(orderIds), "orderIds is not an array")
+function solutionSubmissionParams(solution, accounts, orderIndices) {
+  assert(Array.isArray(orderIndices), "orderIndices is not an array")
   assert(Array.isArray(accounts), "accounts is not an array")
-  orderIds.forEach((o, i) => assert(BN.isBN(o) || Number.isInteger(o), `invalid order id at index ${i}`))
+  orderIndices.forEach((o, i) => assert(BN.isBN(o) || Number.isInteger(o), `invalid order id at index ${i}`))
   accounts.forEach((a, i) => assert(typeof a === "string", `invalid account at index ${i}`))
 
   const orderCount = Math.max(...solution.orders.map(o => o.idx)) + 1
   const userCount = Math.max(...solution.orders.map(o => o.user)) + 1
 
-  assert(orderCount <= orderIds.length, "missing orders in orderIds")
+  assert(orderCount <= orderIndices.length, "missing orders in orderIndices")
   assert(userCount <= accounts.length, "missing users in accounts")
 
   return {
     objectiveValue: solution.objectiveValue,
     owners: solution.orders.map(o => accounts[o.user]),
-    touchedOrderIds: solution.orders.map(o => orderIds[o.idx]),
+    touchedOrderIds: solution.orders.map(o => orderIndices[o.idx]),
     volumes: solution.orders.map(o => o.buy),
     prices: solution.tokens.slice(1).map(t => t.price),
     tokenIdsForPrice: solution.tokens.slice(1).map(t => t.id),

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -947,7 +947,7 @@ contract("BatchExchange", async accounts => {
               [order.sellAmount],
               { from: accounts[order.user] }
             )
-          )[0] // Because placeValidFromOrders returns a list of ids
+          )[0] // Because placeValidFromOrders returns a list of indices
         )
       }
       await closeAuction(batchExchange)

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -318,7 +318,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         1,
         solution.owners,
-        solution.touchedOrderIds,
+        solution.touchedOrderIndices,
         solution.volumes,
         solution.prices,
         solution.tokenIdsForPrice,
@@ -389,7 +389,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         solution.objectiveValue,
         solution.owners,
-        solution.touchedOrderIds,
+        solution.touchedOrderIndices,
         solution.volumes,
         solution.prices,
         solution.tokenIdsForPrice,
@@ -405,7 +405,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           tooLowNewObjective,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           solution.prices,
           solution.tokenIdsForPrice,
@@ -429,7 +429,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         firstSolution.objectiveValue,
         firstSolution.owners,
-        firstSolution.touchedOrderIds,
+        firstSolution.touchedOrderIndices,
         firstSolution.volumes,
         firstSolution.prices,
         firstSolution.tokenIdsForPrice,
@@ -448,7 +448,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           firstSolution.objectiveValue.muln(2), // Note must claim better improvement than we have to get this case!
           insufficientlyBetterSolution.owners,
-          insufficientlyBetterSolution.touchedOrderIds,
+          insufficientlyBetterSolution.touchedOrderIndices,
           insufficientlyBetterSolution.volumes,
           insufficientlyBetterSolution.prices,
           insufficientlyBetterSolution.tokenIdsForPrice,
@@ -471,7 +471,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         solution.objectiveValue,
         solution.owners,
-        solution.touchedOrderIds,
+        solution.touchedOrderIndices,
         solution.volumes,
         solution.prices,
         solution.tokenIdsForPrice,
@@ -482,7 +482,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           solution.objectiveValue.addn(1),
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           solution.prices,
           solution.tokenIdsForPrice,
@@ -511,7 +511,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         solution.objectiveValue,
         solution.owners,
-        solution.touchedOrderIds,
+        solution.touchedOrderIndices,
         volume,
         prices,
         tokenIdsForPrice,
@@ -564,7 +564,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         partialSolution.objectiveValue,
         partialSolution.owners,
-        partialSolution.touchedOrderIds,
+        partialSolution.touchedOrderIndices,
         volume,
         prices,
         tokenIdsForPrice,
@@ -642,7 +642,7 @@ contract("BatchExchange", async accounts => {
       const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIndices)
       // Solution shared values
       const owners = partialSolution.owners
-      const touchedOrderIds = partialSolution.touchedOrderIds
+      const touchedOrderIndices = partialSolution.touchedOrderIndices
       const prices = partialSolution.prices
       const tokenIdsForPrice = partialSolution.tokenIdsForPrice
 
@@ -652,7 +652,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         partialSolution.objectiveValue,
         owners,
-        touchedOrderIds,
+        touchedOrderIndices,
         partialBuyVolumes,
         prices,
         tokenIdsForPrice,
@@ -691,7 +691,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         fullSolution.objectiveValue,
         owners,
-        touchedOrderIds,
+        touchedOrderIndices,
         fullBuyVolumes,
         prices,
         tokenIdsForPrice,
@@ -759,7 +759,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         partialSolution.objectiveValue,
         partialSolution.owners,
-        partialSolution.touchedOrderIds,
+        partialSolution.touchedOrderIndices,
         partialSolution.volumes,
         partialSolution.prices,
         partialSolution.tokenIdsForPrice,
@@ -771,7 +771,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         fullSolution.objectiveValue,
         fullSolution.owners,
-        fullSolution.touchedOrderIds,
+        fullSolution.touchedOrderIndices,
         fullSolution.volumes,
         fullSolution.prices,
         fullSolution.tokenIdsForPrice,
@@ -783,17 +783,17 @@ contract("BatchExchange", async accounts => {
       const secondTradeExample = advancedTrade
       await makeDeposits(batchExchange, accounts, secondTradeExample.deposits)
       const nextBatchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const secondOrderIds = await placeOrders(batchExchange, accounts, secondTradeExample.orders, nextBatchId + 1)
+      const secondOrderIndices = await placeOrders(batchExchange, accounts, secondTradeExample.orders, nextBatchId + 1)
       await closeAuction(batchExchange)
 
       const initialFeeTokenBalance = await owlProxy.balanceOf(batchExchange.address)
-      const secondSolution = solutionSubmissionParams(secondTradeExample.solutions[0], accounts, secondOrderIds)
+      const secondSolution = solutionSubmissionParams(secondTradeExample.solutions[0], accounts, secondOrderIndices)
       // This is where the first auction's fees should be burned!
       await batchExchange.submitSolution(
         nextBatchId,
         secondSolution.objectiveValue,
         secondSolution.owners,
-        secondSolution.touchedOrderIds,
+        secondSolution.touchedOrderIndices,
         secondSolution.volumes,
         secondSolution.prices,
         secondSolution.tokenIdsForPrice,
@@ -803,13 +803,13 @@ contract("BatchExchange", async accounts => {
       assert(initialFeeTokenBalance.sub(basicTrade.solutions[0].burntFees).eq(afterAuctionFeeTokenBalance))
 
       // Better second solution
-      const betterSolution = solutionSubmissionParams(secondTradeExample.solutions[1], accounts, secondOrderIds)
+      const betterSolution = solutionSubmissionParams(secondTradeExample.solutions[1], accounts, secondOrderIndices)
       // This is where the first auction's fees should be burned!
       await batchExchange.submitSolution(
         nextBatchId,
         betterSolution.objectiveValue,
         betterSolution.owners,
-        betterSolution.touchedOrderIds,
+        betterSolution.touchedOrderIndices,
         betterSolution.volumes,
         betterSolution.prices,
         betterSolution.tokenIdsForPrice,
@@ -832,7 +832,7 @@ contract("BatchExchange", async accounts => {
 
       assert(advancedTrade.solutions.length >= 3, "This test must always run on a sequence of at least three solutions.")
       for (const solution of advancedTrade.solutions) {
-        const { owners, touchedOrderIds, volumes, prices, tokenIdsForPrice } = solutionSubmissionParams(
+        const { owners, touchedOrderIndices, volumes, prices, tokenIdsForPrice } = solutionSubmissionParams(
           solution,
           accounts,
           orderIndices
@@ -842,7 +842,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           solution.objectiveValue,
           owners,
-          touchedOrderIds,
+          touchedOrderIndices,
           volumes,
           prices,
           tokenIdsForPrice,
@@ -888,7 +888,7 @@ contract("BatchExchange", async accounts => {
           batchId - 1,
           solution.objectiveValue,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           solution.prices,
           solution.tokenIdsForPrice,
@@ -917,7 +917,7 @@ contract("BatchExchange", async accounts => {
           updatedBatchId,
           solution.objectiveValue,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           solution.prices,
           solution.tokenIdsForPrice,
@@ -958,7 +958,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           solution.objectiveValue,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           solution.prices,
           solution.tokenIdsForPrice,
@@ -986,7 +986,7 @@ contract("BatchExchange", async accounts => {
           batchId + 1,
           solution.objectiveValue,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           solution.prices,
           solution.tokenIdsForPrice,
@@ -1023,7 +1023,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           solution.objectiveValue,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           solution.prices,
           solution.tokenIdsForPrice,
@@ -1049,7 +1049,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           solution.objectiveValue,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           badVolumes,
           solution.prices,
           solution.tokenIdsForPrice,
@@ -1073,7 +1073,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           solution.objectiveValue,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           basicTrade.orders.map(x => x.buyAmount), // <----- THIS IS THE DIFFERENCE!
           solution.prices,
           solution.tokenIdsForPrice,
@@ -1100,7 +1100,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           solution.objectiveValue,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           solution.prices,
           solution.tokenIdsForPrice,
@@ -1124,7 +1124,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           solution.objectiveValue,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           solution.prices,
           [1, 1],
@@ -1137,7 +1137,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           solution.objectiveValue,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           solution.prices,
           [2, 1],
@@ -1163,7 +1163,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           solution.objectiveValue,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           zeroPrices,
           solution.tokenIdsForPrice,
@@ -1226,7 +1226,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         solution.objectiveValue,
         solution.owners,
-        solution.touchedOrderIds,
+        solution.touchedOrderIndices,
         solution.volumes,
         [2, 3, 4].map(toETH),
         [1, 2, 3],
@@ -1248,7 +1248,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         solution.objectiveValue,
         solution.owners,
-        solution.touchedOrderIds,
+        solution.touchedOrderIndices,
         solution.volumes,
         solution.prices,
         solution.tokenIdsForPrice,
@@ -1276,7 +1276,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         partialSolution.objectiveValue,
         partialSolution.owners,
-        partialSolution.touchedOrderIds,
+        partialSolution.touchedOrderIndices,
         partialSolution.volumes,
         partialSolution.prices,
         partialSolution.tokenIdsForPrice,
@@ -1294,7 +1294,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         fullSolution.objectiveValue,
         fullSolution.owners,
-        fullSolution.touchedOrderIds,
+        fullSolution.touchedOrderIndices,
         fullSolution.volumes,
         fullSolution.prices,
         fullSolution.tokenIdsForPrice,
@@ -1322,7 +1322,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         solution.objectiveValue,
         solution.owners,
-        solution.touchedOrderIds,
+        solution.touchedOrderIndices,
         solution.volumes,
         solution.prices,
         solution.tokenIdsForPrice,
@@ -1355,7 +1355,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         solution.objectiveValue,
         solution.owners,
-        solution.touchedOrderIds,
+        solution.touchedOrderIndices,
         solution.volumes,
         solution.prices,
         solution.tokenIdsForPrice,
@@ -1382,7 +1382,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         solution.objectiveValue,
         solution.owners,
-        solution.touchedOrderIds,
+        solution.touchedOrderIndices,
         solution.volumes,
         solution.prices,
         solution.tokenIdsForPrice,
@@ -1407,7 +1407,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           solution.objectiveValue,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           wayTooBigPrices,
           solution.tokenIdsForPrice,
@@ -1444,7 +1444,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         solution.objectiveValue,
         solution.owners,
-        solution.touchedOrderIds,
+        solution.touchedOrderIndices,
         volumes,
         prices,
         solution.tokenIdsForPrice,
@@ -1491,7 +1491,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         ringSolution.objectiveValue,
         ringSolution.owners,
-        ringSolution.touchedOrderIds,
+        ringSolution.touchedOrderIndices,
         ringSolution.volumes,
         ringSolution.prices,
         ringSolution.tokenIdsForPrice,
@@ -1509,7 +1509,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         directSolution.objectiveValue,
         directSolution.owners,
-        directSolution.touchedOrderIds,
+        directSolution.touchedOrderIndices,
         directSolution.volumes,
         directSolution.prices,
         directSolution.tokenIdsForPrice,
@@ -1535,7 +1535,7 @@ contract("BatchExchange", async accounts => {
         batchId,
         solution.objectiveValue,
         solution.owners,
-        solution.touchedOrderIds,
+        solution.touchedOrderIndices,
         solution.volumes,
         solution.prices,
         solution.tokenIdsForPrice,
@@ -1576,7 +1576,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           solution.objectiveValue + 1,
           solution.owners,
-          solution.touchedOrderIds,
+          solution.touchedOrderIndices,
           solution.volumes,
           solution.prices,
           solution.tokenIdsForPrice,
@@ -1596,14 +1596,14 @@ contract("BatchExchange", async accounts => {
       const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIndices)
       const prices = partialSolution.prices
       const owners = partialSolution.owners
-      const touchedOrderIds = partialSolution.touchedOrderIds
+      const touchedOrderIndices = partialSolution.touchedOrderIndices
       const tokenIdsForPrice = partialSolution.tokenIdsForPrice
       // Fill 90% of these orders in first auction.
       await batchExchange.submitSolution(
         batchId,
         partialSolution.objectiveValue,
         owners,
-        touchedOrderIds,
+        touchedOrderIndices,
         partialSolution.volumes,
         prices,
         tokenIdsForPrice,
@@ -1618,7 +1618,7 @@ contract("BatchExchange", async accounts => {
         batchId + 1,
         1,
         owners,
-        touchedOrderIds,
+        touchedOrderIndices,
         remainingBuyVolumes,
         prices,
         tokenIdsForPrice,

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -307,10 +307,10 @@ contract("BatchExchange", async accounts => {
       // Make deposits, place orders and close auction[aka runAuctionScenario(basicTrade)]
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
 
       // Note: the claimed objective value is intentionally incorrect, this is to make sure that a call
       // to `submitSolution` can be used to acurately determine the objective value of a solution
@@ -348,7 +348,7 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, deposits)
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
 
-      const orderIds = await placeOrders(batchExchange, accounts, orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, orders, batchId + 1)
       await closeAuction(batchExchange)
 
       await truffleAssert.reverts(
@@ -356,7 +356,7 @@ contract("BatchExchange", async accounts => {
           batchId,
           1 /* objective value */,
           [accounts[0], accounts[1]] /* user ids */,
-          orderIds,
+          orderIndices,
           solution.buyVolumes,
           solution.prices.slice(1),
           [1, 2],
@@ -381,10 +381,10 @@ contract("BatchExchange", async accounts => {
       // Make deposits, place orders and close auction[aka runAuctionScenario(basicTrade)]
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         solution.objectiveValue,
@@ -421,10 +421,10 @@ contract("BatchExchange", async accounts => {
       const tradeCase = marginalTrade
       await makeDeposits(batchExchange, accounts, tradeCase.deposits)
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, tradeCase.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, tradeCase.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const firstSolution = solutionSubmissionParams(tradeCase.solutions[0], accounts, orderIds)
+      const firstSolution = solutionSubmissionParams(tradeCase.solutions[0], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         firstSolution.objectiveValue,
@@ -435,7 +435,7 @@ contract("BatchExchange", async accounts => {
         firstSolution.tokenIdsForPrice,
         { from: solver }
       )
-      const insufficientlyBetterSolution = solutionSubmissionParams(tradeCase.solutions[1], accounts, orderIds)
+      const insufficientlyBetterSolution = solutionSubmissionParams(tradeCase.solutions[1], accounts, orderIndices)
       const improvementDenominator = await batchExchange.IMPROVEMENT_DENOMINATOR.call()
       assert(
         insufficientlyBetterSolution.objectiveValue
@@ -463,10 +463,10 @@ contract("BatchExchange", async accounts => {
       // Make deposits, place orders and close auction[aka runAuctionScenario(basicTrade)]
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         solution.objectiveValue,
@@ -499,10 +499,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       const volume = solution.volumes
       const prices = solution.prices
       const tokenIdsForPrice = solution.tokenIdsForPrice
@@ -552,10 +552,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIds)
+      const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIndices)
       const volume = partialSolution.volumes
       const prices = partialSolution.prices
       const tokenIdsForPrice = partialSolution.tokenIdsForPrice
@@ -593,8 +593,8 @@ contract("BatchExchange", async accounts => {
         "Bought tokens were not adjusted correctly"
       )
 
-      const orderResult1 = await batchExchange.orders.call(user_1, orderIds[0])
-      const orderResult2 = await batchExchange.orders.call(user_2, orderIds[1])
+      const orderResult1 = await batchExchange.orders.call(user_1, orderIndices[0])
+      const orderResult2 = await batchExchange.orders.call(user_2, orderIndices[1])
 
       assert.equal(
         orderResult1.usedAmount,
@@ -636,10 +636,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIds)
+      const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIndices)
       // Solution shared values
       const owners = partialSolution.owners
       const touchedOrderIds = partialSolution.touchedOrderIds
@@ -685,7 +685,7 @@ contract("BatchExchange", async accounts => {
       )
 
       // Submit better (full) solution
-      const fullSolution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const fullSolution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       const fullBuyVolumes = fullSolution.volumes
       await batchExchange.submitSolution(
         batchId,
@@ -751,10 +751,10 @@ contract("BatchExchange", async accounts => {
       const tradeExample = basicTrade
       await makeDeposits(batchExchange, accounts, tradeExample.deposits)
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIds)
+      const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         partialSolution.objectiveValue,
@@ -766,7 +766,7 @@ contract("BatchExchange", async accounts => {
         { from: solver }
       )
 
-      const fullSolution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const fullSolution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         fullSolution.objectiveValue,
@@ -826,7 +826,7 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, advancedTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, advancedTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, advancedTrade.orders, batchId + 1)
 
       await closeAuction(batchExchange)
 
@@ -835,7 +835,7 @@ contract("BatchExchange", async accounts => {
         const { owners, touchedOrderIds, volumes, prices, tokenIdsForPrice } = solutionSubmissionParams(
           solution,
           accounts,
-          orderIds
+          orderIndices
         )
 
         await batchExchange.submitSolution(
@@ -877,10 +877,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
 
       await closeAuction(batchExchange)
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
 
       // Correct batchId would be batchId
       await truffleAssert.reverts(
@@ -903,13 +903,13 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
 
       const time_remaining = (await batchExchange.getSecondsRemainingInBatch()).toNumber()
       await waitForNSeconds(time_remaining + 241)
 
       const updatedBatchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
 
       // Should be exactly one second past when solutions are being accepted.
       await truffleAssert.reverts(
@@ -932,10 +932,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = []
+      const orderIndices = []
       for (const order of basicTrade.orders) {
         // NOTE: This is different than usual tests!
-        orderIds.push(
+        orderIndices.push(
           (
             await sendTxAndGetReturnValue(
               batchExchange.placeValidFromOrders, // <------ Right here!
@@ -951,7 +951,7 @@ contract("BatchExchange", async accounts => {
         )
       }
       await closeAuction(batchExchange)
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       // The orders placed aren't valid until next batch!
       await truffleAssert.reverts(
         batchExchange.submitSolution(
@@ -974,12 +974,12 @@ contract("BatchExchange", async accounts => {
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
       // NOTE: This is different than usual tests!             -------------->             v- Here -v
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId)
       await closeAuction(batchExchange)
       // Close another auction
       await waitForNSeconds(BATCH_TIME)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       //correct batchId would be batchId
       await truffleAssert.reverts(
         batchExchange.submitSolution(
@@ -1001,9 +1001,9 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = []
+      const orderIndices = []
       for (const order of basicTrade.orders) {
-        orderIds.push(
+        orderIndices.push(
           await sendTxAndGetReturnValue(
             batchExchange.placeOrder,
             order.buyToken,
@@ -1016,7 +1016,7 @@ contract("BatchExchange", async accounts => {
         )
       }
       await closeAuction(batchExchange)
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
 
       await truffleAssert.reverts(
         batchExchange.submitSolution(
@@ -1038,10 +1038,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       const badVolumes = solution.volumes.map(amt => amt.add(new BN(10)))
 
       await truffleAssert.reverts(
@@ -1064,10 +1064,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       await truffleAssert.reverts(
         batchExchange.submitSolution(
           batchId,
@@ -1091,9 +1091,9 @@ contract("BatchExchange", async accounts => {
       }
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
 
       await truffleAssert.reverts(
         batchExchange.submitSolution(
@@ -1115,10 +1115,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       await truffleAssert.reverts(
         batchExchange.submitSolution(
           batchId,
@@ -1152,10 +1152,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       const zeroPrices = [toETH(1), 0]
 
       await truffleAssert.reverts(
@@ -1177,13 +1177,22 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, smallTradeData.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, smallTradeData.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, smallTradeData.orders, batchId + 1)
       await closeAuction(batchExchange)
 
       await truffleAssert.reverts(
-        batchExchange.submitSolution(batchId, 1, accounts.slice(0, 2), orderIds, [tenThousand, tenThousand], [toETH(0.9)], [1], {
-          from: solver,
-        }),
+        batchExchange.submitSolution(
+          batchId,
+          1,
+          accounts.slice(0, 2),
+          orderIndices,
+          [tenThousand, tenThousand],
+          [toETH(0.9)],
+          [1],
+          {
+            from: solver,
+          }
+        ),
         "sell amount less than AMOUNT_MINIMUM"
       )
     })
@@ -1192,12 +1201,12 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, smallTradeData.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, smallTradeData.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, smallTradeData.orders, batchId + 1)
       await closeAuction(batchExchange)
 
       const tooSmallBuyAmounts = [10000, 9990].map(val => new BN(val))
       await truffleAssert.reverts(
-        batchExchange.submitSolution(batchId, 1, accounts.slice(0, 2), orderIds, tooSmallBuyAmounts, [toETH(1)], [1], {
+        batchExchange.submitSolution(batchId, 1, accounts.slice(0, 2), orderIndices, tooSmallBuyAmounts, [toETH(1)], [1], {
           from: solver,
         }),
         "buy amount less than AMOUNT_MINIMUM"
@@ -1209,9 +1218,9 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
 
       await batchExchange.submitSolution(
         batchId,
@@ -1231,10 +1240,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         solution.objectiveValue,
@@ -1259,10 +1268,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIds)
+      const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         partialSolution.objectiveValue,
@@ -1280,7 +1289,7 @@ contract("BatchExchange", async accounts => {
         "fees weren't allocated as expected correctly"
       )
 
-      const fullSolution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const fullSolution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         fullSolution.objectiveValue,
@@ -1300,7 +1309,7 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       const relevantUser = accounts[basicTrade.orders[0].user]
       const buyToken = await batchExchange.tokenIdToAddressMap.call(basicTrade.orders[0].buyToken)
 
@@ -1308,7 +1317,7 @@ contract("BatchExchange", async accounts => {
       await batchExchange.requestWithdraw(buyToken, 100, { from: relevantUser })
 
       await closeAuction(batchExchange)
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         solution.objectiveValue,
@@ -1336,12 +1345,12 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       // solver places withdraw request:
       await batchExchange.requestWithdraw(feeToken, 100, { from: solver })
 
       await closeAuction(batchExchange)
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         solution.objectiveValue,
@@ -1365,10 +1374,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         solution.objectiveValue,
@@ -1388,10 +1397,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIndices)
       const wayTooBigPrices = ["340282366920938463463374607431768211455"]
       await truffleAssert.reverts(
         batchExchange.submitSolution(
@@ -1425,10 +1434,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, basicRingTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicRingTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicRingTrade.orders, batchId + 1)
 
       await closeAuction(batchExchange)
-      const solution = solutionSubmissionParams(basicRingTrade.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(basicRingTrade.solutions[0], accounts, orderIndices)
       const { prices, volumes } = solution
 
       await batchExchange.submitSolution(
@@ -1474,10 +1483,10 @@ contract("BatchExchange", async accounts => {
       await makeDeposits(batchExchange, accounts, shortRingBetterTrade.deposits)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, shortRingBetterTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, shortRingBetterTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const ringSolution = solutionSubmissionParams(shortRingBetterTrade.solutions[0], accounts, orderIds)
+      const ringSolution = solutionSubmissionParams(shortRingBetterTrade.solutions[0], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         ringSolution.objectiveValue,
@@ -1495,7 +1504,7 @@ contract("BatchExchange", async accounts => {
         "CurrentPrice were not adjusted correctly"
       )
 
-      const directSolution = solutionSubmissionParams(shortRingBetterTrade.solutions[1], accounts, orderIds)
+      const directSolution = solutionSubmissionParams(shortRingBetterTrade.solutions[1], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         directSolution.objectiveValue,
@@ -1519,9 +1528,9 @@ contract("BatchExchange", async accounts => {
 
       await makeDeposits(batchExchange, accounts, smallExample.deposits)
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, smallExample.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, smallExample.orders, batchId + 1)
       await closeAuction(batchExchange)
-      const solution = solutionSubmissionParams(smallExample.solutions[0], accounts, orderIds)
+      const solution = solutionSubmissionParams(smallExample.solutions[0], accounts, orderIndices)
       await batchExchange.submitSolution(
         batchId,
         solution.objectiveValue,
@@ -1581,10 +1590,10 @@ contract("BatchExchange", async accounts => {
 
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      const orderIndices = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
       await closeAuction(batchExchange)
 
-      const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIds)
+      const partialSolution = solutionSubmissionParams(basicTrade.solutions[1], accounts, orderIndices)
       const prices = partialSolution.prices
       const owners = partialSolution.owners
       const touchedOrderIds = partialSolution.touchedOrderIds

--- a/test/stablex/stablex_utils.js
+++ b/test/stablex/stablex_utils.js
@@ -54,9 +54,9 @@ const makeDeposits = async function(contract, accounts, depositList) {
  * @returns {BN[]}
  */
 const placeOrders = async function(contract, accounts, orderList, auctionIndex) {
-  const orderIds = []
+  const orderIndices = []
   for (const order of orderList) {
-    orderIds.push(
+    orderIndices.push(
       await sendTxAndGetReturnValue(
         contract.placeOrder,
         order.buyToken,
@@ -68,7 +68,7 @@ const placeOrders = async function(contract, accounts, orderList, auctionIndex) 
       )
     )
   }
-  return orderIds
+  return orderIndices
 }
 
 module.exports = {


### PR DESCRIPTION
In the current implementation different uint types were used for the `orderIndex`
If someone would have stored over 65k(2**16) orders, then these orders could not have been considered in the solution, as the orderIndexs of submitSolution only accepted uint16.

This Pr unifies the uint value and makes sure that not more than 2**16 orders could be submitted.

Also it renames orderId to orderIndex