### PR TITLE
improved tokenConservation array initialization

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -300,7 +300,7 @@ contract BatchExchange is EpochTokenLocker {
         undoCurrentSolution();
         updateCurrentPrices(prices, tokenIdsForPrice);
         delete latestSolution.trades;
-        int256[] memory tokenConservation = TokenConservation.init(tokenIdsForPrice);
+        int256[] memory tokenConservation = TokenConservation.init(tokenIdsForPrice.length + 1);
         uint256 utility = 0;
         for (uint256 i = 0; i < owners.length; i++) {
             Order memory order = orders[owners[i]][orderIndices[i]];

--- a/contracts/libraries/TokenConservation.sol
+++ b/contracts/libraries/TokenConservation.sol
@@ -10,10 +10,10 @@ library TokenConservation {
     using SignedSafeMath for int256;
 
     /** @dev initialize the token conservation data structure
-      * @param tokenIdsForPrice sorted list of tokenIds for which token conservation should be checked
+      * @param tokenNumber is the number of tokens the conservation should be checked for
       */
-    function init(uint256 size) internal pure returns (int256[] memory) {
-        return new int256[](size);
+    function init(uint256 tokenNumber) internal pure returns (int256[] memory) {
+        return new int256[](tokenNumber);
     }
 
     /** @dev returns the token imbalance of the fee token

--- a/contracts/libraries/TokenConservation.sol
+++ b/contracts/libraries/TokenConservation.sol
@@ -12,8 +12,8 @@ library TokenConservation {
     /** @dev initialize the token conservation data structure
       * @param tokenIdsForPrice sorted list of tokenIds for which token conservation should be checked
       */
-    function init(uint16[] memory tokenIdsForPrice) internal pure returns (int256[] memory) {
-        return new int256[](tokenIdsForPrice.length + 1);
+    function init(uint256 size) internal pure returns (int256[] memory) {
+        return new int256[](size);
     }
 
     /** @dev returns the token imbalance of the fee token


### PR DESCRIPTION
Adams feedback:
why pass array to `TokenConservation.init`?

