### PR TITLE
Fix flaky test :invalidates valid order as of next batch:

### DIFF
--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -55,6 +55,15 @@ contract("BatchExchange", async accounts => {
 
     BATCH_TIME = (await batchExchange.BATCH_TIME.call()).toNumber()
   })
+
+  // In the following tests, it might be possible that an batchId is read from the blockchain
+  // and in the next moment this batchId is no longer the current one. In order to prevent these
+  // situations, we set the adjust the start-time of each test to the start of an new auction.
+  beforeEach(async () => {
+    const batchExchange = await BatchExchange.deployed()
+    await closeAuction(batchExchange)
+  })
+
   describe("addToken()", () => {
     it("feeToken is set by default", async () => {
       const feeToken = await MockContract.new()
@@ -221,7 +230,7 @@ contract("BatchExchange", async accounts => {
       const batchExchange = await setupGenericStableX()
 
       const id = await batchExchange.placeOrder.call(0, 1, 3, 10, 20, { from: user_1 })
-      const currentStateIndex = (await batchExchange.getCurrentBatchId.call()).toNumber()
+      const currentStateIndex = (await batchExchange.getCurrentBatchId()).toNumber()
 
       await batchExchange.placeOrder(0, 1, currentStateIndex + 3, 10, 20, { from: user_1 })
       await closeAuction(batchExchange)

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -221,7 +221,7 @@ contract("BatchExchange", async accounts => {
       const batchExchange = await setupGenericStableX()
 
       const id = await batchExchange.placeOrder.call(0, 1, 3, 10, 20, { from: user_1 })
-      const currentStateIndex = (await batchExchange.getCurrentBatchId()).toNumber()
+      const currentStateIndex = (await batchExchange.getCurrentBatchId.call()).toNumber()
 
       await batchExchange.placeOrder(0, 1, currentStateIndex + 3, 10, 20, { from: user_1 })
       await closeAuction(batchExchange)


### PR DESCRIPTION
In one build, we got the following error:
```
 1 failing
  1) Contract: BatchExchange
       cancelOrders()
         invalidates valid order as of next batch:
      validUntil was stored incorrectly
      + expected - actual
      -5255330
      +5255329
      
      at Context.it (test/stablex/batch_exchange.js:231:14)
      at process._tickCallback (internal/process/next_tick.js:68:7)
```
https://travis-ci.org/gnosis/dex-contracts/builds/626213825?utm_source=github_status&utm_medium=notification

This happens, if the following two lines in the test are not executed during the same batchID:
```
      const currentStateIndex = (await batchExchange.getCurrentBatchId()).toNumber()

      await batchExchange.placeOrder(0, 1, currentStateIndex + 3, 10, 20, { from: user_1 })
```
The changes ensure that they are exectued during the same batchId, as a view function call does not modify time.