### PR TITLE
Emit new token event

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -98,6 +98,8 @@ contract BatchExchange is EpochTokenLocker {
         uint128 priceDenominator
     );
 
+    event Token(address token, uint256 id);
+
     /** @dev Event emitted when an order is cancelled but still valid in the batch that is
      * currently being solved. It remains in storage but will not be tradable in any future
      * batch to be solved.
@@ -146,6 +148,7 @@ contract BatchExchange is EpochTokenLocker {
             feeToken.burnOWL(msg.sender, FEE_FOR_LISTING_TOKEN_IN_OWL);
         }
         require(IdToAddressBiMap.insert(registeredTokens, numTokens, token), "Token already registered");
+        emit Token(token, numTokens);
         numTokens++;
     }
 

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -98,7 +98,7 @@ contract BatchExchange is EpochTokenLocker {
         uint128 priceDenominator
     );
 
-    event Token(address token, uint256 id);
+    event TokenListing(address token, uint256 id);
 
     /** @dev Event emitted when an order is cancelled but still valid in the batch that is
      * currently being solved. It remains in storage but will not be tradable in any future
@@ -148,7 +148,7 @@ contract BatchExchange is EpochTokenLocker {
             feeToken.burnOWL(msg.sender, FEE_FOR_LISTING_TOKEN_IN_OWL);
         }
         require(IdToAddressBiMap.insert(registeredTokens, numTokens, token), "Token already registered");
-        emit Token(token, numTokens);
+        emit TokenListing(token, numTokens);
         numTokens++;
     }
 


### PR DESCRIPTION
Proposal for adding a new event for listing tokens

The reasoning:
- It's the only important operation that doesn't have event
- An event doesn't add too much cost
- Doesn't affect to the cost of trading nor submit solutions
- Makes it easier for people to list the tokens by using web3 only
- Makes it easier to index in the graph for ganache and rinkeby, which doesn't support call handlers