### PR TITLE
Allow to unset withdrawBlockers in undoCurrentSolution

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -540,11 +540,15 @@ contract BatchExchange is EpochTokenLocker {
                 Order memory order = orders[owner][orderIndex];
                 (uint128 buyAmount, uint128 sellAmount) = getTradedAmounts(latestSolution.trades[i].volume, order);
                 revertRemainingOrder(owner, orderIndex, sellAmount);
-                subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyAmount);
+                address buyToken = tokenIdToAddressMap(order.buyToken);
+                subtractBalance(owner, buyToken, buyAmount);
+                undoWithdrawBlock(owner, buyToken);
                 emit TradeReversion(owner, orderIndex, sellAmount, buyAmount);
             }
             // subtract granted fees:
-            subtractBalance(latestSolution.solutionSubmitter, tokenIdToAddressMap(0), latestSolution.feeReward);
+            address solutionSubmitter = latestSolution.solutionSubmitter;
+            subtractBalance(solutionSubmitter, address(feeToken), latestSolution.feeReward);
+            undoWithdrawBlock(solutionSubmitter, address(feeToken));
         }
     }
 

--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -218,4 +218,13 @@ contract EpochTokenLocker {
             delete balanceStates[user][token].pendingDeposits;
         }
     }
+
+    /** @dev undoWithdrawBlock allows to undo withdraw blocks, which might have been
+     * set in addBalanceAndBlockWithdrawForThisBatch
+     */
+    function undoWithdrawBlock(address user, address token) internal {
+        if (hasValidWithdrawRequest(user, token)) {
+            lastCreditBatchId[user][token] = 0;
+        }
+    }
 }


### PR DESCRIPTION

This PR enables a new solution submitter to undo all withdrawBlocks, which have been set by a previous solution.