### PR TITLE
[Orderbook] logic to invert orderbook

### DIFF
--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -7,6 +7,10 @@ export class Price {
     this.denominator = denominator;
   }
 
+  inverted() {
+    return new Price(this.denominator, this.numerator);
+  }
+
   toNumber() {
     return this.numerator / this.denominator;
   }
@@ -33,8 +37,8 @@ export class Offer {
 export class Orderbook {
   baseToken: string;
   quoteToken: string;
-  private asks: Map<number, Offer>;
-  private bids: Map<number, Offer>;
+  private asks: Map<number, Offer>; // Mapping from price to cummulative offers at this point.
+  private bids: Map<number, Offer>; // Mapping from price to cummulative offers at this point.
 
   constructor(baseToken: string, quoteToken: string) {
     this.baseToken = baseToken;
@@ -59,6 +63,18 @@ export class Orderbook {
     bids.reverse();
     return {bids, asks};
   }
+
+  invert() {
+    // Switch base/quote token
+    const baseToken = this.baseToken;
+    this.baseToken = this.quoteToken;
+    this.quoteToken = this.baseToken;
+
+    // Invert offers
+    const bids = this.bids;
+    this.bids = invertPricePoints(this.asks);
+    this.asks = invertPricePoints(bids);
+  }
 }
 
 function addOffer(offer: Offer, existingOffers: Map<number, Offer>) {
@@ -76,4 +92,17 @@ function addOffer(offer: Offer, existingOffers: Map<number, Offer>) {
 
 function sortOffersAscending(left: Offer, right: Offer) {
   return left.price.toNumber() - right.price.toNumber();
+}
+
+function invertPricePoints(prices: Map<number, Offer>) {
+  return new Map(
+    Array.from(prices.entries()).map(([_, offer]) => {
+      const inverted_price = offer.price.inverted();
+      const inverted_volume = offer.volume * offer.price.toNumber();
+      return [
+        inverted_price.toNumber(),
+        new Offer(inverted_price, inverted_volume)
+      ];
+    })
+  );
 }

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -37,8 +37,8 @@ export class Offer {
 export class Orderbook {
   baseToken: string;
   quoteToken: string;
-  private asks: Map<number, Offer>; // Mapping from price to cummulative offers at this point.
-  private bids: Map<number, Offer>; // Mapping from price to cummulative offers at this point.
+  private asks: Map<number, Offer>; // Mapping from price to cumulative offers at this point.
+  private bids: Map<number, Offer>; // Mapping from price to cumulative offers at this point.
 
   constructor(baseToken: string, quoteToken: string) {
     this.baseToken = baseToken;

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -68,7 +68,7 @@ export class Orderbook {
     // Switch base/quote token
     const baseToken = this.baseToken;
     this.baseToken = this.quoteToken;
-    this.quoteToken = this.baseToken;
+    this.quoteToken = baseToken;
 
     // Invert offers
     const bids = this.bids;

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -64,16 +64,16 @@ export class Orderbook {
     return {bids, asks};
   }
 
+  /**
+   * @returns the inverse of the current order book (e.g. ETH/DAI becomes DAI/ETH)
+   * by switching bids/asks and recomputing price/volume to the new reference token.
+   */
   invert() {
-    // Switch base/quote token
-    const baseToken = this.baseToken;
-    this.baseToken = this.quoteToken;
-    this.quoteToken = baseToken;
+    const result = new Orderbook(this.quoteToken, this.baseToken);
+    result.bids = invertPricePoints(this.asks);
+    result.asks = invertPricePoints(this.bids);
 
-    // Invert offers
-    const bids = this.bids;
-    this.bids = invertPricePoints(this.asks);
-    this.asks = invertPricePoints(bids);
+    return result;
   }
 }
 

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -68,7 +68,7 @@ export class Orderbook {
    * @returns the inverse of the current order book (e.g. ETH/DAI becomes DAI/ETH)
    * by switching bids/asks and recomputing price/volume to the new reference token.
    */
-  invert() {
+  inverted() {
     const result = new Orderbook(this.quoteToken, this.baseToken);
     result.bids = invertPricePoints(this.asks);
     result.asks = invertPricePoints(this.bids);

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -28,4 +28,35 @@ describe("Orderbook", () => {
       })
     );
   });
+
+  it("inverts by switching bid/asks and inverting prices", () => {
+    const orderbook = new Orderbook("USDC", "DAI");
+
+    // Offering to sell 100 USDC for 2 DAI each, thus willing to buy 200 DAI
+    orderbook.addAsk(new Offer(new Price(2, 1), 100));
+    orderbook.addAsk(new Offer(new Price(1, 1), 200));
+    orderbook.addAsk(new Offer(new Price(4, 1), 300));
+
+    // Offering to buy 50 USDC for 50c each, thus willing to sell 25 DAI
+    orderbook.addBid(new Offer(new Price(1, 2), 50));
+    orderbook.addBid(new Offer(new Price(1, 4), 80));
+    orderbook.addBid(new Offer(new Price(1, 4), 20));
+
+    orderbook.invert();
+
+    assert.equal(
+      JSON.stringify(orderbook.toJSON()),
+      JSON.stringify({
+        bids: [
+          {price: 1, volume: 200},
+          {price: 0.5, volume: 200},
+          {price: 0.25, volume: 1200}
+        ],
+        asks: [
+          {price: 2, volume: 25},
+          {price: 4, volume: 25}
+        ]
+      })
+    );
+  });
 });

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -45,7 +45,7 @@ describe("Orderbook", () => {
     orderbook.addBid(new Offer(new Price(1, 4), 80));
     orderbook.addBid(new Offer(new Price(1, 4), 20));
 
-    const inverse = orderbook.invert();
+    const inverse = orderbook.inverted();
 
     // Original didn't change
     assert.equal(orderbook.baseToken, "USDC");

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -45,13 +45,33 @@ describe("Orderbook", () => {
     orderbook.addBid(new Offer(new Price(1, 4), 80));
     orderbook.addBid(new Offer(new Price(1, 4), 20));
 
-    orderbook.invert();
+    const inverse = orderbook.invert();
 
-    assert.equal(orderbook.baseToken, "DAI");
-    assert.equal(orderbook.quoteToken, "USDC");
+    // Original didn't change
+    assert.equal(orderbook.baseToken, "USDC");
+    assert.equal(orderbook.quoteToken, "DAI");
 
     assert.equal(
       JSON.stringify(orderbook.toJSON()),
+      JSON.stringify({
+        bids: [
+          {price: 0.5, volume: 50},
+          {price: 0.25, volume: 100}
+        ],
+        asks: [
+          {price: 1, volume: 200},
+          {price: 2, volume: 100},
+          {price: 4, volume: 300}
+        ]
+      })
+    );
+
+    // Check inverse
+    assert.equal(inverse.baseToken, "DAI");
+    assert.equal(inverse.quoteToken, "USDC");
+
+    assert.equal(
+      JSON.stringify(inverse.toJSON()),
       JSON.stringify({
         bids: [
           {price: 1, volume: 200},

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -13,6 +13,9 @@ describe("Orderbook", () => {
     orderbook.addBid(new Offer(new Price(99, 100), 70));
     orderbook.addBid(new Offer(new Price(9, 10), 30));
 
+    assert.equal(orderbook.baseToken, "USDC");
+    assert.equal(orderbook.quoteToken, "DAI");
+
     assert.equal(
       JSON.stringify(orderbook.toJSON()),
       JSON.stringify({
@@ -32,17 +35,20 @@ describe("Orderbook", () => {
   it("inverts by switching bid/asks and inverting prices", () => {
     const orderbook = new Orderbook("USDC", "DAI");
 
-    // Offering to sell 100 USDC for 2 DAI each, thus willing to buy 200 DAI
+    // Offering to sell 100 USDC for 2 DAI each, thus willing to buy 200 DAI for 50ç each
     orderbook.addAsk(new Offer(new Price(2, 1), 100));
     orderbook.addAsk(new Offer(new Price(1, 1), 200));
     orderbook.addAsk(new Offer(new Price(4, 1), 300));
 
-    // Offering to buy 50 USDC for 50c each, thus willing to sell 25 DAI
+    // Offering to buy 50 USDC for 50ç each, thus willing to sell 25 DAI for 2 USDC each
     orderbook.addBid(new Offer(new Price(1, 2), 50));
     orderbook.addBid(new Offer(new Price(1, 4), 80));
     orderbook.addBid(new Offer(new Price(1, 4), 20));
 
     orderbook.invert();
+
+    assert.equal(orderbook.baseToken, "DAI");
+    assert.equal(orderbook.quoteToken, "USDC");
 
     assert.equal(
       JSON.stringify(orderbook.toJSON()),


### PR DESCRIPTION
This PR introduces logic, which allows to "invert" a given orderbook. This will e.g. turn an ETH/DAI book into a DAI/ETH book. 

This can be useful as instead of representing each token pair twice (A/B & B/A) we can instead chose a canonical representation (e.g. by alphabet, thus A/B) and still use the inverse orderbook (e.g. if I want to compute the book between B/C and would like to use B/A * A/C to get there)

### Test Plan

added a unit test