### PR TITLE
Improving readability by introducing solvingBatchId

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -215,13 +215,13 @@ contract BatchExchange is EpochTokenLocker {
       * Emits an {OrderCancelation} or {OrderDeletion} with sender's address and orderIndex
       */
     function cancelOrders(uint256[] memory indices) public {
-        uint32 solvingBatchId = getCurrentBatchId() - 1;
+        uint32 batchIdBeingSolved = getCurrentBatchId() - 1;
         for (uint256 i = 0; i < indices.length; i++) {
-            if (!checkOrderValidity(orders[msg.sender][indices[i]], solvingBatchId)) {
+            if (!checkOrderValidity(orders[msg.sender][indices[i]], batchIdBeingSolved)) {
                 delete orders[msg.sender][indices[i]];
                 emit OrderDeletion(msg.sender, indices[i]);
             } else {
-                orders[msg.sender][indices[i]].validUntil = solvingBatchId;
+                orders[msg.sender][indices[i]].validUntil = batchIdBeingSolved;
                 emit OrderCancelation(msg.sender, indices[i]);
             }
         }

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -215,12 +215,13 @@ contract BatchExchange is EpochTokenLocker {
       * Emits an {OrderCancelation} or {OrderDeletion} with sender's address and orderIndex
       */
     function cancelOrders(uint256[] memory indices) public {
+        uint32 solvingBatchId = getCurrentBatchId() - 1;
         for (uint256 i = 0; i < indices.length; i++) {
-            if (!checkOrderValidity(orders[msg.sender][indices[i]], getCurrentBatchId() - 1)) {
+            if (!checkOrderValidity(orders[msg.sender][indices[i]], solvingBatchId)) {
                 delete orders[msg.sender][indices[i]];
                 emit OrderDeletion(msg.sender, indices[i]);
             } else {
-                orders[msg.sender][indices[i]].validUntil = getCurrentBatchId() - 1;
+                orders[msg.sender][indices[i]].validUntil = solvingBatchId;
                 emit OrderCancelation(msg.sender, indices[i]);
             }
         }


### PR DESCRIPTION
This was one of Allan's comments for improving readability.

While I don't like `solvingBatchId` to much, I can not think of a better name. `currentlyIsSolvedBatchId` is too long. `previousBatchId` is not descriptive enough. 
Do you have anything better?
