### PR TITLE
Emit event on SolutionSubmission

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,7 +1,7 @@
 const truffleConfig = require("@gnosis.pm/util-contracts/src/util/truffleConfig")
 
 const DEFAULT_GAS_PRICE_GWEI = 25
-const DEFAULT_GAS_LIMIT = 6721975
+const DEFAULT_GAS_LIMIT = 8e6
 const DEFAULT_MNEMONIC = "candy maple cake sugar pudding cream honey rich smooth crumble sweet treat"
 
 // Load env vars


### PR DESCRIPTION
Worst case gas cost: 20k

This will allow us to track information such as prices, different ingredients of the total objective value and fees burnt.

### Test Plan

Benchmarked impact on the worst case ring trade example. 

It turns out we need to provide >6.8M gas although we in the end only end up using 5.2M. This is because the gas refund for releasing storage is only granted at the end of the transaction and the provided gas needs to be large enough to be non-negative at all times throughout the tx.