### PR TITLE
Trigger Deployment from CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/*
 coverage/*
 coverage.json
+deploy/*
 node_modules/*
 package-lock.json
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ deploy:
   bucket: $BUCKET_NAME
   access_key_id: $AWS_ACCESS_KEY_ID
   secret_access_key: $AWS_SECRET_ACCESS_KEY
-  local_dir: deploy
+  local_dir: ./deploy
   on:
     tags: true
 after_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,13 @@ script:
 before_deploy:
   - mkdir -p deploy
   - yarn pack --filename deploy/dex-contracts-$TRAVIS_TAG.tgz
-  - ls $PWD/deploy/dex-contracts-*.tgz
 deploy:
   provider: s3
   bucket: $BUCKET_NAME
   access_key_id: $AWS_ACCESS_KEY_ID
   secret_access_key: $AWS_SECRET_ACCESS_KEY
   local_dir: deploy
+  skip_cleanup: true
   on:
     tags: true
 after_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,13 @@ script:
 before_deploy:
   - mkdir -p deploy
   - yarn pack --filename deploy/dex-contracts-$TRAVIS_TAG.tgz
+  - ls $PWD/deploy/dex-contracts-*.tgz
 deploy:
   provider: s3
   bucket: $BUCKET_NAME
   access_key_id: $AWS_ACCESS_KEY_ID
   secret_access_key: $AWS_SECRET_ACCESS_KEY
-  local_dir: ./deploy
+  local_dir: deploy
   on:
     tags: true
 after_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ script:
   - yarn run coverage && cat ./coverage/lcov.info | coveralls
 before_deploy:
   - mkdir -p deploy
-  - yarn pack --filename deploy/dex-contracts-$TRAVIS_TAG.tgz
+  - export PACKAGE_VERSION=$(jq -r '.version' package.json)
+  - yarn pack --filename deploy/dex-contracts-$PACKAGE_VERSION.tgz
 deploy:
   provider: s3
   bucket: $BUCKET_NAME
@@ -31,5 +32,5 @@ after_deploy:
     curl -X POST
     -F "token=$GITLAB_TOKEN"
     -F "ref=master"
-    -F "variables[TAG]=$TRAVIS_TAG"
+    -F "variables[PACKAGE_VERSION]=$PACKAGE_VERSION"
     https://gitlab.gnosisdev.com/api/v4/projects/$GITLAB_PROJECT/trigger/pipeline

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,21 @@ script:
   - yarn run pretty-check
   - solium -d contracts/
   - yarn run coverage && cat ./coverage/lcov.info | coveralls
+before_deploy:
+  - yarn pack --filename build/dex-contracts-$TRAVIS_TAG.tgz
+deploy:
+  provider: s3
+  access_key_id: ""
+  secret_access_key: ""
+  bucket: ""
+  script: bash ci/deploy.sh
+  on:
+    tags: true
+after_deploy:
+  - >
+    curl
+      -X POST
+      -F "token=$GITLAB_TOKEN"
+      -F "ref=master"
+      -F "variables[TAG]=$TRAVIS_TAG"
+      https://gitlab.gnosisdev.com/api/v4/projects/$GITLAB_PROJECT/trigger/pipeline

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ script:
   - solium -d contracts/
   - yarn run coverage && cat ./coverage/lcov.info | coveralls
 before_deploy:
-  - yarn pack --filename build/dex-contracts-$TRAVIS_TAG.tgz
+  - yarn pack --filename build/deploy/dex-contracts-$TRAVIS_TAG.tgz
 deploy:
   provider: s3
   access_key_id: ""
   secret_access_key: ""
   bucket: ""
-  script: bash ci/deploy.sh
+  local_dir: build/deploy
   on:
     tags: true
 after_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ before_deploy:
   - yarn pack --filename deploy/dex-contracts-$TRAVIS_TAG.tgz
 deploy:
   provider: s3
-  access_key_id: ""
-  secret_access_key: ""
-  bucket: ""
+  bucket: $BUCKET_NAME
+  access_key_id: $AWS_ACCESS_KEY_ID
+  secret_access_key: $AWS_SECRET_ACCESS_KEY
   local_dir: deploy
   on:
     tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,6 @@ after_deploy:
   - >
     curl -X POST
     -F "token=$GITLAB_TOKEN"
-    -F "ref=master"
+    -F "ref=v0.1.0"
     -F "variables[PACKAGE_VERSION]=$PACKAGE_VERSION"
     https://gitlab.gnosisdev.com/api/v4/projects/$GITLAB_PROJECT/trigger/pipeline

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,8 @@ deploy:
     tags: true
 after_deploy:
   - >
-    curl
-      -X POST
-      -F "token=$GITLAB_TOKEN"
-      -F "ref=master"
-      -F "variables[TAG]=$TRAVIS_TAG"
-      https://gitlab.gnosisdev.com/api/v4/projects/$GITLAB_PROJECT/trigger/pipeline
+    curl -X POST
+    -F "token=$GITLAB_TOKEN"
+    -F "ref=master"
+    -F "variables[TAG]=$TRAVIS_TAG"
+    https://gitlab.gnosisdev.com/api/v4/projects/$GITLAB_PROJECT/trigger/pipeline

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ script:
   - solium -d contracts/
   - yarn run coverage && cat ./coverage/lcov.info | coveralls
 before_deploy:
-  - mkdir -p deploy
   - export PACKAGE_VERSION=$(jq -r '.version' package.json)
+  - test "v$PACKAGE_VERSION" = "$TRAVIS_TAG"
+  - mkdir -p deploy
   - yarn pack --filename deploy/dex-contracts-$PACKAGE_VERSION.tgz
 deploy:
   provider: s3

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,14 @@ script:
   - solium -d contracts/
   - yarn run coverage && cat ./coverage/lcov.info | coveralls
 before_deploy:
-  - yarn pack --filename build/deploy/dex-contracts-$TRAVIS_TAG.tgz
+  - mkdir -p deploy
+  - yarn pack --filename deploy/dex-contracts-$TRAVIS_TAG.tgz
 deploy:
   provider: s3
   access_key_id: ""
   secret_access_key: ""
   bucket: ""
-  local_dir: build/deploy
+  local_dir: deploy
   on:
     tags: true
 after_deploy:

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "verify-stablex": "truffle run verify BatchExchange",
     "lint": "eslint .",
     "solhint": "solhint \"contracts/**/*.sol\"",
-    "prepack": "yarn run build",
+    "prepack": "yarn run build && mkdir -p build/deploy",
     "prettier:solidity": "prettier --write 'contracts/**/*.sol'",
     "prettier:js": "prettier --write './**/*.js'",
     "pretty-check": "prettier --check 'contracts/**/*.sol' && prettier --check './**/*.js'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.1.3",
+  "version": "0.0.3",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "verify-stablex": "truffle run verify BatchExchange",
     "lint": "eslint .",
     "solhint": "solhint \"contracts/**/*.sol\"",
-    "prepack": "yarn run build && mkdir -p build/deploy",
+    "prepack": "yarn run build",
     "prettier:solidity": "prettier --write 'contracts/**/*.sol'",
     "prettier:js": "prettier --write './**/*.js'",
     "pretty-check": "prettier --check 'contracts/**/*.sol' && prettier --check './**/*.js'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.0.5",
+  "version": "0.1.3",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.0.3",
+  "version": "0.1.3",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "directories": {


### PR DESCRIPTION
This PR is to trigger NPM package deployment from CI. To keep our secret node API token extra safe, we yarn package on Travis and then only push the package on GitLab CI. We use an intermediary Amazon S3 storage to pass the file between to two. How it works:

1. On Travis:
  - Package `@gnosis.pm/dex-contracts` on Travis
  - Upload to Amazon S3 bucket
  - Trigger the GitLab pipeline
2. On GitLab
  - Download the .tgz package
  - Verify the package for no shenanigans 
  - Upload it to npmjs.org

### Test Plan

Release 0.1.4! :tada: 