### PR TITLE
[scripts] Place spread orders between trusted tokens

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "prepack": "truffle build && yarn run networks-reset",
     "prettier:solidity": "prettier --write 'contracts/**/*.sol'",
     "prettier:js": "prettier --write './**/*.js'",
-    "pretty-check": "prettier --check 'contracts/**/*.sol' && prettier --check './**/*.js'"
+    "pretty-check": "prettier --check 'contracts/**/*.sol' && prettier --check './**/*.js'",
+    "spread-orders": "npx truffle exec scripts/stablex/place_spread_orders.js"
   },
   "repository": {
     "type": "git",

--- a/scripts/stablex/add_token_list.js
+++ b/scripts/stablex/add_token_list.js
@@ -1,9 +1,9 @@
-const { addTokens } = require("./utilities.js")
+const { addTokens, token_list_url } = require("./utilities.js")
 const fetch = require("node-fetch")
 const argv = require("yargs")
   .option("token_list_url", {
     describe: "A url which can be fetched with node-fetch",
-    default: "https://raw.githubusercontent.com/gnosis/dex-js/master/src/tokenList.json",
+    default: token_list_url
   })
   .help(false)
   .version(false).argv

--- a/scripts/stablex/add_token_list.js
+++ b/scripts/stablex/add_token_list.js
@@ -3,7 +3,7 @@ const fetch = require("node-fetch")
 const argv = require("yargs")
   .option("token_list_url", {
     describe: "A url which can be fetched with node-fetch",
-    default: token_list_url
+    default: token_list_url,
   })
   .help(false)
   .version(false).argv

--- a/scripts/stablex/cancel_order.js
+++ b/scripts/stablex/cancel_order.js
@@ -3,7 +3,19 @@ const argv = require("yargs")
   .option("accountId", {
     describe: "Account index of the order placer",
   })
-  .demand(["accountId", "orderId"])
+  .option("orderIds", {
+    type: "array",
+    describe: "Order IDs to be canceled",
+    coerce: array => {
+      try {
+        return array.flatMap(v => v.split(",").map(o => parseInt(o)))
+      } catch (TypeError) {
+        console.log(`Detected individual order cancelation ${array[0]}`)
+        return array
+      }
+    },
+  })
+  .demand(["accountId", "orderIds"])
   .help(false)
   .version(false).argv
 
@@ -11,9 +23,9 @@ module.exports = async callback => {
   try {
     const accounts = await web3.eth.getAccounts()
     const instance = await BatchExchange.deployed()
-    await instance.cancelOrders([argv.orderId], { from: accounts[argv.accountId] })
+    await instance.cancelOrders(argv.orderIds, { from: accounts[argv.accountId] })
 
-    console.log(`Successfully cancelled order with ID ${argv.orderId}`)
+    console.log(`Successfully cancelled order with ID ${argv.orderIds}`)
     callback()
   } catch (error) {
     callback(error)

--- a/scripts/stablex/place_margin_orders.js
+++ b/scripts/stablex/place_margin_orders.js
@@ -1,27 +1,17 @@
 const BatchExchange = artifacts.require("BatchExchange")
-const ERC20 = artifacts.require("ERC20")
 const fetch = require("node-fetch")
 const BN = require("bn.js")
 const { sendTxAndGetReturnValue } = require("../../test/utilities.js")
 
 const token_list_url = "https://raw.githubusercontent.com/gnosis/dex-js/master/src/tokenList.json"
 
-const fetchTokenInfo = async function(contract, tokenIds) {
+const fetchTokenInfo = async function() {
   console.log(`Recovering token data from URL ${token_list_url}`)
   const token_list = await (await fetch(token_list_url)).json()
   const token_data = {}
   for (const token of token_list) {
     token_data[token.id] = token
   }
-
-  // console.log("Recovering token data from EVM")
-  // const tokenObjects = []
-  // for (const id of tokenIds) {
-  //   const tokenAddress = await contract.tokenIdToAddressMap(id)
-  //   const tokenInstance = await ERC20.at(tokenAddress)
-  //   console.log(await tokenInstance.decimals)
-  //   tokenObjects.push(await ERC20.at(tokenAddress))
-  // }
   return token_data
 }
 
@@ -60,7 +50,7 @@ module.exports = async callback => {
     const batch_index = (await instance.getCurrentBatchId.call()).toNumber()
 
     const trusted_tokens = argv.tokens.split(",").map(t => parseInt(t))
-    const token_data = await fetchTokenInfo(instance, trusted_tokens)
+    const token_data = await fetchTokenInfo()
 
     const expectedReturnFactor = 1 + argv.margin / 100
     const sellAmount = argv.sellAmount

--- a/scripts/stablex/place_margin_orders.js
+++ b/scripts/stablex/place_margin_orders.js
@@ -1,7 +1,65 @@
 const BatchExchange = artifacts.require("BatchExchange")
 const ERC20 = artifacts.require("ERC20")
-const { sendTxAndGetReturnValue } = require("../../test/utilities.js")
+const fetch = require("node-fetch")
 const BN = require("bn.js")
+const { sendTxAndGetReturnValue } = require("../../test/utilities.js")
+
+const token_list_url = "https://raw.githubusercontent.com/gnosis/dex-js/master/src/tokenList.json"
+
+
+const fetchTokenInfo = function(tokenIds) {
+  // console.log(`Recovering token data from URL ${token_list_url}`)
+  // const token_list = await (await fetch(token_list_url)).json()
+  // // TODO - automate this with tokenIdToAddress dot decimals
+  // const token_data = {}
+  // for (const token of token_list) {
+  //   token_data[token.id] = token.decimals
+  // }
+  // console.log(TOKEN_DECMIALS)
+
+  // console.log("Recovering token data from EVM")
+  // const tokenObjects = []
+  // for (const id of trusted_tokens) {
+  //   const tokenAddress = await instance.tokenIdToAddressMap(id)
+  //   const tokenInstance = await ERC20.at(tokenAddress)
+  //   console.log(await tokenInstance.decimals)
+  //   tokenObjects.push(await ERC20.at(tokenAddress))
+  // }
+
+  console.log("Using hardcoded token data")
+  return {
+    2: { 
+      decimals: 6,
+      name: "USDT",
+      address: 0xdac17f958d2ee523a2206206994597c13d831ec7,
+    },
+    3: { 
+      decimals: 18,
+      name: "TUSD",
+      address: 0x0000000000085d4780B73119b644AE5ecd22b376,
+    },
+    4: {
+      decimals: 6,
+      name: "USDC",
+      address: 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
+    },
+    5: {
+      decimals: 18,
+      name: "PAX",
+      address: 0x8e870d67f660d95d5be530380d0ec0bd388289e1,
+    },
+    6: {
+      decimals: 2,
+      name: "GUSD",
+      address: 0x056fd409e1d7a124bd7017459dfea2f387b6d5cd,
+    },
+    7: {
+      decimals: 18,
+      name: "DAI",
+      address: 0x6b175474e89094c44da98b954eedeac495271d0f
+    },
+  }
+}
 
 const argv = require("yargs")
   .option("tokens", {
@@ -29,16 +87,6 @@ const argv = require("yargs")
   .help("Make sure that you have an RPC connection to the network in consideration")
   .version(false).argv
 
-// TODO - automate this with tokenIdToAddress dot decimals
-const TOKEN_DECMIALS = {
-  2: 6,
-  3: 18,
-  4: 6,
-  5: 18,
-  6: 2,
-  7: 18,
-}
-
 module.exports = async callback => {
   try {
     const instance = await BatchExchange.deployed()
@@ -48,14 +96,7 @@ module.exports = async callback => {
     const batch_index = (await instance.getCurrentBatchId.call()).toNumber()
 
     const trusted_tokens = argv.tokens.split(",").map(t => parseInt(t))
-    // console.log("Recovering token data...")
-    // const tokenObjects = []
-    // for (const id of trusted_tokens) {
-    //   const tokenAddress = await instance.tokenIdToAddressMap(id)
-    //   const tokenInstance = await ERC20.at(tokenAddress)
-    //   console.log(await tokenInstance.decimals)
-    //   tokenObjects.push(await ERC20.at(tokenAddress))
-    // }
+    const token_data = fetchTokenInfo(trusted_tokens)
 
     const expectedReturnFactor = 1 + argv.margin / 100
     const sellAmount = argv.sellAmount
@@ -67,16 +108,16 @@ module.exports = async callback => {
     let sellAmounts = []
     for (let i = 0; i < trusted_tokens.length - 1; i++) {
       const tokenA = trusted_tokens[i]
-      const tokenScaleA = new BN(10).pow(new BN(TOKEN_DECMIALS[tokenA]))
+      const tokenScaleA = new BN(10).pow(new BN(token_data[tokenA].decimals))
       for (let j = i + 1; j < trusted_tokens.length; j++) {
         const tokenB = trusted_tokens[j]
-        const tokenScaleB = new BN(10).pow(new BN(TOKEN_DECMIALS[tokenB]))
+        const tokenScaleB = new BN(10).pow(new BN(token_data[tokenB].decimals))
         buyTokens = buyTokens.concat(tokenA, tokenB)
         sellTokens = sellTokens.concat(tokenB, tokenA)
         buyAmounts = buyAmounts.concat(tokenScaleA.muln(buyAmount), tokenScaleB.muln(buyAmount))
         sellAmounts = sellAmounts.concat(tokenScaleB.muln(sellAmount), tokenScaleA.muln(sellAmount))
-        console.log(`Selling ${sellAmounts[sellAmounts.length - 2]} of token ${tokenA} for ${buyAmounts[buyAmounts.length - 2]} of token ${tokenB}`)
-        console.log(`Selling ${sellAmounts[sellAmounts.length - 1]} of token ${tokenB} for ${buyAmounts[buyAmounts.length - 1]} of token ${tokenA}`)
+        console.log(`Selling ${sellAmounts[sellAmounts.length - 2]} ${token_data[tokenB].name} for ${buyAmounts[buyAmounts.length - 2]} ${token_data[tokenA].name}`)
+        console.log(`Selling ${sellAmounts[sellAmounts.length - 1]} ${token_data[tokenA].name} for ${buyAmounts[buyAmounts.length - 1]} ${token_data[tokenB].name}`)
       }
     }
 

--- a/scripts/stablex/place_margin_orders.js
+++ b/scripts/stablex/place_margin_orders.js
@@ -6,7 +6,6 @@ const { sendTxAndGetReturnValue } = require("../../test/utilities.js")
 
 const token_list_url = "https://raw.githubusercontent.com/gnosis/dex-js/master/src/tokenList.json"
 
-
 const fetchTokenInfo = function(tokenIds) {
   // console.log(`Recovering token data from URL ${token_list_url}`)
   // const token_list = await (await fetch(token_list_url)).json()
@@ -28,20 +27,20 @@ const fetchTokenInfo = function(tokenIds) {
 
   console.log("Using hardcoded token data")
   return {
-    2: { 
+    2: {
       decimals: 6,
       name: "USDT",
       address: 0xdac17f958d2ee523a2206206994597c13d831ec7,
     },
-    3: { 
+    3: {
       decimals: 18,
       name: "TUSD",
-      address: 0x0000000000085d4780B73119b644AE5ecd22b376,
+      address: 0x0000000000085d4780b73119b644ae5ecd22b376,
     },
     4: {
       decimals: 6,
       name: "USDC",
-      address: 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48
+      address: 0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48,
     },
     5: {
       decimals: 18,
@@ -56,7 +55,7 @@ const fetchTokenInfo = function(tokenIds) {
     7: {
       decimals: 18,
       name: "DAI",
-      address: 0x6b175474e89094c44da98b954eedeac495271d0f
+      address: 0x6b175474e89094c44da98b954eedeac495271d0f,
     },
   }
 }
@@ -116,8 +115,14 @@ module.exports = async callback => {
         sellTokens = sellTokens.concat(tokenB, tokenA)
         buyAmounts = buyAmounts.concat(tokenScaleA.muln(buyAmount), tokenScaleB.muln(buyAmount))
         sellAmounts = sellAmounts.concat(tokenScaleB.muln(sellAmount), tokenScaleA.muln(sellAmount))
-        console.log(`Selling ${sellAmounts[sellAmounts.length - 2]} ${token_data[tokenB].name} for ${buyAmounts[buyAmounts.length - 2]} ${token_data[tokenA].name}`)
-        console.log(`Selling ${sellAmounts[sellAmounts.length - 1]} ${token_data[tokenA].name} for ${buyAmounts[buyAmounts.length - 1]} ${token_data[tokenB].name}`)
+        console.log(
+          `Selling ${sellAmounts[sellAmounts.length - 2]} ${token_data[tokenB].name}
+            for ${buyAmounts[buyAmounts.length - 2]} ${token_data[tokenA].name}`
+        )
+        console.log(
+          `Selling ${sellAmounts[sellAmounts.length - 1]} ${token_data[tokenA].name}
+            for ${buyAmounts[buyAmounts.length - 1]} ${token_data[tokenB].name}`
+        )
       }
     }
 

--- a/scripts/stablex/place_margin_orders.js
+++ b/scripts/stablex/place_margin_orders.js
@@ -61,8 +61,8 @@ module.exports = async callback => {
       for (let j = i + 1; j < trusted_tokens.length; j++) {
         const tokenB = trusted_tokens[j]
         const tokenScaleB = new BN(10).pow(new BN(TOKEN_DECMIALS[tokenB]))
-        buyTokens = buyTokens.concat([tokenA, tokenB])
-        sellTokens = sellTokens.concat([tokenB, tokenA])
+        buyTokens = buyTokens.concat(tokenA, tokenB)
+        sellTokens = sellTokens.concat(tokenB, tokenA)
         buyAmounts = buyAmounts.concat(tokenScaleA.muln(buyAmount), tokenScaleB.muln(buyAmount))
         sellAmounts = sellAmounts.concat(tokenScaleA.muln(sellAmount), tokenScaleB.muln(sellAmount))
       }

--- a/scripts/stablex/place_margin_orders.js
+++ b/scripts/stablex/place_margin_orders.js
@@ -1,0 +1,91 @@
+const BatchExchange = artifacts.require("BatchExchange")
+const { sendTxAndGetReturnValue } = require("../../test/utilities.js")
+const BN = require("bn.js")
+
+const argv = require("yargs")
+  .option("tokens", {
+    describe: "Collection of trusted tokens",
+  })
+  .option("accountId", {
+    describe: "Account index of the order placer",
+  })
+  .option("margin", {
+    type: "float",
+    describe: "Percentage increase required for trade (fees not accounted)",
+    default: 0.2,
+  })
+  .option("sellAmount", {
+    type: "float",
+    describe: "Maximum sell amount (considered infinite if empty)",
+    default: 100,
+  })
+  .option("expiry", {
+    type: "int",
+    describe: "Maximum auction batch for which these orders are valid",
+    default: 2**32 - 1
+  })
+  .demand(["tokens", "accountId"])
+  .help(false)
+  .version(false).argv
+
+
+// TODO - automate this with tokenIdToAddress dot decimals
+const TOKEN_DECMIALS = {
+  2: 6,
+  3: 18,
+  4: 6,
+  5: 18,
+  6: 2,
+  7: 18
+}
+
+module.exports = async callback => {
+  try {
+    const instance = await BatchExchange.deployed()
+    const accounts = await web3.eth.getAccounts()
+    const account = accounts[argv.accountId]
+    console.log(account)
+    const batch_index = (await instance.getCurrentBatchId.call()).toNumber()
+
+    const trusted_tokens = argv.tokens.split(",").map(t => parseInt(t))
+    const expectedReturnFactor = new BN(1 + argv.margin / 100)
+    const sellAmount = new BN(argv.sellAmount)
+    const buyAmount = expectedReturnFactor.mul(sellAmount)
+
+    let buyTokens = []
+    let sellTokens = []
+    let buyAmounts = []
+    let sellAmounts = []
+    for (let i = 0; i < trusted_tokens.length - 1; i++) {
+      const tokenA = trusted_tokens[i]
+      const tokenScaleA = new BN(10).pow(new BN(TOKEN_DECMIALS[tokenA]))
+      for (let j = i + 1; j < trusted_tokens.length; j++) {
+        const tokenB = trusted_tokens[j]
+        const tokenScaleB = new BN(10).pow(new BN(TOKEN_DECMIALS[tokenB]))
+        buyTokens = buyTokens.concat([tokenA, tokenB])
+        sellTokens = sellTokens.concat([tokenB, tokenA])
+        buyAmounts = buyAmounts.concat(
+          buyAmount.mul(tokenScaleA),
+          buyAmount.mul(tokenScaleB)
+        )
+        sellAmounts = sellAmounts.concat(
+          sellAmount.mul(tokenScaleA),
+          sellAmount.mul(tokenScaleB)
+        )
+      }
+    }
+
+    // Allowing user 2 batches (10 minutes) to cancel if it is incorrectly placed
+    const validFroms = Array(buyTokens.length).fill(batch_index + 2)
+    const validTos = Array(buyTokens.length).fill(argv.expiry)
+
+    const id = await sendTxAndGetReturnValue(instance.placeValidFromOrders, buyTokens, sellTokens, validFroms, validTos, buyAmounts, sellAmounts, {
+      from: account,
+    })
+    console.log(`Successfully placed margin orders with IDs ${id}`)
+
+    callback()
+  } catch (error) {
+    callback(error)
+  }
+}

--- a/scripts/stablex/place_spread_orders.js
+++ b/scripts/stablex/place_spread_orders.js
@@ -5,16 +5,15 @@ const readline = require("readline")
 
 const { sendTxAndGetReturnValue } = require("../../test/utilities.js")
 
-
 const rl = readline.createInterface({
   input: process.stdin,
-  output: process.stdout
+  output: process.stdout,
 })
 
 const token_list_url = "https://raw.githubusercontent.com/gnosis/dex-js/master/src/tokenList.json"
 
 const promptUser = function(message) {
-  return new Promise((resolve) => rl.question(message, (answer) => resolve(answer)))
+  return new Promise(resolve => rl.question(message, answer => resolve(answer)))
 }
 
 const fetchTokenInfo = async function() {

--- a/scripts/stablex/place_spread_orders.js
+++ b/scripts/stablex/place_spread_orders.js
@@ -22,7 +22,7 @@ const argv = require("yargs")
   .option("accountId", {
     describe: "Account index of the order placer",
   })
-  .option("margin", {
+  .option("spread", {
     type: "float",
     describe: "Percentage increase required for trade (fees not accounted)",
     default: 0.25,
@@ -52,7 +52,7 @@ module.exports = async callback => {
     const trusted_tokens = argv.tokens.split(",").map(t => parseInt(t))
     const token_data = await fetchTokenInfo()
 
-    const expectedReturnFactor = 1 + argv.margin / 100
+    const expectedReturnFactor = 1 + argv.spread / 100
     const sellAmount = argv.sellAmount
     const buyAmount = sellAmount * expectedReturnFactor
 
@@ -99,7 +99,7 @@ module.exports = async callback => {
         from: account,
       }
     )
-    console.log(`Successfully placed margin orders with IDs ${id}`)
+    console.log(`Successfully placed spread orders with IDs ${id}`)
 
     callback()
   } catch (error) {

--- a/scripts/stablex/place_spread_orders.js
+++ b/scripts/stablex/place_spread_orders.js
@@ -4,13 +4,12 @@ const BN = require("bn.js")
 const readline = require("readline")
 
 const { sendTxAndGetReturnValue } = require("../../test/utilities.js")
+const token_list_url = require("./utilities.js")
 
 const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout,
 })
-
-const token_list_url = "https://raw.githubusercontent.com/gnosis/dex-js/master/src/tokenList.json"
 
 const promptUser = function(message) {
   return new Promise(resolve => rl.question(message, answer => resolve(answer)))
@@ -64,7 +63,7 @@ const argv = require("yargs")
   })
   .demand(["tokens", "accountId"])
   .help(
-    "Make sure that you have an RPC connection to the network in consideration. Example usage \n   npx truffle exec scripts/stablex/place_spread_orders.js --tokens=2,3,4 --accountId 0 --spread 0.3 --validFrom 5"
+    "Make sure that you have an RPC connection to the network in consideration. For network configurations, please see truffle-config.js Example usage \n   npx truffle exec scripts/stablex/place_spread_orders.js --tokens=2,3,4 --accountId 0 --spread 0.3 --validFrom 5"
   )
   .version(false).argv
 

--- a/scripts/stablex/utilities.js
+++ b/scripts/stablex/utilities.js
@@ -1,5 +1,6 @@
 const BN = require("bn.js")
 const { waitForNSeconds } = require("../../test/utilities.js")
+const token_list_url = "https://raw.githubusercontent.com/gnosis/dex-js/master/src/tokenList.json"
 
 const addTokens = async function(token_addresses, web3, artifacts) {
   const accounts = await web3.eth.getAccounts()
@@ -39,4 +40,5 @@ const closeAuction = async (instance, web3Provider = web3) => {
 module.exports = {
   addTokens,
   closeAuction,
+  token_list_url
 }

--- a/scripts/stablex/utilities.js
+++ b/scripts/stablex/utilities.js
@@ -40,5 +40,5 @@ const closeAuction = async (instance, web3Provider = web3) => {
 module.exports = {
   addTokens,
   closeAuction,
-  token_list_url
+  token_list_url,
 }


### PR DESCRIPTION
This is a first "working" pass through the margin trading strategy script. It remains to fetch the token's decimal information from the EVM.

**Test Plan:**
run the following rinkeby command (which should place 6 orders between tokens 2,3,4) with correct buy-sell amounts for account 1 from the default nemonic in the truffle configuration file. 

```sh
npx truffle exec scripts/stablex/place_margin_orders.js --network rinkeby --tokens 2,3,4 --spread 1 --accountId 1
```


TODO -

1. Fetch token Decimals from EVM
2. Console log the gathered information in plain text and possibly inform the user how they can cancel their order before they become valid.