### PR TITLE
[Easy] Remove flatMap from script parsing

### DIFF
--- a/scripts/stablex/cancel_order.js
+++ b/scripts/stablex/cancel_order.js
@@ -4,15 +4,10 @@ const argv = require("yargs")
     describe: "Account index of the order placer",
   })
   .option("orderIds", {
-    type: "array",
+    type: "string",
     describe: "Order IDs to be canceled",
-    coerce: array => {
-      try {
-        return array[0].split(",").map(o => parseInt(o))
-      } catch (TypeError) {
-        console.log(`Detected individual order cancelation ${array[0]}`)
-        return array
-      }
+    coerce: str => {
+      return str.split(",").map(o => parseInt(o))
     },
   })
   .demand(["accountId", "orderIds"])

--- a/scripts/stablex/cancel_order.js
+++ b/scripts/stablex/cancel_order.js
@@ -8,7 +8,7 @@ const argv = require("yargs")
     describe: "Order IDs to be canceled",
     coerce: array => {
       try {
-        return array.flatMap(v => v.split(",").map(o => parseInt(o)))
+        return array[0].split(",").map(o => parseInt(o))
       } catch (TypeError) {
         console.log(`Detected individual order cancelation ${array[0]}`)
         return array

--- a/scripts/stablex/place_spread_orders.js
+++ b/scripts/stablex/place_spread_orders.js
@@ -35,7 +35,7 @@ const argv = require("yargs")
     type: "array",
     describe: "Collection of trusted tokenIds",
     coerce: array => {
-      return array.flatMap(v => v.split(",").map(t => parseInt(t)))
+      return array[0].split(",").map(t => parseInt(t))
     },
   })
   .option("accountId", {

--- a/scripts/stablex/place_spread_orders.js
+++ b/scripts/stablex/place_spread_orders.js
@@ -32,10 +32,10 @@ const formatAmount = function(amount, token) {
 const argv = require("yargs")
   .option("tokens", {
     alias: "t",
-    type: "array",
+    type: "string",
     describe: "Collection of trusted tokenIds",
-    coerce: array => {
-      return array[0].split(",").map(t => parseInt(t))
+    coerce: str => {
+      return str.split(",").map(t => parseInt(t))
     },
   })
   .option("accountId", {


### PR DESCRIPTION
The previous place_spread_orders and cancel_orders scripts were parsing `[ 'i,j,k' ]` with flatMap which was not necessary and only worked on node v13. This update addresses that and closes #514. 


Test Plan:

```sh
 export PK=ac20fd13d9a7f9325262ce81c07b16b1c3f92be56da33789b831a8f6eaef9ef0 
npx truffle exec scripts/stablex/place_spread_orders.js --tokens=2,3,4,5,6 --accountId 0 --network rinkeby
```

Should result in 

```
> Warning: possible unsupported (undocumented in help) command line option: --tokens,--accountId
Using network 'rinkeby'.

Recovering token data from URL https://raw.githubusercontent.com/gnosis/dex-js/master/src/tokenList.json
Sell 1000000000000000000000 TUSD for 1002500000 USDT
Sell 1000000000 USDT for 1002499999999966445568 TUSD
Sell 1000000000 USDC for 1002500000 USDT
Sell 1000000000 USDT for 1002500000 USDC
Sell 1000000000000000000000 PAX for 1002500000 USDT
Sell 1000000000 USDT for 1002499999999966445568 PAX
Sell 100000 GUSD for 1002500000 USDT
Sell 1000000000 USDT for 100250 GUSD
Sell 1000000000 USDC for 1002499999999966445568 TUSD
Sell 1000000000000000000000 TUSD for 1002500000 USDC
Sell 1000000000000000000000 PAX for 1002499999999966445568 TUSD
Sell 1000000000000000000000 TUSD for 1002499999999966445568 PAX
Sell 100000 GUSD for 1002499999999966445568 TUSD
Sell 1000000000000000000000 TUSD for 100250 GUSD
Sell 1000000000000000000000 PAX for 1002500000 USDC
Sell 1000000000 USDC for 1002499999999966445568 PAX
Sell 100000 GUSD for 1002500000 USDC
Sell 1000000000 USDC for 100250 GUSD
Sell 100000 GUSD for 1002499999999966445568 PAX
Sell 1000000000000000000000 PAX for 100250 GUSD
Are you sure you want to send this transaction to the EVM? [yN] N
```
