### PR TITLE
[scripts] improving information that getAuctionElements prints

### DIFF
--- a/scripts/stablex/get_auction_elements.js
+++ b/scripts/stablex/get_auction_elements.js
@@ -1,9 +1,9 @@
 const BatchExchange = artifacts.require("BatchExchange")
 const BN = require("bn.js")
 const argv = require("yargs")
-  .option("valid", {
+  .option("expired", {
     type: "boolean",
-    describe: "Only show valid and future orders",
+    describe: "Also show expired orders",
   })
   .option("covered", {
     type: "boolean",
@@ -12,7 +12,6 @@ const argv = require("yargs")
   .option("tokens", {
     describe: "Filter only orders between the given tokens",
   })
-  .help(false)
   .version(false).argv
 
 const { decodeAuctionElements } = require("../../test/utilities.js")
@@ -89,7 +88,7 @@ module.exports = async callback => {
     let auctionElementsDecoded = decodeAuctionElements(auctionElementsEncoded)
 
     const batchId = (await instance.getCurrentBatchId()).toNumber()
-    if (argv.valid) {
+    if (!argv.expired) {
       auctionElementsDecoded = auctionElementsDecoded.filter(order => order.validUntil >= batchId)
     }
 
@@ -102,7 +101,7 @@ module.exports = async callback => {
       auctionElementsDecoded = auctionElementsDecoded.filter(order => tokens.has(order.buyToken) && tokens.has(order.sellToken))
     }
 
-    auctionElementsDecoded.map(o => printOrder(o, batchId))
+    auctionElementsDecoded.forEach(order => printOrder(order, batchId))
     console.log(`Found ${auctionElementsDecoded.length} orders`)
 
     callback()

--- a/scripts/stablex/get_auction_elements.js
+++ b/scripts/stablex/get_auction_elements.js
@@ -56,6 +56,7 @@ const colorForValidUntil = function(order, currentBatchId) {
 
 const colorForRemainingAmount = function(order) {
   if (
+    order.priceDenominator > 0 &&
     order.remainingAmount
       .mul(new BN(100))
       .div(order.priceDenominator)

--- a/scripts/stablex/get_auction_elements.js
+++ b/scripts/stablex/get_auction_elements.js
@@ -1,14 +1,109 @@
 const BatchExchange = artifacts.require("BatchExchange")
+const BN = require("bn.js")
+const argv = require("yargs")
+  .option("valid", {
+    type: "boolean",
+    describe: "Only show valid and future orders",
+  })
+  .option("covered", {
+    type: "boolean",
+    describe: "Only show orders that have some balance in the sell token",
+  })
+  .option("tokens", {
+    describe: "Filter only orders between the given tokens",
+  })
+  .help(false)
+  .version(false).argv
 
 const { decodeAuctionElements } = require("../../test/utilities.js")
+
+const COLORS = {
+  NONE: "\x1b[0m",
+  RED: "\x1b[31m",
+  YELLOW: "\x1b[33m",
+}
+
+const formatAmount = function(amount) {
+  const string = amount.toString()
+  if (string.length > 4) {
+    return `${string.substring(0, 2)} * 10^${string.length - 2}`
+  } else {
+    return string
+  }
+}
+
+const colorForValidFrom = function(order, currentBatchId) {
+  let color = COLORS.NONE
+  if (order.validFrom >= currentBatchId) {
+    color = COLORS.RED
+    if (order.validFrom - 5 <= currentBatchId) {
+      color = COLORS.YELLOW
+    }
+  }
+  return color
+}
+
+const colorForValidUntil = function(order, currentBatchId) {
+  let color = COLORS.NONE
+  if (order.validUntil - 5 <= currentBatchId) {
+    color = COLORS.YELLOW
+    if (order.validUntil <= currentBatchId) {
+      color = COLORS.RED
+    }
+  }
+  return color
+}
+
+const colorForRemainingAmount = function(order) {
+  if (
+    order.remainingAmount
+      .mul(new BN(100))
+      .div(order.priceDenominator)
+      .toNumber() < 1
+  ) {
+    return COLORS.YELLOW
+  } else {
+    return COLORS.NONE
+  }
+}
+
+const printOrder = function(order, currentBatchId) {
+  console.log("{")
+  console.log(`  user: ${order.user}`)
+  console.log(`  sellTokenBalance: ${formatAmount(order.sellTokenBalance)}`)
+  console.log(`  buyToken: ${order.buyToken}`)
+  console.log(`  sellToken: ${order.sellToken}`)
+  console.log(`  ${colorForValidFrom(order, currentBatchId)}validFrom: ${new Date(order.validFrom * 300 * 1000)}${COLORS.NONE}`)
+  console.log(
+    `  ${colorForValidUntil(order, currentBatchId)}validUntil: ${new Date(order.validUntil * 300 * 1000)}${COLORS.NONE}`
+  )
+  console.log(`  price: Sell ${formatAmount(order.priceDenominator)} for at least ${formatAmount(order.priceNumerator)}`)
+  console.log(`  ${colorForRemainingAmount(order)}remaining: ${formatAmount(order.remainingAmount)}${COLORS.NONE}`)
+  console.log("}")
+}
 
 module.exports = async callback => {
   try {
     const instance = await BatchExchange.deployed()
     const auctionElementsEncoded = await instance.getEncodedOrders.call()
-    const auctionElementsDecoded = decodeAuctionElements(auctionElementsEncoded)
+    let auctionElementsDecoded = decodeAuctionElements(auctionElementsEncoded)
 
-    console.log(auctionElementsDecoded)
+    const batchId = (await instance.getCurrentBatchId()).toNumber()
+    if (argv.valid) {
+      auctionElementsDecoded = auctionElementsDecoded.filter(order => order.validUntil >= batchId)
+    }
+
+    if (argv.covered) {
+      auctionElementsDecoded = auctionElementsDecoded.filter(order => !order.sellTokenBalance.isZero())
+    }
+
+    if (argv.tokens) {
+      const tokens = new Set(argv.tokens.split(",").map(t => parseInt(t)))
+      auctionElementsDecoded = auctionElementsDecoded.filter(order => tokens.has(order.buyToken) && tokens.has(order.sellToken))
+    }
+
+    auctionElementsDecoded.map(o => printOrder(o, batchId))
+    console.log(`Found ${auctionElementsDecoded.length} orders`)
 
     callback()
   } catch (error) {


### PR DESCRIPTION
While working with martin's market orders over the holidays I found it helpful to have a bit more control over filtering certain auction elements.

This PR adds flags to filter for (1) valid in time (2) covered in balance (3) certain order pairs.

It also adds some color coding for orders that are almost completely filled or not yet valid/about to expire.

### Test Plan

Run the script with a bunch of options. E.g.

```
npx truffle exec scripts/stablex/get_auction_elements.js --network mainnet --valid --covered --tokens 1,6
```