### PR TITLE
[BatchExchangeViewer] allow to fetch balances

### DIFF
--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -25,7 +25,7 @@ contract BatchExchangeViewer {
         uint256 withdrawableBalance; // Amount that can be withdrawn in the requested auction
     }
 
-    /** @dev Returns the user's token balances for the auction that is currently being settled
+    /** @dev Returns the user's token balances for the auction that is currently being solved
      */
     function getBalances(address user) public view returns (Balance[] memory) {
         uint32 currentBatch = batchExchange.getCurrentBatchId();


### PR DESCRIPTION
This PR adds a method to get all balances of tokens listed in the exchange for a given user (this excludes pathological tokens which the user deposited without listing them).

It uses the experimental ABI encoder which allows nicely structured return values (instead of returning bytes or implicitly aligned arrays).

Unfortunately we cannot give accurate estimates of how much of a token is actually withdrawable (we have to take the requested amount which could be infinitely high cf. #539)

### Test Plan

unit test + deploying this on rinkeby and running:

```js
await instance.getBalances("0x42b7e89374BcEAb213c699488f667c7a9144C28b")
```