### PR TITLE
[BatchExchangeViewer] fix subtle overflow bug

### DIFF
--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -110,7 +110,8 @@ contract BatchExchangeViewer {
             bytes memory unfiltered = batchExchange.getEncodedUsersPaginated(nextPageUser, nextPageUserOffset, pageSize);
             hasNextPage = unfiltered.length / AUCTION_ELEMENT_WIDTH == pageSize;
             for (uint16 index = 0; index < unfiltered.length / AUCTION_ELEMENT_WIDTH; index++) {
-                bytes memory element = unfiltered.slice(index * AUCTION_ELEMENT_WIDTH, AUCTION_ELEMENT_WIDTH);
+                // make sure we don't overflow index * AUCTION_ELEMENT_WIDTH
+                bytes memory element = unfiltered.slice(uint256(index) * AUCTION_ELEMENT_WIDTH, AUCTION_ELEMENT_WIDTH);
                 if (
                     maxValidFrom >= getValidFrom(element) &&
                     minValidUntil <= getValidUntil(element) &&


### PR DESCRIPTION
Closes #555

There was a very subtle overflow bug where since `index` is a u16 & `AUCTION_ELEMENT_WIDTH` is a u8 we overflow as soon as we have more than 585 orders (2^16 / 112).

This PR fixes this by casting index into a u256 before multiplying

### Test Plan

Make sure to migrate the fixed version of the Viewer contracts on this branch.

```
git checkout issueExampleBatchViewer
git rebase fix_viewer
rm -r build
npx truffle compile
npm run inject-networks
npx truffle exec scripts/stablex/test.js --network rinkeby
```
