### PR TITLE
New paginated approach for reading the orders from blockchain

### DIFF
--- a/scripts/stablex/get_auction_elements.js
+++ b/scripts/stablex/get_auction_elements.js
@@ -12,9 +12,13 @@ const argv = require("yargs")
   .option("tokens", {
     describe: "Filter only orders between the given tokens",
   })
+  .option("pageSize", {
+    default: 100,
+    describe: "The page  size for the function getOrdersPaginated",
+  })
   .version(false).argv
 
-const { getOrdersViaPaginatedApproach } = require("./utilities")
+const { getOrdersPaginated } = require("./utilities")
 
 const COLORS = {
   NONE: "\x1b[0m",
@@ -85,7 +89,7 @@ const printOrder = function(order, currentBatchId) {
 module.exports = async callback => {
   try {
     const instance = await BatchExchange.deployed()
-    let auctionElementsDecoded = await getOrdersViaPaginatedApproach(instance, 100)
+    let auctionElementsDecoded = await getOrdersPaginated(instance, argv.pageSize)
 
     const batchId = (await instance.getCurrentBatchId()).toNumber()
     if (!argv.expired) {

--- a/scripts/stablex/get_auction_elements.js
+++ b/scripts/stablex/get_auction_elements.js
@@ -14,7 +14,7 @@ const argv = require("yargs")
   })
   .version(false).argv
 
-const { decodeOrdersBN } = require("../../src/encoding")
+const { getOrdersViaPaginatedApproach } = require("./utilities")
 
 const COLORS = {
   NONE: "\x1b[0m",
@@ -85,8 +85,7 @@ const printOrder = function(order, currentBatchId) {
 module.exports = async callback => {
   try {
     const instance = await BatchExchange.deployed()
-    const auctionElementsEncoded = await instance.getEncodedOrders.call()
-    let auctionElementsDecoded = decodeOrdersBN(auctionElementsEncoded)
+    let auctionElementsDecoded = await getOrdersViaPaginatedApproach(instance, 100)
 
     const batchId = (await instance.getCurrentBatchId()).toNumber()
     if (!argv.expired) {

--- a/scripts/stablex/utilities.js
+++ b/scripts/stablex/utilities.js
@@ -37,7 +37,7 @@ const closeAuction = async (instance, web3Provider = web3) => {
   await waitForNSeconds(time_remaining + 1, web3Provider)
 }
 
-const getOrdersViaPaginatedApproach = async (instance, pageSize) => {
+const getOrdersPaginated = async (instance, pageSize) => {
   const { decodeOrdersBN } = require("../../src/encoding")
   let orders = []
   let currentUser = "0x0000000000000000000000000000000000000000"
@@ -57,5 +57,5 @@ module.exports = {
   addTokens,
   closeAuction,
   token_list_url,
-  getOrdersViaPaginatedApproach,
+  getOrdersPaginated,
 }

--- a/scripts/stablex/utilities.js
+++ b/scripts/stablex/utilities.js
@@ -37,8 +37,25 @@ const closeAuction = async (instance, web3Provider = web3) => {
   await waitForNSeconds(time_remaining + 1, web3Provider)
 }
 
+const getOrdersViaPaginatedApproach = async (instance, pageSize) => {
+  const { decodeOrdersBN } = require("../../src/encoding")
+  let orders = []
+  let currentUser = "0x0000000000000000000000000000000000000000"
+  let currentOffSet = 0
+  let lastPageSize = pageSize
+  while (lastPageSize == pageSize) {
+    const page = decodeOrdersBN(await instance.getEncodedUsersPaginated(currentUser, currentOffSet, pageSize))
+    orders = orders.concat(page)
+    currentUser = page[page.length - 1].user
+    currentOffSet = orders.filter(order => order.user == currentUser).length
+    lastPageSize = page.length
+  }
+  return orders
+}
+
 module.exports = {
   addTokens,
   closeAuction,
   token_list_url,
+  getOrdersViaPaginatedApproach,
 }


### PR DESCRIPTION
As the current approach for reading the orders would not work anymore for the mainnet network, due to too many orders, I implemented the paginated approach.

testplan:
```
npx truffle exec  scripts/stablex/get_auction_elements.js --network mainnet  
```
and observe all >660 orders