### PR TITLE
[Easy] Bump version to v0.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "directories": {


### PR DESCRIPTION
This bumps contract version to v0.2.2. From what I understand we want to used released version with `dex-services` and the recent change #532 has the nice side effect of including `ERC20Detailed` contract in the build output which the price estimation wants to use.