### PR TITLE
Do not allow orders for unlisted tokens.

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -469,6 +469,8 @@ contract BatchExchange is EpochTokenLocker {
         uint128 buyAmount,
         uint128 sellAmount
     ) private returns (uint16) {
+        require(IdToAddressBiMap.hasId(registeredTokens, buyToken), "Buy token must be listed");
+        require(IdToAddressBiMap.hasId(registeredTokens, sellToken), "Sell token must be listed");
         require(buyToken != sellToken, "Exchange tokens not distinct");
         require(validFrom >= getCurrentBatchId(), "Orders can't be placed in the past");
         orders[msg.sender].push(

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -149,6 +149,18 @@ contract("BatchExchange", async accounts => {
         "Exchange tokens not distinct"
       )
     })
+    it("rejects orders for unlisted tokens", async () => {
+      const batchExchange = await setupGenericStableX()
+      const currentBatch = (await batchExchange.getCurrentBatchId()).toNumber()
+      await truffleAssert.reverts(
+        batchExchange.placeOrder(2, 0, currentBatch + 1, 1, 1),
+        "Buy token must be listed"
+      )
+      await truffleAssert.reverts(
+        batchExchange.placeOrder(0, 2, currentBatch + 1, 1, 1),
+        "Sell token must be listed"
+      )
+    })
     it("places order and verifys contract storage is updated correctly", async () => {
       const batchExchange = await setupGenericStableX()
 

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -152,14 +152,8 @@ contract("BatchExchange", async accounts => {
     it("rejects orders for unlisted tokens", async () => {
       const batchExchange = await setupGenericStableX()
       const currentBatch = (await batchExchange.getCurrentBatchId()).toNumber()
-      await truffleAssert.reverts(
-        batchExchange.placeOrder(2, 0, currentBatch + 1, 1, 1),
-        "Buy token must be listed"
-      )
-      await truffleAssert.reverts(
-        batchExchange.placeOrder(0, 2, currentBatch + 1, 1, 1),
-        "Sell token must be listed"
-      )
+      await truffleAssert.reverts(batchExchange.placeOrder(2, 0, currentBatch + 1, 1, 1), "Buy token must be listed")
+      await truffleAssert.reverts(batchExchange.placeOrder(0, 2, currentBatch + 1, 1, 1), "Sell token must be listed")
     })
     it("places order and verifys contract storage is updated correctly", async () => {
       const batchExchange = await setupGenericStableX()

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -267,16 +267,16 @@ contract("BatchExchange", async accounts => {
   })
   describe("replaceOrders()", () => {
     it("cancels and creates new orders", async () => {
-      const batchExchange = await setupGenericStableX()
+      const batchExchange = await setupGenericStableX(8)
 
       await batchExchange.placeOrder(0, 1, 3, 10, 20, { from: user_1 })
-      const order2 = await sendTxAndGetReturnValue(batchExchange.placeOrder, 2, 4, 5, 30, 40, { from: user_1 })
+      const order2 = await sendTxAndGetReturnValue(batchExchange.placeOrder, 2, 3, 5, 30, 40, { from: user_1 })
 
       const currentStateIndex = (await batchExchange.getCurrentBatchId()).toNumber()
       await batchExchange.replaceOrders(
         [order2],
-        [5, 6],
-        [7, 8],
+        [4, 5],
+        [6, 7],
         [currentStateIndex, currentStateIndex],
         [11, 12],
         [13, 14],
@@ -285,8 +285,8 @@ contract("BatchExchange", async accounts => {
 
       assert.equal((await batchExchange.orders(user_1, 0)).sellToken, 1, "First order should be present")
       assert.equal((await batchExchange.orders(user_1, 1)).sellToken, 0, "Second order should be removed")
-      assert.equal((await batchExchange.orders(user_1, 2)).sellToken, 7, "Third order should be present")
-      assert.equal((await batchExchange.orders(user_1, 3)).sellToken, 8, "Fourth order should be present")
+      assert.equal((await batchExchange.orders(user_1, 2)).sellToken, 6, "Third order should be present")
+      assert.equal((await batchExchange.orders(user_1, 3)).sellToken, 7, "Fourth order should be present")
     })
   })
   describe("submitSolution()", () => {


### PR DESCRIPTION
Changes are minimal (two require statements) to prevent orders being placed buying or selling unlisted tokens. There was mention in the related issues that we should include a regression test for the public view `getEncodedUserOrders`, but I still don't see the purpose. Waiting on @fleupold  to elaborate.

Closes #462





**Test plan:** Unit tests