### PR TITLE
Don't pop from accounts list

### DIFF
--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -39,9 +39,7 @@ const smallTradeData = {
 }
 
 contract("BatchExchange", async accounts => {
-  const solver = accounts.pop()
-  const competingSolver = accounts.pop()
-  const [user_1, user_2, user_3] = accounts
+  const [user_1, user_2, user_3, solver, competingSolver] = accounts
   const zero_address = "0x0000000000000000000000000000000000000000"
 
   let BATCH_TIME

--- a/test/stablex/regression_tests.js
+++ b/test/stablex/regression_tests.js
@@ -12,7 +12,7 @@ const { solutionSubmissionParams, basicTrade, utilityOverflow } = require("../re
 const { makeDeposits, placeOrders, setupGenericStableX } = require("./stablex_utils")
 
 contract("BatchExchange", async accounts => {
-  const solver = accounts.pop()
+  const solver = accounts[0]
 
   before(async () => {
     const feeToken = await MockContract.new()


### PR DESCRIPTION
Closes #487

Tests fail exclusively on advancedTrade which uses 5 different users. It looks like `from` is undefined in the failure cases. The from is taken from the global account list that is passed into the test suite. It turns out that we were popping and thus mutating that list in multiple places, which might cause this behaviour.

This PR replaces the mutating pop with a read and should just no longer drain the accounts array to a point where not enough accounts are left.