### PR TITLE
[Orderbook] Allowing to add/fold two orderbooks into one

### DIFF
--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -82,6 +82,10 @@ export class Orderbook {
     return result;
   }
 
+  /**
+   * In-place adds the given orderbook to the current one, combining all bids and asks at the same price point
+   * @param orderbook the orderbook to be added to this one
+   */
   add(orderbook: Orderbook) {
     if (orderbook.pair() != this.pair()) {
       throw new Error(

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -1,3 +1,5 @@
+import {Order} from ".";
+
 export class Price {
   numerator: number;
   denominator: number;
@@ -47,6 +49,10 @@ export class Orderbook {
     this.bids = new Map();
   }
 
+  pair() {
+    return `${this.baseToken}/${this.quoteToken}`;
+  }
+
   addBid(bid: Offer) {
     addOffer(bid, this.bids);
   }
@@ -74,6 +80,20 @@ export class Orderbook {
     result.asks = invertPricePoints(this.bids);
 
     return result;
+  }
+
+  add(orderbook: Orderbook) {
+    if (orderbook.pair() != this.pair()) {
+      throw new Error(
+        `Cannot add ${orderbook.pair()} orderbook to ${this.pair()} orderbook`
+      );
+    }
+    orderbook.bids.forEach(bid => {
+      this.addBid(bid);
+    });
+    orderbook.asks.forEach(ask => {
+      this.addAsk(ask);
+    });
   }
 }
 

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -117,4 +117,13 @@ describe("Orderbook", () => {
       })
     );
   });
+
+  it("cannot add orderbooks for different token pairs", () => {
+    const first_orderbook = new Orderbook("DAI", "ETH");
+    const second_orderbook = new Orderbook("DAI", "USDC");
+
+    assert.throws(() => {
+      first_orderbook.add(second_orderbook);
+    });
+  });
 });

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -85,4 +85,36 @@ describe("Orderbook", () => {
       })
     );
   });
+
+  it("can add another orderbook by combining bids and asks", () => {
+    const first_orderbook = new Orderbook("USDC", "DAI");
+    first_orderbook.addAsk(new Offer(new Price(11, 10), 50));
+    first_orderbook.addAsk(new Offer(new Price(12, 10), 150));
+    first_orderbook.addBid(new Offer(new Price(9, 10), 50));
+    first_orderbook.addBid(new Offer(new Price(99, 100), 80));
+
+    const second_orderbook = new Orderbook("USDC", "DAI");
+    second_orderbook.addAsk(new Offer(new Price(11, 10), 60));
+    second_orderbook.addAsk(new Offer(new Price(13, 10), 200));
+    second_orderbook.addBid(new Offer(new Price(9, 10), 50));
+    second_orderbook.addBid(new Offer(new Price(95, 100), 70));
+
+    first_orderbook.add(second_orderbook);
+
+    assert.equal(
+      JSON.stringify(first_orderbook.toJSON()),
+      JSON.stringify({
+        bids: [
+          {price: 0.99, volume: 80},
+          {price: 0.95, volume: 70},
+          {price: 0.9, volume: 100}
+        ],
+        asks: [
+          {price: 1.1, volume: 110},
+          {price: 1.2, volume: 150},
+          {price: 1.3, volume: 200}
+        ]
+      })
+    );
+  });
 });


### PR DESCRIPTION
This PR adds logic for combining two orderbooks of the same symbol. When we want to create the multi-hop orderbook for DAI/ETH we will create books like DAI/USDC * USDC/ETH, DAI/PAX * PAX/ETH, etc. Eventually all these books will have to be folded into one combined orderbook using this method.

### Test Plan

unit test