### PR TITLE
Less rounding errors in getExectuedSellAmount

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -614,7 +614,8 @@ contract BatchExchange is EpochTokenLocker {
       * execSellAmount = (execBuyAmount * p[buyToken]) / (p[sellToken] * (1 - phi))
       *                = (execBuyAmount * buyTokenPrice / sellTokenPrice) * FEE_DENOMINATOR / (FEE_DENOMINATOR - 1)
       * in order to minimize rounding errors, the order of operations is switched
-      *                = ((executedBuyAmount * buyTokenPrice) / (FEE_DENOMINATOR - 1)) * FEE_DENOMINATOR) / sellTokenPrice
+      *                = (executedBuyAmount * buyTokenPrice * FEE_DENOMINATOR) /
+      *                  ((FEE_DENOMINATOR - 1) * sellTokenPrice)
       */
     function getExecutedSellAmount(uint128 executedBuyAmount, uint128 buyTokenPrice, uint128 sellTokenPrice)
         private
@@ -625,8 +626,8 @@ contract BatchExchange is EpochTokenLocker {
         return
             uint256(executedBuyAmount)
                 .mul(buyTokenPrice)
-                .div(FEE_DENOMINATOR - 1)
                 .mul(FEE_DENOMINATOR)
+                .div(FEE_DENOMINATOR - 1)
                 .div(sellTokenPrice)
                 .toUint128();
         /* solium-enable indentation */

--- a/test/resources/math.js
+++ b/test/resources/math.js
@@ -71,8 +71,8 @@ function getExecutedSellAmount(executedBuyAmount, buyTokenPrice, sellTokenPrice)
 
   return executedBuyAmount
     .mul(buyTokenPrice)
-    .div(FEE_DENOMINATOR_MINUS_ONE)
     .mul(FEE_DENOMINATOR)
+    .div(FEE_DENOMINATOR_MINUS_ONE)
     .div(sellTokenPrice)
 }
 


### PR DESCRIPTION
As title.

This was a suggestion by Alan.
This change improves the rounding behaviour, but it might introduce reverts due to overflows, in the very rare cases where buyTokenAmount, and buyTokenPrice are very huge.


Note: @bh2smith @nlordell : The test suite you guys build is fantastic. It was really just one change in the function geExectuedSellAmount and the tests seem to pass. Amazing!

---
This Pr has implications for dex-solver and dex-services