### PR TITLE
[Audit] Consume claimable withdraw 

### DIFF
--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -206,6 +206,7 @@ contract EpochTokenLocker {
     }
 
     function subtractBalance(address user, address token, uint256 amount) internal {
+        require(amount <= getBalance(user, token), "Amount exceeds user's balance.");
         updateDepositsBalance(user, token);
         balanceStates[user][token].balance = balanceStates[user][token].balance.sub(amount);
     }

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -20,7 +20,6 @@ const {
   shortRingBetterTrade,
   smallExample,
   marginalTrade,
-  utilityOverflow,
 } = require("../resources/examples")
 const { makeDeposits, placeOrders, setupGenericStableX } = require("./stablex_utils")
 
@@ -1857,29 +1856,6 @@ contract("BatchExchange", async accounts => {
       await batchExchange.addToken(erc20_1.address)
 
       assert.equal(await batchExchange.hasToken.call(erc20_1.address), true)
-    })
-  })
-  describe("Regression Tests", async () => {
-    it("Accepts large (> 2^128) utility evaluation", async () => {
-      const batchExchange = await setupGenericStableX(3)
-
-      await makeDeposits(batchExchange, accounts, utilityOverflow.deposits)
-      const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
-      const orderIds = await placeOrders(batchExchange, accounts, utilityOverflow.orders, batchId + 1)
-      await closeAuction(batchExchange)
-      const solution = solutionSubmissionParams(utilityOverflow.solutions[0], accounts, orderIds)
-
-      const objectiveValue = await batchExchange.submitSolution.call(
-        batchId,
-        solution.objectiveValue,
-        solution.owners,
-        solution.touchedorderIds,
-        solution.volumes,
-        solution.prices,
-        solution.tokenIdsForPrice,
-        { from: solver }
-      )
-      assert(objectiveValue > new BN(2).pow(new BN(128)))
     })
   })
 })

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -1080,7 +1080,7 @@ contract("BatchExchange", async accounts => {
         "Token conservation does not hold"
       )
     })
-    it("throws, if sell volume is bigger than balance available", async () => {
+    it("throws if sell volume is bigger than available balance", async () => {
       const batchExchange = await setupGenericStableX()
 
       for (const deposit of basicTrade.deposits) {
@@ -1104,7 +1104,7 @@ contract("BatchExchange", async accounts => {
           solution.tokenIdsForPrice,
           { from: solver }
         ),
-        "SafeMath: subtraction overflow"
+        "Amount exceeds user's balance"
       )
     })
     it("reverts, if tokenIds for prices are not sorted", async () => {

--- a/test/stablex/regression_tests.js
+++ b/test/stablex/regression_tests.js
@@ -4,6 +4,7 @@ const IdToAddressBiMap = artifacts.require("IdToAddressBiMap")
 const IterableAppendOnlySet = artifacts.require("IterableAppendOnlySet")
 
 const BN = require("bn.js")
+const truffleAssert = require("truffle-assertions")
 
 const { closeAuction } = require("../../scripts/stablex/utilities.js")
 
@@ -71,19 +72,19 @@ contract("BatchExchange", async accounts => {
       await closeAuction(batchExchange)
       const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
 
-      await batchExchange.submitSolution.call(
-        batchId,
-        solution.objectiveValue,
-        solution.owners,
-        solution.touchedorderIds,
-        solution.volumes,
-        solution.prices,
-        solution.tokenIdsForPrice,
-        { from: solver }
+      await truffleAssert.reverts(
+        batchExchange.submitSolution.call(
+          batchId,
+          solution.objectiveValue,
+          solution.owners,
+          solution.touchedorderIds,
+          solution.volumes,
+          solution.prices,
+          solution.tokenIdsForPrice,
+          { from: solver }
+        ),
+        "Amount exceeds user's balance"
       )
-
-      // Claim back initial deposit that has already been traded.
-      await batchExchange.withdraw(attackerAddress, tokenAddress)
     })
   })
 })

--- a/test/stablex/regression_tests.js
+++ b/test/stablex/regression_tests.js
@@ -1,0 +1,89 @@
+const BatchExchange = artifacts.require("BatchExchange")
+const MockContract = artifacts.require("MockContract")
+const IdToAddressBiMap = artifacts.require("IdToAddressBiMap")
+const IterableAppendOnlySet = artifacts.require("IterableAppendOnlySet")
+
+const BN = require("bn.js")
+
+const { closeAuction } = require("../../scripts/stablex/utilities.js")
+
+const { solutionSubmissionParams, basicTrade, utilityOverflow } = require("../resources/examples")
+const { makeDeposits, placeOrders, setupGenericStableX } = require("./stablex_utils")
+
+contract("BatchExchange", async accounts => {
+  const solver = accounts.pop()
+
+  before(async () => {
+    const feeToken = await MockContract.new()
+    await feeToken.givenAnyReturnBool(true)
+    const lib1 = await IdToAddressBiMap.new()
+    const lib2 = await IterableAppendOnlySet.new()
+    await BatchExchange.link(IdToAddressBiMap, lib1.address)
+    await BatchExchange.link(IterableAppendOnlySet, lib2.address)
+  })
+
+  // In the following tests, it might be possible that an batchId is read from the blockchain
+  // and in the next moment this batchId is no longer the current one. In order to prevent these
+  // situations, we set the adjust the start-time of each test to the start of an new auction.
+  beforeEach(async () => {
+    const batchExchange = await BatchExchange.deployed()
+    await closeAuction(batchExchange)
+  })
+
+  describe("Regression Tests", async () => {
+    it("Accepts large (> 2^128) utility evaluation", async () => {
+      const batchExchange = await setupGenericStableX(3)
+
+      await makeDeposits(batchExchange, accounts, utilityOverflow.deposits)
+      const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
+      const orderIds = await placeOrders(batchExchange, accounts, utilityOverflow.orders, batchId + 1)
+      await closeAuction(batchExchange)
+      const solution = solutionSubmissionParams(utilityOverflow.solutions[0], accounts, orderIds)
+
+      const objectiveValue = await batchExchange.submitSolution.call(
+        batchId,
+        solution.objectiveValue,
+        solution.owners,
+        solution.touchedorderIds,
+        solution.volumes,
+        solution.prices,
+        solution.tokenIdsForPrice,
+        { from: solver }
+      )
+      assert(objectiveValue > new BN(2).pow(new BN(128)))
+    })
+    it("Consume claimable withdraw balance", async () => {
+      const batchExchange = await setupGenericStableX()
+
+      await makeDeposits(batchExchange, accounts, basicTrade.deposits)
+      const firstOrder = basicTrade.orders[0]
+      const tokenAddress = await batchExchange.tokenIdToAddressMap.call(firstOrder.sellToken)
+      const attackerAddress = accounts[firstOrder.user]
+
+      await batchExchange.requestWithdraw(tokenAddress, firstOrder.sellAmount, { from: attackerAddress })
+      await closeAuction(batchExchange)
+      // Ensure withdraw is claimable.
+      assert(batchExchange.hasValidWithdrawRequest.call(attackerAddress, tokenAddress), true)
+      
+      const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
+      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+
+      await closeAuction(batchExchange)
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+
+      await batchExchange.submitSolution.call(
+        batchId,
+        solution.objectiveValue,
+        solution.owners,
+        solution.touchedorderIds,
+        solution.volumes,
+        solution.prices,
+        solution.tokenIdsForPrice,
+        { from: solver }
+      )
+
+      // Claim back initial deposit that has already been traded.
+      await batchExchange.withdraw(attackerAddress, tokenAddress)
+    })
+  })
+})

--- a/test/stablex/regression_tests.js
+++ b/test/stablex/regression_tests.js
@@ -64,7 +64,7 @@ contract("BatchExchange", async accounts => {
       await closeAuction(batchExchange)
       // Ensure withdraw is claimable.
       assert(batchExchange.hasValidWithdrawRequest.call(attackerAddress, tokenAddress), true)
-      
+
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
       const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
 

--- a/test/stablex/regression_tests.js
+++ b/test/stablex/regression_tests.js
@@ -53,7 +53,7 @@ contract("BatchExchange", async accounts => {
       )
       assert(objectiveValue > new BN(2).pow(new BN(128)))
     })
-    it("Consume claimable withdraw balance", async () => {
+    it("Should not allow to use claimable withdraws in solution", async () => {
       const batchExchange = await setupGenericStableX()
 
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
@@ -64,7 +64,8 @@ contract("BatchExchange", async accounts => {
       await batchExchange.requestWithdraw(tokenAddress, firstOrder.sellAmount, { from: attackerAddress })
       await closeAuction(batchExchange)
       // Ensure withdraw is claimable.
-      assert(batchExchange.hasValidWithdrawRequest.call(attackerAddress, tokenAddress), true)
+      assert(await batchExchange.hasValidWithdrawRequest.call(attackerAddress, tokenAddress), true)
+      assert(await batchExchange.getBalance.call(attackerAddress, tokenAddress), 0)
 
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
       const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)


### PR DESCRIPTION
This PR introduces a regression test (example scenario) of an exploit discovered in the audit #448.

The Regression test is summarized as the following sequence of events/transactions:

1. **Deposit:** 
Two users about to trade deposit token 0 and 1 respectively.
2. **Request Withdraw:** 
User 0 requests to withdraw the full amount of recent deposit.
3. **Close Auction:** 
Wait until withdraw request becomes claimable.
4. **Place Orders:** 
Users place orders selling the full amount of their recent deposits (buying the opposite respective tokens) such that these two orders would directly match.
5. **Close Auction:** 
Solution is submitted matching the two above trade requests.
6. **Claim Traded Balance:** 
User 0 proceeds in claiming their valid withdraw request of their original deposited token that has already been traded.


Closes #448 