### PR TITLE
[Very Easy] Don't need empty contract declaration!

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -8,7 +8,6 @@
     "not-rely-on-time": "error",
     "compiler-fixed": true,
     "no-simple-event-func-name": true,
-    "no-empty-blocks": "off",
     "two-lines-top-level-separator": "off",
     "separate-by-one-line-in-contract": "warn",
     "bracket-align": "warn"

--- a/contracts/DevDependencies.sol
+++ b/contracts/DevDependencies.sol
@@ -8,6 +8,3 @@ pragma solidity ^0.5.0;
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";
 import "solidity-multicall/contracts/MultiCaller.sol";
 import "@gnosis.pm/owl-token/contracts/TokenOWLProxy.sol";
-
-
-contract DevDependencies {}


### PR DESCRIPTION
Just discovered that this DevDependencies contract doesn't need to have an empty block