### PR TITLE
Typo - forgot to destructure import of url string

### DIFF
--- a/scripts/stablex/place_spread_orders.js
+++ b/scripts/stablex/place_spread_orders.js
@@ -4,7 +4,7 @@ const BN = require("bn.js")
 const readline = require("readline")
 
 const { sendTxAndGetReturnValue } = require("../../test/utilities.js")
-const token_list_url = require("./utilities.js")
+const { token_list_url } = require("./utilities.js")
 
 const rl = readline.createInterface({
   input: process.stdin,


### PR DESCRIPTION
place_spread_orders script was unusable because of the invalid import of `token_list_url`