### PR TITLE
[Fix] getOrdersPaginated in the special case page.lenth ==0

### DIFF
--- a/scripts/stablex/utilities.js
+++ b/scripts/stablex/utilities.js
@@ -46,9 +46,12 @@ const getOrdersPaginated = async (instance, pageSize) => {
   while (lastPageSize == pageSize) {
     const page = decodeOrdersBN(await instance.getEncodedUsersPaginated(currentUser, currentOffSet, pageSize))
     orders = orders.concat(page)
-    if (page.length > 0) {
-      currentUser = page[page.length - 1].user
-      currentOffSet = orders.filter(order => order.user == currentUser).length
+    for (const index in page) {
+      if (page[index].user != currentUser) {
+        currentUser = page[index].user
+        currentOffSet = 0
+      }
+      currentOffSet += 1
     }
     lastPageSize = page.length
   }

--- a/scripts/stablex/utilities.js
+++ b/scripts/stablex/utilities.js
@@ -46,8 +46,10 @@ const getOrdersPaginated = async (instance, pageSize) => {
   while (lastPageSize == pageSize) {
     const page = decodeOrdersBN(await instance.getEncodedUsersPaginated(currentUser, currentOffSet, pageSize))
     orders = orders.concat(page)
-    currentUser = page[page.length - 1].user
-    currentOffSet = orders.filter(order => order.user == currentUser).length
+    if (page.length > 0) {
+      currentUser = page[page.length - 1].user
+      currentOffSet = orders.filter(order => order.user == currentUser).length
+    }
     lastPageSize = page.length
   }
   return orders


### PR DESCRIPTION
@twalth3r found a small error in my implementation of getOrdersPaginated while coding the solution in python.

If `page.length ==0`, then the script would throw, as `page[page.length -1]` would not exist