### PR TITLE
Bump to v0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "directories": {


### PR DESCRIPTION
Publishing v0.1.4 failed because it was previously deployed and yanked, so bump again and publish again!