### PR TITLE
fixes PR [Audit] Consume claimable withdraw

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -348,7 +348,7 @@ contract BatchExchange is EpochTokenLocker {
         for (uint256 i = 0; i < owners.length; i++) {
             Order memory order = orders[owners[i]][orderIds[i]];
             (, uint128 executedSellAmount) = getTradedAmounts(buyVolumes[i], order);
-            subtractBalance(owners[i], tokenIdToAddressMap(order.sellToken), executedSellAmount);
+            subtractBalanceWithPendingWithdrawCheck(owners[i], tokenIdToAddressMap(order.sellToken), executedSellAmount);
         }
         uint256 disregardedUtility = 0;
         for (uint256 i = 0; i < owners.length; i++) {

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -348,7 +348,7 @@ contract BatchExchange is EpochTokenLocker {
         for (uint256 i = 0; i < owners.length; i++) {
             Order memory order = orders[owners[i]][orderIds[i]];
             (, uint128 executedSellAmount) = getTradedAmounts(buyVolumes[i], order);
-            subtractBalanceWithPendingWithdrawCheck(owners[i], tokenIdToAddressMap(order.sellToken), executedSellAmount);
+            subtractBalance(owners[i], tokenIdToAddressMap(order.sellToken), executedSellAmount);
         }
         uint256 disregardedUtility = 0;
         for (uint256 i = 0; i < owners.length; i++) {
@@ -654,11 +654,11 @@ contract BatchExchange is EpochTokenLocker {
                 Order memory order = orders[owner][orderId];
                 (uint128 buyAmount, uint128 sellAmount) = getTradedAmounts(latestSolution.trades[i].volume, order);
                 revertRemainingOrder(owner, orderId, sellAmount);
-                subtractBalance(owner, tokenIdToAddressMap(order.buyToken), buyAmount);
+                subtractBalanceUnchecked(owner, tokenIdToAddressMap(order.buyToken), buyAmount);
                 emit TradeReversion(owner, orderId, sellAmount, buyAmount);
             }
             // subtract granted fees:
-            subtractBalance(latestSolution.solutionSubmitter, tokenIdToAddressMap(0), latestSolution.feeReward);
+            subtractBalanceUnchecked(latestSolution.solutionSubmitter, tokenIdToAddressMap(0), latestSolution.feeReward);
         }
     }
 

--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -207,7 +207,7 @@ contract EpochTokenLocker {
 
     /**
      * The following function should be used to substract amounts from the current balances state.
-     * For the substraction, the current withdrawRequests are considered and effectively they are reducing
+     * For the substraction the current withdrawRequests are considered and they are effectively reducing
      * the available balance.
      */
     function subtractBalance(address user, address token, uint256 amount) internal {
@@ -217,16 +217,16 @@ contract EpochTokenLocker {
 
     /**
      * The following function should be used to substract amounts from the current balance
-     * state, if the pending withdrawRequests are not considered and do not effectively reduce
+     * state, if the pending withdrawRequests are not considered and should not effectively reduce
      * the available balance.
      * For example, the reversion of trades from a previous batch-solution do not
-     * need to consider pendingWithdraws. This is the case, as withdraws are blocked for accounts
-     * which got funds credited from a previous submission in the same batch.
-     * PendingWithdraws even must not be considered as otherwise, a solution reversion could be blocked:
-     * A bigger withdrawRequest could set the return value of
+     * need to consider withdrawRequests. This is the case as withdraws are blocked for one
+     * batch for accounts, which got funds credited in a previous submission.
+     * PendingWithdraws even must not be considered, as otherwise, a solution reversion could
+     * be blocked: A bigger withdrawRequest could set the return value of
      * getBalance(user, token) to zero, although the user just got tokens credited in
-     * the last submission. Hence, the check `amount <= getBalance(user, token)` would fail and the reversion
-     * would be blocked.
+     * the last submission. In this situation, during the unwinding of the previous orders,
+     * the check `amount <= getBalance(user, token)` would fail and the reversion would be blocked.
      */
     function subtractBalanceUnchecked(address user, address token, uint256 amount) internal {
         updateDepositsBalance(user, token);

--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -206,7 +206,7 @@ contract EpochTokenLocker {
     }
 
     /**
-     * The following function should be used to substract amounts from the current balances state.
+     * The following function should be used to subtract amounts from the current balances state.
      * For the substraction the current withdrawRequests are considered and they are effectively reducing
      * the available balance.
      */
@@ -221,10 +221,10 @@ contract EpochTokenLocker {
      * the available balance.
      * For example, the reversion of trades from a previous batch-solution do not
      * need to consider withdrawRequests. This is the case as withdraws are blocked for one
-     * batch for accounts, which got funds credited in a previous submission.
-     * PendingWithdraws even must not be considered, as otherwise, a solution reversion could
-     * be blocked: A bigger withdrawRequest could set the return value of
-     * getBalance(user, token) to zero, although the user just got tokens credited in
+     * batch for accounts having credited funds in a previous submission.
+     * PendingWithdraws must also be ignored since otherwise for the reversion of trades,
+     * a solution reversion could be blocked: A bigger withdrawRequest could set the return value of
+     * getBalance(user, token) to zero, although the user was just credited tokens in
      * the last submission. In this situation, during the unwinding of the previous orders,
      * the check `amount <= getBalance(user, token)` would fail and the reversion would be blocked.
      */

--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -205,8 +205,12 @@ contract EpochTokenLocker {
         balanceStates[user][token].balance = balanceStates[user][token].balance.add(amount);
     }
 
-    function subtractBalance(address user, address token, uint256 amount) internal {
+    function subtractBalanceWithPendingWithdrawCheck(address user, address token, uint256 amount) internal {
         require(amount <= getBalance(user, token), "Amount exceeds user's balance.");
+        subtractBalance(user, token, amount);
+    }
+
+    function subtractBalance(address user, address token, uint256 amount) internal {
         updateDepositsBalance(user, token);
         balanceStates[user][token].balance = balanceStates[user][token].balance.sub(amount);
     }

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -1303,7 +1303,6 @@ contract("BatchExchange", async accounts => {
     })
     it("ensures that a solution reversion can not be prevented by additional withdrawRequests", async () => {
       const batchExchange = await setupGenericStableX()
-      const feeToken = await batchExchange.tokenIdToAddressMap.call(0)
 
       await makeDeposits(batchExchange, accounts, basicTrade.deposits)
 
@@ -1331,12 +1330,6 @@ contract("BatchExchange", async accounts => {
         { from: solver }
       )
 
-      assert.equal(
-        basicTrade.solutions[1].burntFees.toString(),
-        await batchExchange.getBalance.call(solver, feeToken),
-        "fees weren't allocated as expected correctly"
-      )
-
       const fullSolution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
       await batchExchange.submitSolution(
         batchId,
@@ -1348,8 +1341,6 @@ contract("BatchExchange", async accounts => {
         fullSolution.tokenIdsForPrice,
         { from: competingSolver }
       )
-
-      assert.equal(0, await batchExchange.getBalance.call(solver, feeToken), "First submitter's reward was not reverted")
     })
     it("ensures credited tokens can't be withdrawn in same batch as solution submission", async () => {
       const batchExchange = await setupGenericStableX()


### PR DESCRIPTION
The PR: https://github.com/gnosis/dex-contracts/pull/451/files fixed that we were not considering current currentBalances correctly while assessing the correctness of a solution.

Unfortunately, the fix introduced another bug. Now, one can block reversions of previously submitted solutions by requesting withdraws for the bought tokens. Effectively, the withdrawRequests would reduce the available balance for my bought tokens, such that the `substractBalance` during the undoing of the solution would fail in the following assertion:
`        require(amount <= getBalance(user, token), "Amount exceeds user's balance.");
`

This PR fixes this and ensures that previously submitted solutions can be undone.

---
testplan: unit tests
