### PR TITLE
[Fix] non-development migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.1.4",
+  "version": "0.1.3",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.1.5-dev",
+  "version": "0.1.4",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "directories": {

--- a/src/migration/utilities.js
+++ b/src/migration/utilities.js
@@ -14,18 +14,13 @@ function initializeContract(path, deployer, accounts) {
 
 function getDependency(artifacts, network, deployer, account, path) {
   let contract
-
-  if (isDevelopmentNetwork(network)) {
-    // If this migration script is used from the repository dex-contracts, the contract
-    // data is received via the artificats.require.
-    // If this migration script is used from an external project, the first try statement
-    // will fail and it will get the contracts from the function initializeContract.
-    try {
-      contract = artifacts.require(path.split("/").pop())
-    } catch (error) {
-      contract = initializeContract(path, deployer, account)
-    }
-  } else {
+  // If this migration script is used from the repository dex-contracts, the contract
+  // data is received via the artificats.require.
+  // If this migration script is used from an external project, the first try statement
+  // will fail and it will get the contracts from the function initializeContract.
+  try {
+    contract = artifacts.require(path.split("/").pop())
+  } catch (error) {
     contract = initializeContract(path, deployer, account)
   }
   return contract


### PR DESCRIPTION
In the last PR: https://github.com/gnosis/dex-contracts/pull/489
a bug was introduced as the for nonDevelopment networks, also the BatchExchange as a dependency would be tried to be pulled, although we have to get it from the usual build artifacts.
