### PR TITLE
[Easy] feeDenominator a contract constant

### DIFF
--- a/src/migration/PoC_dfusion.js
+++ b/src/migration/PoC_dfusion.js
@@ -1,7 +1,7 @@
 const { isDevelopmentNetwork, getDependency } = require("./utilities.js")
 const deployOwl = require("@gnosis.pm/owl-token/src/migrations-truffle-5/3_deploy_OWL")
 
-async function migrate({ artifacts, deployer, network, accounts, web3, feeDenominator = 1000, maxTokens = 2 ** 16 - 1 }) {
+async function migrate({ artifacts, deployer, network, accounts, web3, maxTokens = 2 ** 16 - 1 }) {
   let fee_token
   if (isDevelopmentNetwork(network)) {
     await deployOwl({
@@ -37,7 +37,7 @@ async function migrate({ artifacts, deployer, network, accounts, web3, feeDenomi
 
   // eslint-disable-next-line no-console
   console.log("Deploy BatchExchange contract")
-  await deployer.deploy(BatchExchange, maxTokens, feeDenominator, fee_token.address)
+  await deployer.deploy(BatchExchange, maxTokens, fee_token.address)
 }
 
 module.exports = migrate

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -23,8 +23,6 @@ const {
 } = require("../resources/examples")
 const { makeDeposits, placeOrders, setupGenericStableX } = require("./stablex_utils")
 
-const feeDenominator = 1000 // fee is (1 / feeDenominator)
-
 const fiveThousand = new BN("5000")
 const tenThousand = new BN("10000")
 const smallTradeData = {
@@ -51,7 +49,7 @@ contract("BatchExchange", async accounts => {
     const lib2 = await IterableAppendOnlySet.new()
     await BatchExchange.link(IdToAddressBiMap, lib1.address)
     await BatchExchange.link(IterableAppendOnlySet, lib2.address)
-    const batchExchange = await BatchExchange.new(2 ** 16 - 1, feeDenominator, feeToken.address)
+    const batchExchange = await BatchExchange.new(2 ** 16 - 1, feeToken.address)
 
     BATCH_TIME = (await batchExchange.BATCH_TIME.call()).toNumber()
   })
@@ -68,7 +66,7 @@ contract("BatchExchange", async accounts => {
     it("feeToken is set by default", async () => {
       const feeToken = await MockContract.new()
       await feeToken.givenAnyReturnBool(true)
-      const batchExchange = await BatchExchange.new(2 ** 16 - 1, feeDenominator, feeToken.address)
+      const batchExchange = await BatchExchange.new(2 ** 16 - 1, feeToken.address)
 
       assert.equal((await batchExchange.tokenAddressToIdMap.call(feeToken.address)).toNumber(), 0)
       assert.equal(await batchExchange.tokenIdToAddressMap.call(0), feeToken.address)
@@ -76,7 +74,7 @@ contract("BatchExchange", async accounts => {
     it("Anyone can add tokens", async () => {
       const feeToken = await MockContract.new()
       await feeToken.givenAnyReturnBool(true)
-      const batchExchange = await BatchExchange.new(2 ** 16 - 1, feeDenominator, feeToken.address)
+      const batchExchange = await BatchExchange.new(2 ** 16 - 1, feeToken.address)
 
       const token_1 = await ERC20.new()
       await batchExchange.addToken(token_1.address, { from: user_1 })
@@ -92,7 +90,7 @@ contract("BatchExchange", async accounts => {
     it("Rejects same token added twice", async () => {
       const feeToken = await MockContract.new()
       await feeToken.givenAnyReturnBool(true)
-      const batchExchange = await BatchExchange.new(2 ** 16 - 1, feeDenominator, feeToken.address)
+      const batchExchange = await BatchExchange.new(2 ** 16 - 1, feeToken.address)
       const token = await ERC20.new()
       await batchExchange.addToken(token.address)
       await truffleAssert.reverts(batchExchange.addToken(token.address), "Token already registered")
@@ -100,7 +98,7 @@ contract("BatchExchange", async accounts => {
     it("No exceed max tokens", async () => {
       const feeToken = await MockContract.new()
       await feeToken.givenAnyReturnBool(true)
-      const batchExchange = await BatchExchange.new(3, feeDenominator, feeToken.address)
+      const batchExchange = await BatchExchange.new(3, feeToken.address)
       await batchExchange.addToken((await ERC20.new()).address)
       await batchExchange.addToken((await ERC20.new()).address)
 
@@ -116,7 +114,7 @@ contract("BatchExchange", async accounts => {
 
       await owlProxy.mintOWL(user_1, owlAmount)
 
-      const batchExchange = await BatchExchange.new(2, feeDenominator, owlProxy.address)
+      const batchExchange = await BatchExchange.new(2, owlProxy.address)
       const token = await ERC20.new()
       await owlProxy.approve(batchExchange.address, owlAmount)
       assert(owlAmount.eq(await owlProxy.balanceOf(user_1)))
@@ -133,7 +131,7 @@ contract("BatchExchange", async accounts => {
       await owlProxy.setMinter(user_1)
       const owlAmount = toETH(10)
 
-      const batchExchange = await BatchExchange.new(2, feeDenominator, owlProxy.address)
+      const batchExchange = await BatchExchange.new(2, owlProxy.address)
       const token = await ERC20.new()
       await owlProxy.approve(batchExchange.address, owlAmount)
       assert(owlAmount.eq(await owlProxy.allowance.call(user_1, batchExchange.address)))
@@ -734,7 +732,7 @@ contract("BatchExchange", async accounts => {
 
       await owlProxy.mintOWL(user_1, owlAmount)
 
-      const batchExchange = await BatchExchange.new(2, feeDenominator, owlProxy.address)
+      const batchExchange = await BatchExchange.new(2, owlProxy.address)
       await owlProxy.approve(batchExchange.address, owlAmount)
 
       const token = await MockContract.new()

--- a/test/stablex/stablex_utils.js
+++ b/test/stablex/stablex_utils.js
@@ -15,14 +15,13 @@ const { sendTxAndGetReturnValue } = require("../utilities")
  * Makes deposit transactions from a list of Deposit Objects
  * @param {number} numTokens - number of tokens to be registered on this exchange.
  * @param {number} maxTokens - Maximum number of tokens (a contract contructor parameter)
- * @param {number} feeDenominator - Fee for order execution (a contract contructor parameter)
  * @returns {}
  */
-const setupGenericStableX = async function(numTokens = 2, maxTokens = 2 ** 16 - 1, feeDenominator = 1000) {
+const setupGenericStableX = async function(numTokens = 2, maxTokens = 2 ** 16 - 1) {
   const feeToken = await MockContract.new()
   await feeToken.givenAnyReturnBool(true)
 
-  const instance = await BatchExchange.new(maxTokens, feeDenominator, feeToken.address)
+  const instance = await BatchExchange.new(maxTokens, feeToken.address)
   const tokens = [feeToken]
   for (let i = 0; i < numTokens - 1; i++) {
     const token = await MockContract.new()


### PR DESCRIPTION
Since the documentation for the product explicitly state that the fee is 0.1%  and constants are more gas efficient, the dfusion team has agreed to make this a constant with the contract. Changes included here are esssentially;

- make `feeDenominator` constant (equal to 1000) an rename as `FEE_DENOMINATOR`
- remove this parameter from the contract's constructor
- and adjust all relevant places that used to call the constructor (such as migrations)


