### PR TITLE
Gas optimisation in updateupdateDepositsBalance

### DIFF
--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -214,6 +214,7 @@ contract EpochTokenLocker {
     function updateDepositsBalance(address user, address token) private {
         uint256 batchId = balanceStates[user][token].pendingDeposits.batchId;
         if (batchId > 0 && batchId < getCurrentBatchId()) {
+            // batchId > 0 is checked in order save an SSTORE in case there is no pending deposit
             balanceStates[user][token].balance = balanceStates[user][token].balance.add(
                 balanceStates[user][token].pendingDeposits.amount
             );

--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -212,7 +212,8 @@ contract EpochTokenLocker {
     }
 
     function updateDepositsBalance(address user, address token) private {
-        if (balanceStates[user][token].pendingDeposits.batchId < getCurrentBatchId()) {
+        uint256 batchId = balanceStates[user][token].pendingDeposits.batchId;
+        if (batchId > 0 && batchId < getCurrentBatchId()) {
             balanceStates[user][token].balance = balanceStates[user][token].balance.add(
                 balanceStates[user][token].pendingDeposits.amount
             );


### PR DESCRIPTION
HUGE gas optimization:

If I am running Ben's advanced "Large Examples" test-case without this optimization, it consumes 4264249  gas for the first submission and 5209727 gas for the second one.

With this gas optimization, we get:
3569261 gas for the first submission and 3846841 gas for the second one.

---
testplan: unit tests