### PR TITLE
[Viewer] Allow sellTokenBalance to be computed for a certain batchId

### DIFF
--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -1,11 +1,13 @@
 pragma solidity ^0.5.0;
 
 import "solidity-bytes-utils/contracts/BytesLib.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "./BatchExchange.sol";
 
 
 contract BatchExchangeViewer {
     using BytesLib for bytes;
+    using SafeMath for uint256;
 
     uint8 public constant AUCTION_ELEMENT_WIDTH = 112;
     // Can be used by external contracts to indicate no filter as it doesn't seem possible
@@ -45,6 +47,7 @@ contract BatchExchangeViewer {
             getEncodedOrdersPaginated(
                 batch,
                 batch,
+                batch + 1,
                 getTokenIdsFromAdresses(tokenFilter),
                 previousPageUser,
                 previousPageUserOffset,
@@ -79,6 +82,7 @@ contract BatchExchangeViewer {
             getEncodedOrdersPaginated(
                 batch - 1,
                 batch - 1,
+                batch,
                 getTokenIdsFromAdresses(tokenFilter),
                 previousPageUser,
                 previousPageUserOffset,
@@ -89,6 +93,8 @@ contract BatchExchangeViewer {
     /** @dev Queries a page in the list of all orders
      *  @param maxValidFrom all returned orders will have a validFrom <= this value (they were placed at or before that batch)
      *  @param minValidUntil all returned orders will have a validUntil >= this value (validity ends at or after that batch)
+     *  @param sellBalanceTargetBatchIndex the batchIndex at which we are expecting the sellTokenBalance to be valid
+        (e.g. in the current live orderbook we want to include sellBalances that are valid in currentBatch + 1).
      *  @param tokenFilter all returned order will have buy *and* sell token from this list (leave empty for "no filter")
      *  @param previousPageUser address taken from nextPageUser return value from last page (address(0) for first page)
      *  @param previousPageUserOffset offset taken nextPageUserOffset return value from last page (0 for first page)
@@ -98,6 +104,7 @@ contract BatchExchangeViewer {
     function getEncodedOrdersPaginated(
         uint32 maxValidFrom,
         uint32 minValidUntil,
+        uint32 sellBalanceTargetBatchIndex,
         uint16[] memory tokenFilter,
         address previousPageUser,
         uint16 previousPageUserOffset,
@@ -112,6 +119,7 @@ contract BatchExchangeViewer {
             for (uint16 index = 0; index < unfiltered.length / AUCTION_ELEMENT_WIDTH; index++) {
                 // make sure we don't overflow index * AUCTION_ELEMENT_WIDTH
                 bytes memory element = unfiltered.slice(uint256(index) * AUCTION_ELEMENT_WIDTH, AUCTION_ELEMENT_WIDTH);
+                element = updateSellTokenBalanceForBatchId(element, sellBalanceTargetBatchIndex);
                 if (
                     maxValidFrom >= getValidFrom(element) &&
                     minValidUntil <= getValidUntil(element) &&
@@ -158,6 +166,15 @@ contract BatchExchangeViewer {
         return slice.toAddress(0);
     }
 
+    function getSellTokenBalance(bytes memory element) public pure returns (uint256) {
+        bytes memory slice = element.slice(20, 52);
+        return slice.toUint(0);
+    }
+
+    function updateSellTokenBalance(bytes memory element, uint256 amount) public pure returns (bytes memory) {
+        return element.slice(0, 20).concat(abi.encodePacked(amount)).concat(element.slice(52, AUCTION_ELEMENT_WIDTH - 52));
+    }
+
     function getBuyToken(bytes memory element) public pure returns (uint16) {
         bytes memory slice = element.slice(52, 2);
         return slice.toUint16(0);
@@ -184,5 +201,23 @@ contract BatchExchangeViewer {
             result[index] = batchExchange.tokenAddressToIdMap(tokenIds[index]);
         }
         return result;
+    }
+
+    function updateSellTokenBalanceForBatchId(bytes memory element, uint32 targetBatchIndex) public view returns (bytes memory) {
+        address user = getUser(element);
+        uint16 sellToken = getSellToken(element);
+        address sellTokenAddress = batchExchange.tokenIdToAddressMap(sellToken);
+        uint256 sellTokenBalance = getSellTokenBalance(element);
+        (uint256 depositAmount, uint32 depositBatch) = batchExchange.getPendingDeposit(user, sellTokenAddress);
+        // The deposit will be valid at target batch, thus add to balance
+        if (depositBatch < targetBatchIndex) {
+            sellTokenBalance = sellTokenBalance.add(depositAmount);
+        }
+        // The withdraw will be valid at target batch, thus subtract from balance
+        (uint256 withdrawAmount, uint32 withdrawBatch) = batchExchange.getPendingWithdraw(user, sellTokenAddress);
+        if (withdrawBatch < targetBatchIndex) {
+            sellTokenBalance = sellTokenBalance.sub(Math.min(sellTokenBalance, withdrawAmount));
+        }
+        return updateSellTokenBalance(element, sellTokenBalance);
     }
 }

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -209,13 +209,13 @@ contract BatchExchangeViewer {
         address sellTokenAddress = batchExchange.tokenIdToAddressMap(sellToken);
         uint256 sellTokenBalance = getSellTokenBalance(element);
         (uint256 depositAmount, uint32 depositBatch) = batchExchange.getPendingDeposit(user, sellTokenAddress);
-        // The deposit will be valid at target batch, thus add to balance
-        if (depositBatch < targetBatchIndex) {
+        // The deposit is not valid currently but will be valid at target batch, thus add to balance
+        if (depositBatch >= getCurrentBatchId() && depositBatch < targetBatchIndex) {
             sellTokenBalance = sellTokenBalance.add(depositAmount);
         }
-        // The withdraw will be valid at target batch, thus subtract from balance
         (uint256 withdrawAmount, uint32 withdrawBatch) = batchExchange.getPendingWithdraw(user, sellTokenAddress);
-        if (withdrawBatch < targetBatchIndex) {
+        // The withdraw is not valid currently but will be valid at target batch, thus subtract from balance
+        if (withdrawBatch >= getCurrentBatchId() && withdrawBatch < targetBatchIndex) {
             sellTokenBalance = sellTokenBalance.sub(Math.min(sellTokenBalance, withdrawAmount));
         }
         return updateSellTokenBalance(element, sellTokenBalance);

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -210,12 +210,12 @@ contract BatchExchangeViewer {
         uint256 sellTokenBalance = getSellTokenBalance(element);
         (uint256 depositAmount, uint32 depositBatch) = batchExchange.getPendingDeposit(user, sellTokenAddress);
         // The deposit is not valid currently but will be valid at target batch, thus add to balance
-        if (depositBatch >= getCurrentBatchId() && depositBatch < targetBatchIndex) {
+        if (depositBatch >= batchExchange.getCurrentBatchId() && depositBatch < targetBatchIndex) {
             sellTokenBalance = sellTokenBalance.add(depositAmount);
         }
         (uint256 withdrawAmount, uint32 withdrawBatch) = batchExchange.getPendingWithdraw(user, sellTokenAddress);
         // The withdraw is not valid currently but will be valid at target batch, thus subtract from balance
-        if (withdrawBatch >= getCurrentBatchId() && withdrawBatch < targetBatchIndex) {
+        if (withdrawBatch >= batchExchange.getCurrentBatchId() && withdrawBatch < targetBatchIndex) {
             sellTokenBalance = sellTokenBalance.sub(Math.min(sellTokenBalance, withdrawAmount));
         }
         return updateSellTokenBalance(element, sellTokenBalance);


### PR DESCRIPTION
Reported by @koeppelmann 

When we query the current order book we are getting the sellTokenBalances that are valid for the auction that is currently being sold. However, when visualizing the orderbook for the purpose of predicting at what price we should place an order to be matched in the next auction, we need to consider the balances that will be valid in the next auction.

For this we need to potentially add pendingDeposits and subtract pendingWithdraws.

This PR allows to specify a sellTokenBalanceTargetBatchId into the main filter function and will adjust the returned sellTokenBalance for this targetBatch. This means `getFinalizedOrderBook` will use the current batch ID whereas `getOpenOrderBook` will use the next batch ID.

### Test Plan

Added unit test explaining the behavior.