### PR TITLE
[Easy] Revert version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.1.5-dev",
+  "version": "0.1.3",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "directories": {


### PR DESCRIPTION
#489 introduced that change

Version bumps should always happen in their own PR (and once that PR is merged to master, it should be tagged with the version). Moreover this skipped v0.1.4 and was likely just merged to master by accident.