### PR TITLE
[Easy] Move and rename utility function

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -394,7 +394,6 @@ contract BatchExchange is EpochTokenLocker {
     /**
      * Public View Methods
      */
-
     /** @dev View returning ID of listed tokens
       * @param addr address of listed token.
       * @return tokenId as stored within the contract.
@@ -542,7 +541,6 @@ contract BatchExchange is EpochTokenLocker {
     /**
      * Private Functions
      */
-
     function placeOrderInternal(
         uint16 buyToken,
         uint16 sellToken,

--- a/contracts/EpochTokenLocker.sol
+++ b/contracts/EpochTokenLocker.sol
@@ -120,7 +120,6 @@ contract EpochTokenLocker {
     /**
      * Public view functions
      */
-
     /** @dev getter function used to display pending deposit
       * @param user address of user
       * @param token address of ERC20 token

--- a/scripts/stablex/get_auction_elements.js
+++ b/scripts/stablex/get_auction_elements.js
@@ -14,7 +14,7 @@ const argv = require("yargs")
   })
   .version(false).argv
 
-const { decodeAuctionElements } = require("../../test/utilities.js")
+const { decodeOrdersBN } = require("../../src/encoding")
 
 const COLORS = {
   NONE: "\x1b[0m",
@@ -86,7 +86,7 @@ module.exports = async callback => {
   try {
     const instance = await BatchExchange.deployed()
     const auctionElementsEncoded = await instance.getEncodedOrders.call()
-    let auctionElementsDecoded = decodeAuctionElements(auctionElementsEncoded)
+    let auctionElementsDecoded = decodeOrdersBN(auctionElementsEncoded)
 
     const batchId = (await instance.getCurrentBatchId()).toNumber()
     if (!argv.expired) {

--- a/src/encoding.js
+++ b/src/encoding.js
@@ -43,6 +43,21 @@ function decodeOrders(bytes) {
   return result
 }
 
+function decodeOrdersBN(bytes) {
+  return decodeOrders(bytes).map(e => ({
+    user: e.user,
+    sellTokenBalance: new BN(e.sellTokenBalance),
+    buyToken: parseInt(e.buyToken),
+    sellToken: parseInt(e.sellToken),
+    validFrom: parseInt(e.validFrom),
+    validUntil: parseInt(e.validUntil),
+    priceNumerator: new BN(e.priceNumerator),
+    priceDenominator: new BN(e.priceDenominator),
+    remainingAmount: new BN(e.remainingAmount),
+  }))
+}
+
 module.exports = {
   decodeOrders,
+  decodeOrdersBN,
 }

--- a/test/stablex/batch_exchange.js
+++ b/test/stablex/batch_exchange.js
@@ -1844,7 +1844,7 @@ contract("BatchExchange", async accounts => {
       await waitForNSeconds(BATCH_TIME)
       await batchExchange.cancelOrders([0])
 
-      const auctionElements = decodeOrdersBN(await batchExchange.getEncodedOrders(user_1))
+      const auctionElements = decodeOrdersBN(await batchExchange.getEncodedUserOrders(user_1))
       assert.equal(JSON.stringify(auctionElements), JSON.stringify([cancelledOrderInfo, freedOrderInfo, validOrderInfo]))
     })
   })

--- a/test/stablex/batch_exchange_viewer.js
+++ b/test/stablex/batch_exchange_viewer.js
@@ -2,7 +2,7 @@ const BatchExchange = artifacts.require("BatchExchange")
 const BatchExchangeViewer = artifacts.require("BatchExchangeViewer")
 const MockContract = artifacts.require("MockContract")
 
-const { decodeAuctionElements } = require("../utilities")
+const { decodeOrdersBN } = require("../../src/encoding")
 const { closeAuction } = require("../../scripts/stablex/utilities.js")
 
 const zero_address = "0x0000000000000000000000000000000000000000"
@@ -41,7 +41,7 @@ contract("BatchExchangeViewer", accounts => {
       )
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
-      const result = decodeAuctionElements(await viewer.getOpenOrderBook())
+      const result = decodeOrdersBN(await viewer.getOpenOrderBook())
       assert.equal(result.filter(e => e.validFrom == batchId).length, 10)
     })
     it("can be queried with pagination", async () => {
@@ -65,7 +65,7 @@ contract("BatchExchangeViewer", accounts => {
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
       const result = await viewer.getOpenOrderBookPaginated(zero_address, 0, 5)
-      assert.equal(decodeAuctionElements(result.elements).filter(e => e.validFrom == batchId).length, 5)
+      assert.equal(decodeOrdersBN(result.elements).filter(e => e.validFrom == batchId).length, 5)
       assert.equal(result.nextPageUser, accounts[0])
       assert.equal(result.nextPageUserOffset, 15)
     })
@@ -95,7 +95,7 @@ contract("BatchExchangeViewer", accounts => {
       await closeAuction(batchExchange)
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
-      const result = decodeAuctionElements(await viewer.getFinalizedOrderBook())
+      const result = decodeOrdersBN(await viewer.getFinalizedOrderBook())
       assert.equal(result.filter(e => e.validFrom == batchId).length, 10)
     })
     it("can be queried with pagination", async () => {
@@ -122,7 +122,7 @@ contract("BatchExchangeViewer", accounts => {
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
       const result = await viewer.getFinalizedOrderBookPaginated(zero_address, 0, 5)
-      assert.equal(decodeAuctionElements(result.elements).filter(e => e.validFrom == batchId).length, 5)
+      assert.equal(decodeOrdersBN(result.elements).filter(e => e.validFrom == batchId).length, 5)
       assert.equal(result.nextPageUser, accounts[0])
       assert.equal(result.nextPageUserOffset, 15)
     })

--- a/test/stablex/batch_exchange_viewer.js
+++ b/test/stablex/batch_exchange_viewer.js
@@ -88,7 +88,7 @@ contract("BatchExchangeViewer", accounts => {
         Array(5).fill(0) //sellAmounts
       )
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
-      const result = decodeAuctionElements(await viewer.getOpenOrderBook([token_1.address, token_2.address]))
+      const result = decodeOrdersBN(await viewer.getOpenOrderBook([token_1.address, token_2.address]))
       assert.equal(result.filter(e => e.validFrom == batchId).length, 5)
     })
   })
@@ -171,7 +171,7 @@ contract("BatchExchangeViewer", accounts => {
       await closeAuction(batchExchange)
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
-      const result = decodeAuctionElements(await viewer.getFinalizedOrderBook([token_1.address, token_2.address]))
+      const result = decodeOrdersBN(await viewer.getFinalizedOrderBook([token_1.address, token_2.address]))
       assert.equal(result.filter(e => e.validFrom == batchId).length, 5)
     })
   })

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -1,9 +1,6 @@
 const { sha256 } = require("ethereumjs-util")
 const memoize = require("fast-memoize")
 const { MerkleTree } = require("merkletreejs")
-const BN = require("bn.js")
-
-const { decodeOrders } = require("../src/encoding")
 
 /**
  * funds accounts with specified value for Mintable Token
@@ -174,20 +171,6 @@ function partitionArray(input, spacing) {
   return output
 }
 
-function decodeAuctionElements(bytes) {
-  return decodeOrders(bytes).map(e => ({
-    user: e.user,
-    sellTokenBalance: new BN(e.sellTokenBalance),
-    buyToken: parseInt(e.buyToken),
-    sellToken: parseInt(e.sellToken),
-    validFrom: parseInt(e.validFrom),
-    validUntil: parseInt(e.validUntil),
-    priceNumerator: new BN(e.priceNumerator),
-    priceDenominator: new BN(e.priceDenominator),
-    remainingAmount: new BN(e.remainingAmount),
-  }))
-}
-
 module.exports = {
   waitForNSeconds,
   fundAccounts,
@@ -201,5 +184,4 @@ module.exports = {
   partitionArray,
   setupMultiCaller,
   sendTxAndGetReturnValue,
-  decodeAuctionElements,
 }


### PR DESCRIPTION
 `decodeAuctionElements` was in test utilities, but would be nice to expose for integration projects (like `dex-liquidity-provision`) to `decodeOrdersBN` which has the exact same functionality and can still be used for testing. 

Perhaps we would like to reevaluate what other helper methods should/could be exposed here.