### PR TITLE
Update token list location (dex-js)

### DIFF
--- a/scripts/stablex/add_token_list.js
+++ b/scripts/stablex/add_token_list.js
@@ -3,7 +3,7 @@ const fetch = require("node-fetch")
 const argv = require("yargs")
   .option("token_list_url", {
     describe: "A url which can be fetched with node-fetch",
-    default: "https://raw.githubusercontent.com/gnosis/dex-react/develop/src/api/tokenList/tokenList.json",
+    default: "https://raw.githubusercontent.com/gnosis/dex-js/master/src/tokenList.json",
   })
   .help(false)
   .version(false).argv


### PR DESCRIPTION
The list was moved to `dex-js` so it can be reused in `dex-telegram`, `dex-react` or any other module.

This PR updates the path of the raw file.