### PR TITLE
Include ERC20 Abi in NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "build/contracts/SnappBase.json",
     "build/contracts/SnappBaseCore.json",
     "build/contracts/TokenConservation.json",
+    "build/contracts/ERC20.json",
     "networks.json",
     "src"
   ],

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "build/contracts/SnappBase.json",
     "build/contracts/SnappBaseCore.json",
     "build/contracts/TokenConservation.json",
-    "build/contracts/ERC20.json",
+    "build/contracts/IERC20.json",
     "networks.json",
     "src"
   ],


### PR DESCRIPTION
This PR includes the truffle artifact for IERC20 in the NPM package

It is convenient for us to get a IERC20 Abi in the NPM package so we don't need to include any additional dependency for that or to copy the file in out project.
