### PR TITLE
pageSize for getEncodedUserOrders

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -382,7 +382,7 @@ contract BatchExchange is EpochTokenLocker {
       * @return encoded bytes representing all orders
       */
     function getEncodedUserOrders(address user, uint256 offset, uint16 pageSize) public view returns (bytes memory elements) {
-        for (uint256 i = offset; i < Math.min(orders[user].length, offset + pageSize + 1); i++) {
+        for (uint256 i = offset; i < Math.min(orders[user].length, offset + pageSize); i++) {
             elements = elements.concat(
                 encodeAuctionElement(user, getBalance(user, tokenIdToAddressMap(orders[user][i].sellToken)), orders[user][i])
             );
@@ -398,7 +398,7 @@ contract BatchExchange is EpochTokenLocker {
             address user = allUsers.first();
             bool stop = false;
             while (!stop) {
-                elements = elements.concat(getEncodedUserOrders(user, 0, uint16(-2)));
+                elements = elements.concat(getEncodedUserOrders(user, 0, uint16(-1)));
                 if (user == allUsers.last) {
                     stop = true;
                 } else {

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -401,12 +401,7 @@ contract BatchExchange is EpochTokenLocker {
       * @return encoded bytes representing all orders
       */
     function getEncodedUserOrders(address user) public view returns (bytes memory elements) {
-        for (uint256 i = 0; i < orders[user].length; i++) {
-            elements = elements.concat(
-                encodeAuctionElement(user, getBalance(user, tokenIdToAddressMap(orders[user][i].sellToken)), orders[user][i])
-            );
-        }
-        return elements;
+        return getEncodedUserOrdersPaginated(user, 0, uint16(-1));
     }
 
     /** @dev View returning all byte-encoded sell orders

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -381,8 +381,8 @@ contract BatchExchange is EpochTokenLocker {
       * @param user address of user whose orders are being queried
       * @return encoded bytes representing all orders
       */
-    function getEncodedUserOrders(address user) public view returns (bytes memory elements) {
-        for (uint256 i = 0; i < orders[user].length; i++) {
+    function getEncodedUserOrders(address user, uint256 offset, uint16 pageSize) public view returns (bytes memory elements) {
+        for (uint256 i = offset; i < Math.min(orders[user].length, offset + pageSize + 1); i++) {
             elements = elements.concat(
                 encodeAuctionElement(user, getBalance(user, tokenIdToAddressMap(orders[user][i].sellToken)), orders[user][i])
             );
@@ -398,7 +398,7 @@ contract BatchExchange is EpochTokenLocker {
             address user = allUsers.first();
             bool stop = false;
             while (!stop) {
-                elements = elements.concat(getEncodedUserOrders(user));
+                elements = elements.concat(getEncodedUserOrders(user, 0, uint16(-2)));
                 if (user == allUsers.last) {
                     stop = true;
                 } else {

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -388,7 +388,7 @@ contract BatchExchange is EpochTokenLocker {
         view
         returns (bytes memory elements)
     {
-        for (uint256 i = offset; i < Math.min(orders[user].length, offset + pageSize); i++) {
+        for (uint16 i = offset; i < Math.min(orders[user].length, offset + pageSize); i++) {
             elements = elements.concat(
                 encodeAuctionElement(user, getBalance(user, tokenIdToAddressMap(orders[user][i].sellToken)), orders[user][i])
             );

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -379,10 +379,29 @@ contract BatchExchange is EpochTokenLocker {
 
     /** @dev View returning all byte-encoded sell orders for specified user
       * @param user address of user whose orders are being queried
+      * @param offset uint determining the starting orderIndex
+      * @param pageSize uint determining the count of elements to be viewed
       * @return encoded bytes representing all orders
       */
-    function getEncodedUserOrders(address user, uint256 offset, uint16 pageSize) public view returns (bytes memory elements) {
+    function getEncodedUserOrdersPaginated(address user, uint16 offset, uint16 pageSize)
+        public
+        view
+        returns (bytes memory elements)
+    {
         for (uint256 i = offset; i < Math.min(orders[user].length, offset + pageSize); i++) {
+            elements = elements.concat(
+                encodeAuctionElement(user, getBalance(user, tokenIdToAddressMap(orders[user][i].sellToken)), orders[user][i])
+            );
+        }
+        return elements;
+    }
+
+    /** @dev View returning all byte-encoded sell orders for specified user
+      * @param user address of user whose orders are being queried
+      * @return encoded bytes representing all orders
+      */
+    function getEncodedUserOrders(address user) public view returns (bytes memory elements) {
+        for (uint256 i = 0; i < orders[user].length; i++) {
             elements = elements.concat(
                 encodeAuctionElement(user, getBalance(user, tokenIdToAddressMap(orders[user][i].sellToken)), orders[user][i])
             );
@@ -398,7 +417,7 @@ contract BatchExchange is EpochTokenLocker {
             address user = allUsers.first();
             bool stop = false;
             while (!stop) {
-                elements = elements.concat(getEncodedUserOrders(user, 0, uint16(-1)));
+                elements = elements.concat(getEncodedUserOrders(user));
                 if (user == allUsers.last) {
                     stop = true;
                 } else {

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -1657,39 +1657,16 @@ contract("BatchExchange", async accounts => {
   describe("getEncodedUserOrdersPaginated()", async () => {
     it("returns correct orders considering offset and pageSize", async () => {
       const batchExchange = await setupGenericStableX()
-      const zeroBN = new BN(0)
-      const tenBN = new BN(10)
-      const twentyBN = new BN(20)
-
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const OrderInfo = {
-        user: user_1.toLowerCase(),
-        sellTokenBalance: zeroBN,
-        buyToken: 1,
-        sellToken: 0,
-        validFrom: batchId,
-        validUntil: batchId + 10,
-        priceNumerator: twentyBN,
-        priceDenominator: tenBN,
-        remainingAmount: tenBN,
-      }
 
       // Place 3 orders
       for (let i = 0; i < 3; i++) {
-        await batchExchange.placeOrder(
-          OrderInfo.buyToken,
-          OrderInfo.sellToken,
-          OrderInfo.validUntil,
-          OrderInfo.priceNumerator.addn(i),
-          OrderInfo.priceDenominator
-        )
+        await batchExchange.placeOrder(new BN(1), new BN(0), batchId + 10, new BN(i), new BN(i))
       }
 
       // get 2nd order with getEncodedUserOrdersPaginated(user_1, 1, 1)
-      const expectedOrder = OrderInfo
-      expectedOrder.priceNumerator = expectedOrder.priceNumerator.addn(1)
       const auctionElements = decodeAuctionElements(await batchExchange.getEncodedUserOrdersPaginated(user_1, 1, 1))
-      assert.equal(JSON.stringify(auctionElements), JSON.stringify([expectedOrder]))
+      assert.equal(auctionElements[0].priceNumerator, 1)
     })
   })
   describe("getEncodedUserOrders()", async () => {

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -1654,6 +1654,44 @@ contract("BatchExchange", async accounts => {
       }
     })
   })
+  describe("getEncodedUserOrdersPaginated()", async () => {
+    it("returns correct orders considering offset and pageSize", async () => {
+      const batchExchange = await setupGenericStableX()
+      const zeroBN = new BN(0)
+      const tenBN = new BN(10)
+      const twentyBN = new BN(20)
+
+      const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
+      const OrderInfo = {
+        user: user_1.toLowerCase(),
+        sellTokenBalance: zeroBN,
+        buyToken: 1,
+        sellToken: 0,
+        validFrom: batchId,
+        validUntil: batchId + 10,
+        priceNumerator: twentyBN,
+        priceDenominator: tenBN,
+        remainingAmount: tenBN,
+      }
+
+      // Place 3 orders
+      for (let i = 0; i < 3; i++) {
+        await batchExchange.placeOrder(
+          OrderInfo.buyToken,
+          OrderInfo.sellToken,
+          OrderInfo.validUntil,
+          OrderInfo.priceNumerator.addn(i),
+          OrderInfo.priceDenominator
+        )
+      }
+
+      // get 2nd order with getEncodedUserOrdersPaginated(user_1, 1, 1)
+      const expectedOrder = OrderInfo
+      expectedOrder.priceNumerator = expectedOrder.priceNumerator.addn(1)
+      const auctionElements = decodeAuctionElements(await batchExchange.getEncodedUserOrdersPaginated(user_1, 1, 1))
+      assert.equal(JSON.stringify(auctionElements), JSON.stringify([expectedOrder]))
+    })
+  })
   describe("getEncodedUserOrders()", async () => {
     it("returns null when there are no orders", async () => {
       const batchExchange = await setupGenericStableX()


### PR DESCRIPTION
This address the pagination proposal from here:
https://github.com/gnosis/dex-contracts/issues/386#issuecomment-567574354

This would improve the performance of the view, if there are traders with a lot of orders