### PR TITLE
[Easy] OrderIds are u16

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -98,7 +98,7 @@ contract BatchExchange is EpochTokenLocker {
         uint128 priceDenominator
     );
 
-    event TokenListing(address token, uint256 id);
+    event TokenListing(address token, uint16 id);
 
     /** @dev Event emitted when an order is cancelled but still valid in the batch that is
      * currently being solved. It remains in storage but will not be tradable in any future
@@ -112,11 +112,11 @@ contract BatchExchange is EpochTokenLocker {
 
     /** @dev Event emitted when a new trade is settled
      */
-    event Trade(address indexed owner, uint16 indexed orderId, uint256 executedSellAmount, uint256 executedBuyAmount);
+    event Trade(address indexed owner, uint16 indexed orderId, uint128 executedSellAmount, uint128 executedBuyAmount);
 
     /** @dev Event emitted when an already exectued trade gets reverted
      */
-    event TradeReversion(address indexed owner, uint16 indexed orderId, uint256 executedSellAmount, uint256 executedBuyAmount);
+    event TradeReversion(address indexed owner, uint16 indexed orderId, uint128 executedSellAmount, uint128 executedBuyAmount);
 
     /** @dev Constructor determines exchange parameters
       * @param maxTokens The maximum number of tokens that can be listed.

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -29,7 +29,7 @@ contract BatchExchange is EpochTokenLocker {
     uint256 public constant FEE_FOR_LISTING_TOKEN_IN_OWL = 10 ether;
 
     /** @dev minimum allowed value (in WEI) of any prices or executed trade amounts */
-    uint256 public constant AMOUNT_MINIMUM = 10**4;
+    uint128 public constant AMOUNT_MINIMUM = 10**4;
 
     /** Corresponds to percentage that competing solution must improve on current
       * (p = IMPROVEMENT_DENOMINATOR + 1 / IMPROVEMENT_DENOMINATOR)

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -104,11 +104,11 @@ contract BatchExchange is EpochTokenLocker {
      * currently being solved. It remains in storage but will not be tradable in any future
      * batch to be solved.
      */
-    event OrderCancelation(address indexed owner, uint256 id);
+    event OrderCancelation(address indexed owner, uint16 id);
 
     /** @dev Event emitted when an order is removed from storage.
      */
-    event OrderDeletion(address indexed owner, uint256 id);
+    event OrderDeletion(address indexed owner, uint16 id);
 
     /** @dev Event emitted when a new trade is settled
      */

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -104,7 +104,7 @@ contract BatchExchange is EpochTokenLocker {
      * currently being solved. It remains in storage but will not be tradable in any future
      * batch to be solved.
      */
-    event OrderCancellation(address indexed owner, uint16 id);
+    event OrderCancelation(address indexed owner, uint16 id);
 
     /** @dev Event emitted when an order is removed from storage.
      */
@@ -208,7 +208,7 @@ contract BatchExchange is EpochTokenLocker {
       *
       * @param orderIds referencing the indices of user's orders to be canceled
       *
-      * Emits an {OrderCancellation} or {OrderDeletion} with sender's address and orderId
+      * Emits an {OrderCancelation} or {OrderDeletion} with sender's address and orderId
       */
     function cancelOrders(uint16[] memory orderIds) public {
         uint32 batchIdBeingSolved = getCurrentBatchId() - 1;
@@ -218,7 +218,7 @@ contract BatchExchange is EpochTokenLocker {
                 emit OrderDeletion(msg.sender, orderIds[i]);
             } else {
                 orders[msg.sender][orderIds[i]].validUntil = batchIdBeingSolved;
-                emit OrderCancellation(msg.sender, orderIds[i]);
+                emit OrderCancelation(msg.sender, orderIds[i]);
             }
         }
     }
@@ -233,7 +233,7 @@ contract BatchExchange is EpochTokenLocker {
       * @param sellAmounts maximum amounts of sell token to be exchanged in new orders
       * @return an array of indices in which `msg.sender`'s new orders are included
       *
-      * Emits {OrderCancellation} events for all cancelled orders and {OrderPlacement} events with relevant new order details.
+      * Emits {OrderCancelation} events for all cancelled orders and {OrderPlacement} events with all relevant new order details.
       */
     function replaceOrders(
         uint16[] memory cancellations,

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -104,7 +104,7 @@ contract BatchExchange is EpochTokenLocker {
      * currently being solved. It remains in storage but will not be tradable in any future
      * batch to be solved.
      */
-    event OrderCancellation(address indexed owner, uint6 id);
+    event OrderCancellation(address indexed owner, uint16 id);
 
     /** @dev Event emitted when an order is removed from storage.
      */

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -104,7 +104,7 @@ contract BatchExchange is EpochTokenLocker {
      * currently being solved. It remains in storage but will not be tradable in any future
      * batch to be solved.
      */
-    event OrderCancelation(address indexed owner, uint16 id);
+    event OrderCancellation(address indexed owner, uint6 id);
 
     /** @dev Event emitted when an order is removed from storage.
      */
@@ -208,7 +208,7 @@ contract BatchExchange is EpochTokenLocker {
       *
       * @param orderIds referencing the indices of user's orders to be canceled
       *
-      * Emits an {OrderCancelation} or {OrderDeletion} with sender's address and orderId
+      * Emits an {OrderCancellation} or {OrderDeletion} with sender's address and orderId
       */
     function cancelOrders(uint16[] memory orderIds) public {
         uint32 batchIdBeingSolved = getCurrentBatchId() - 1;
@@ -218,7 +218,7 @@ contract BatchExchange is EpochTokenLocker {
                 emit OrderDeletion(msg.sender, orderIds[i]);
             } else {
                 orders[msg.sender][orderIds[i]].validUntil = batchIdBeingSolved;
-                emit OrderCancelation(msg.sender, orderIds[i]);
+                emit OrderCancellation(msg.sender, orderIds[i]);
             }
         }
     }
@@ -233,7 +233,7 @@ contract BatchExchange is EpochTokenLocker {
       * @param sellAmounts maximum amounts of sell token to be exchanged in new orders
       * @return an array of indices in which `msg.sender`'s new orders are included
       *
-      * Emits {OrderCancelation} events for all cancelled orders and {OrderPlacement} events with all relevant new order details.
+      * Emits {OrderCancellation} events for all cancelled orders and {OrderPlacement} events with relevant new order details.
       */
     function replaceOrders(
         uint16[] memory cancellations,


### PR DESCRIPTION
An easy mistake (since `orderId` corresponds to an array index) is that `orderId` is `uint256`. However, for space saving reasons, we have decided to restrict this value to `uint16` (allows ~65K order per account.. which should suffice). 

**Test Plan:** Unit tests