### PR TITLE
Simplifying the middleValue calculation in binary search

### DIFF
--- a/contracts/libraries/TokenConservation.sol
+++ b/contracts/libraries/TokenConservation.sol
@@ -83,7 +83,7 @@ library TokenConservation {
         uint256 leftValue = 0;
         uint256 rightValue = tokenIdsForPrice.length - 1;
         while (rightValue >= leftValue) {
-            uint256 middleValue = leftValue + (rightValue - leftValue) / 2;
+            uint256 middleValue = (leftValue + rightValue) / 2;
             if (tokenIdsForPrice[middleValue] == tokenId) {
                 // shifted one to the right to account for fee token at index 0
                 return middleValue + 1;


### PR DESCRIPTION
Notice that this change is no equivalent for all inputs.
```
We found an example where (l + r) / 2 != l + (r - l) / 2

counterexample when (l, r) = (1, 0)
```

But in our situation with l<r, these values are the same, which can be proven by induction
