### PR TITLE
[Bug] getEncodedOrders -> getEncodedUserOrders in appropriate test

### DIFF
--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -1785,7 +1785,7 @@ contract("BatchExchange", async accounts => {
   describe("getEncodedUserOrders()", async () => {
     it("returns null when there are no orders", async () => {
       const batchExchange = await setupGenericStableX()
-      const auctionElements = await batchExchange.getEncodedOrders()
+      const auctionElements = await batchExchange.getEncodedUserOrders(accounts[0])
       assert.equal(auctionElements, null)
     })
     it("returns correct orders whether valid, cancelled or freed", async () => {
@@ -1843,7 +1843,7 @@ contract("BatchExchange", async accounts => {
       await waitForNSeconds(BATCH_TIME)
       await batchExchange.cancelOrders([0])
 
-      const auctionElements = decodeAuctionElements(await batchExchange.getEncodedOrders())
+      const auctionElements = decodeAuctionElements(await batchExchange.getEncodedUserOrders(user_1))
       assert.equal(JSON.stringify(auctionElements), JSON.stringify([cancelledOrderInfo, freedOrderInfo, validOrderInfo]))
     })
   })


### PR DESCRIPTION
The `getEncodedUserOrders` was not being used in its own test.