### PR TITLE
[Bug/Typo] Unnecessary Cast to uint128

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -584,7 +584,7 @@ contract BatchExchange is EpochTokenLocker {
         uint256 utilityError = execSellTimesBuy.mod(order.priceDenominator).mul(currentPrices[order.buyToken]).div(
             order.priceDenominator
         );
-        return roundedUtility.sub(utilityError).toUint128();
+        return roundedUtility.sub(utilityError);
     }
 
     /** @dev computes a measure of how much of an order was disregarded (only valid when limit price is respected)

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -608,7 +608,7 @@ contract BatchExchange is EpochTokenLocker {
         if (limitTermLeft > limitTermRight) {
             limitTerm = limitTermLeft.sub(limitTermRight);
         }
-        return leftoverSellAmount.mul(limitTerm).div(order.priceDenominator).toUint128();
+        return leftoverSellAmount.mul(limitTerm).div(order.priceDenominator);
     }
 
     /** @dev Evaluates executedBuy amount based on prices and executedBuyAmout (fees included)

--- a/test/resources/examples/index.js
+++ b/test/resources/examples/index.js
@@ -231,7 +231,6 @@ const marginalTrade = generateTestCase({
   ],
 })
 
-
 const utilityOverflow = generateTestCase({
   deposits: [
     { amount: toETH(10), token: 0, user: 0 },
@@ -247,7 +246,7 @@ const utilityOverflow = generateTestCase({
     {
       name: "Utility Overflow",
       prices: ["1000000000000000000", "998999900119977150048", "10000000000198528574"].map(val => new BN(val)),
-      buyVolumes: ["1998999800099984", "99800080039994614733", "998000900199892164",].map(val => new BN(val)),
+      buyVolumes: ["1998999800099984", "99800080039994614733", "998000900199892164"].map(val => new BN(val)),
     },
   ],
 })

--- a/test/resources/examples/index.js
+++ b/test/resources/examples/index.js
@@ -231,6 +231,27 @@ const marginalTrade = generateTestCase({
   ],
 })
 
+
+const utilityOverflow = generateTestCase({
+  deposits: [
+    { amount: toETH(10), token: 0, user: 0 },
+    { amount: toETH(1), token: 1, user: 1 },
+    { amount: toETH(100), token: 2, user: 2 },
+  ],
+  orders: [
+    { sellToken: 0, buyToken: 1, sellAmount: toETH(10), buyAmount: new BN("10000000000000000"), user: 0 },
+    { sellToken: 1, buyToken: 2, sellAmount: toETH(1), buyAmount: new BN("1000"), user: 1 },
+    { sellToken: 2, buyToken: 1, sellAmount: toETH(100), buyAmount: toETH(1), user: 2 },
+  ],
+  solutions: [
+    {
+      name: "Utility Overflow",
+      prices: ["1000000000000000000", "998999900119977150048", "10000000000198528574"].map(val => new BN(val)),
+      buyVolumes: ["1998999800099984", "99800080039994614733", "998000900199892164",].map(val => new BN(val)),
+    },
+  ],
+})
+
 module.exports = Object.assign(
   {
     basicTrade,
@@ -243,6 +264,7 @@ module.exports = Object.assign(
     smallExample,
     stableXExample,
     marginalTrade,
+    utilityOverflow,
   },
   require("./generate")
 )

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -1826,9 +1826,6 @@ contract("BatchExchange", async accounts => {
   describe("Special Examples", async () => {
     it("Overflows u128 on utility evaluation", async () => {
       const batchExchange = await setupGenericStableX(3)
-      const feeToken = await batchExchange.tokenIdToAddressMap.call(0)
-      const wethToken = await batchExchange.tokenIdToAddressMap.call(1)
-      const otherToken = await batchExchange.tokenIdToAddressMap.call(2)
 
       await makeDeposits(batchExchange, accounts, utilityOverflow.deposits)
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -1824,7 +1824,7 @@ contract("BatchExchange", async accounts => {
     })
   })
   describe("Special Examples", async () => {
-    it.only("Overflows u128 on utility evaluation", async () => {
+    it("Overflows u128 on utility evaluation", async () => {
       const batchExchange = await setupGenericStableX(3)
       const feeToken = await batchExchange.tokenIdToAddressMap.call(0)
       const wethToken = await batchExchange.tokenIdToAddressMap.call(1)

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -1823,7 +1823,7 @@ contract("BatchExchange", async accounts => {
       assert.equal(await batchExchange.hasToken.call(erc20_1.address), true)
     })
   })
-  describe("Special Examples", async () => {
+  describe("Regression Tests", async () => {
     it("Accepts large (> 2^128) utility evaluation", async () => {
       const batchExchange = await setupGenericStableX(3)
 

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -1824,7 +1824,7 @@ contract("BatchExchange", async accounts => {
     })
   })
   describe("Special Examples", async () => {
-    it("Overflows u128 on utility evaluation", async () => {
+    it("Accepts large (> 2^128) utility evaluation", async () => {
       const batchExchange = await setupGenericStableX(3)
 
       await makeDeposits(batchExchange, accounts, utilityOverflow.deposits)
@@ -1832,7 +1832,8 @@ contract("BatchExchange", async accounts => {
       const orderIds = await placeOrders(batchExchange, accounts, utilityOverflow.orders, batchId + 1)
       await closeAuction(batchExchange)
       const solution = solutionSubmissionParams(utilityOverflow.solutions[0], accounts, orderIds)
-      await batchExchange.submitSolution(
+
+      const objectiveValue = await batchExchange.submitSolution.call(
         batchId,
         solution.objectiveValue,
         solution.owners,
@@ -1842,6 +1843,7 @@ contract("BatchExchange", async accounts => {
         solution.tokenIdsForPrice,
         { from: solver }
       )
+      assert(objectiveValue > new BN(2).pow(new BN(128)))
     })
   })
 })


### PR DESCRIPTION
As discovered and pointed out by @fleupold, utility calculations are overflowing and failing on this SafeCast to Uint128 (even though the functions are meant to return u256 in the first place.

Notice that this function is meant to return `u256` anyway:

https://github.com/gnosis/dex-contracts/blob/5ab2c4e231c96621fad6fada12100de2b97fdda6/contracts/BatchExchange.sol#L601-L612

https://github.com/gnosis/dex-contracts/blob/5ab2c4e231c96621fad6fada12100de2b97fdda6/contracts/BatchExchange.sol#L578-L588

Note, again, that it was @fleupold  who uncovered this problem and got to the root of it.