### PR TITLE
[Easy] EVM Token Info

### DIFF
--- a/contracts/DevDependencies.sol
+++ b/contracts/DevDependencies.sol
@@ -5,6 +5,7 @@ pragma solidity ^0.5.0;
 //  contracts during development.
 //
 //  For other environments, only use compiled contracts from the NPM package.
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";
 import "solidity-multicall/contracts/MultiCaller.sol";
 import "@gnosis.pm/owl-token/contracts/TokenOWLProxy.sol";

--- a/scripts/stablex/cancel_order.js
+++ b/scripts/stablex/cancel_order.js
@@ -4,15 +4,10 @@ const argv = require("yargs")
     describe: "Account index of the order placer",
   })
   .option("orderIds", {
-    type: "array",
+    type: "string",
     describe: "Order IDs to be canceled",
-    coerce: array => {
-      try {
-        return array[0].split(",").map(o => parseInt(o))
-      } catch (TypeError) {
-        console.log(`Detected individual order cancelation ${array[0]}`)
-        return array
-      }
+    coerce: str => {
+      return str.split(",").map(o => parseInt(o))
     },
   })
   .demand(["accountId", "orderIds"])

--- a/scripts/stablex/cancel_order.js
+++ b/scripts/stablex/cancel_order.js
@@ -8,7 +8,7 @@ const argv = require("yargs")
     describe: "Order IDs to be canceled",
     coerce: array => {
       try {
-        return array.flatMap(v => v.split(",").map(o => parseInt(o)))
+        return array[0].split(",").map(o => parseInt(o))
       } catch (TypeError) {
         console.log(`Detected individual order cancelation ${array[0]}`)
         return array

--- a/scripts/stablex/place_spread_orders.js
+++ b/scripts/stablex/place_spread_orders.js
@@ -35,7 +35,7 @@ const argv = require("yargs")
     type: "array",
     describe: "Collection of trusted tokenIds",
     coerce: array => {
-      return array.flatMap(v => v.split(",").map(t => parseInt(t)))
+      return array[0].split(",").map(t => parseInt(t))
     },
   })
   .option("accountId", {

--- a/scripts/stablex/place_spread_orders.js
+++ b/scripts/stablex/place_spread_orders.js
@@ -32,10 +32,10 @@ const formatAmount = function(amount, token) {
 const argv = require("yargs")
   .option("tokens", {
     alias: "t",
-    type: "array",
+    type: "string",
     describe: "Collection of trusted tokenIds",
-    coerce: array => {
-      return array[0].split(",").map(t => parseInt(t))
+    coerce: str => {
+      return str.split(",").map(t => parseInt(t))
     },
   })
   .option("accountId", {


### PR DESCRIPTION
The curated token list frmo `dex-js` does not share the same "IDs" for tokens as they are on the Batch Exchange contract. Rather, the ids are meant for the frontend for the display order of the token listing in the drop down menu. 

In order to be much safer, this script now fetches relevant token info (like number of decimals) directly from the EVM (based on the Exchange contract and the tokens themselves).

Note that #531 should be merged first.

**Test Plan**

```
 export PK=ac20fd13d9a7f9325262ce81c07b16b1c3f92be56da33789b831a8f6eaef9ef0 
npx truffle exec scripts/stablex/place_spread_orders.js --tokens=2,3,6 --accountId 0 --network rinkeby
```

Expect to see the following log messages in the console:

```
Using network 'rinkeby'.

Fetching token data from EVM
Found Token USDT at ID 2 with 6 decimals
Found Token TUSD at ID 3 with 18 decimals
Found Token GUSD at ID 6 with 2 decimals
Sell 1000000000000000000000 TUSD for 1002500000 USDT
Sell 1000000000 USDT for 1002499999999966445568 TUSD
Sell 100000 GUSD for 1002500000 USDT
Sell 1000000000 USDT for 100250 GUSD
Sell 100000 GUSD for 1002499999999966445568 TUSD
Sell 1000000000000000000000 TUSD for 100250 GUSD
Are you sure you want to send this transaction to the EVM? [yN] 
```