### PR TITLE
[Orderbook] transitive closure

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@gnosis.pm/solidity-data-structures": "^1.2.4",
     "@gnosis.pm/util-contracts": "^2.0.6",
     "@truffle/contract": "^4.1.13",
+    "@types/bn.js": "^4.11.6",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^7.0.2",
     "axios": "^0.19.2",

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -1,0 +1,71 @@
+export class Fraction {
+  numerator: number;
+  denominator: number;
+
+  constructor(numerator: number, denominator: number) {
+    this.numerator = numerator;
+    this.denominator = denominator;
+  }
+
+  reduce() {
+    const greatest_common_denominator = gcd(this.numerator, this.denominator);
+    this.numerator /= greatest_common_denominator;
+    this.denominator /= greatest_common_denominator;
+  }
+
+  inverted() {
+    return new Fraction(this.denominator, this.numerator);
+  }
+
+  negated() {
+    return new Fraction(this.numerator * -1, this.denominator);
+  }
+
+  mul(other: Fraction) {
+    const result = new Fraction(
+      this.numerator * other.numerator,
+      this.denominator * other.denominator
+    );
+    result.reduce();
+    return result;
+  }
+
+  div(other: Fraction) {
+    return this.mul(other.inverted());
+  }
+
+  sub(other: Fraction) {
+    return this.add(other.negated());
+  }
+
+  add(other: Fraction) {
+    const result = new Fraction(
+      this.numerator * other.denominator + other.numerator * this.denominator,
+      this.denominator * other.denominator
+    );
+    result.reduce();
+    return result;
+  }
+
+  toNumber() {
+    return this.numerator / this.denominator;
+  }
+
+  toJSON() {
+    return this.toNumber();
+  }
+}
+
+// https://github.com/AllAlgorithms/typescript/blob/master/math/gcd/gcd.ts
+function gcd(num1: number, num2: number): number {
+  if (num1 === 0 || num2 === 0) {
+    return 0;
+  }
+  if (num1 === num2) {
+    return num1;
+  }
+  if (num1 > num2) {
+    return gcd(num1 - num2, num2);
+  }
+  return gcd(num1, num2 - num1);
+}

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -1,19 +1,31 @@
-export class Fraction {
-  private numerator: number;
-  private denominator: number;
+import BN from "bn.js";
 
-  constructor(numerator: number, denominator: number) {
-    this.numerator = numerator;
-    if (denominator == 0) {
+export class Fraction {
+  private numerator: BN;
+  private denominator: BN;
+
+  constructor(numerator: BN | number, denominator: BN | number) {
+    if (typeof numerator == "number") {
+      this.numerator = new BN(numerator);
+    } else {
+      this.numerator = numerator;
+    }
+
+    if (typeof denominator == "number") {
+      this.denominator = new BN(denominator);
+    } else {
+      this.denominator = denominator;
+    }
+
+    if (this.denominator.isZero()) {
       throw Error("Denominator cannot be zero");
     }
-    this.denominator = denominator;
   }
 
   reduce() {
     const greatest_common_denominator = gcd(this.numerator, this.denominator);
-    this.numerator /= greatest_common_denominator;
-    this.denominator /= greatest_common_denominator;
+    this.numerator = this.numerator.div(greatest_common_denominator);
+    this.denominator = this.denominator.div(greatest_common_denominator);
   }
 
   inverted() {
@@ -21,13 +33,13 @@ export class Fraction {
   }
 
   negated() {
-    return new Fraction(this.numerator * -1, this.denominator);
+    return new Fraction(this.numerator.neg(), this.denominator);
   }
 
   mul(other: Fraction) {
     const result = new Fraction(
-      this.numerator * other.numerator,
-      this.denominator * other.denominator
+      this.numerator.mul(other.numerator),
+      this.denominator.mul(other.denominator)
     );
     result.reduce();
     return result;
@@ -43,15 +55,17 @@ export class Fraction {
 
   add(other: Fraction) {
     const result = new Fraction(
-      this.numerator * other.denominator + other.numerator * this.denominator,
-      this.denominator * other.denominator
+      this.numerator
+        .mul(other.denominator)
+        .add(other.numerator.mul(this.denominator)),
+      this.denominator.mul(other.denominator)
     );
     result.reduce();
     return result;
   }
 
   toNumber() {
-    return this.numerator / this.denominator;
+    return this.numerator.toNumber() / this.denominator.toNumber();
   }
 
   toJSON() {
@@ -60,15 +74,15 @@ export class Fraction {
 }
 
 // https://github.com/AllAlgorithms/typescript/blob/master/math/gcd/gcd.ts
-function gcd(num1: number, num2: number): number {
-  if (num1 === 0 || num2 === 0) {
-    return 0;
+function gcd(num1: BN, num2: BN): BN {
+  if (num1.isZero() || num2.isZero()) {
+    return new BN(0);
   }
-  if (num1 === num2) {
+  if (num1.eq(num2)) {
     return num1;
   }
-  if (num1 > num2) {
-    return gcd(num1 - num2, num2);
+  if (num1.gt(num2)) {
+    return gcd(num1.sub(num2), num2);
   }
-  return gcd(num1, num2 - num1);
+  return gcd(num1, num2.sub(num1));
 }

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -13,8 +13,18 @@ export class Fraction {
     }
   }
 
+  isZero() {
+    return this.numerator.isZero();
+  }
+
   gt(other: Fraction) {
-    return this.sub(other).toNumber() > 0;
+    const diff = this.sub(other);
+    return diff.numerator.mul(diff.denominator).gt(new BN(0));
+  }
+
+  lt(other: Fraction) {
+    const diff = this.sub(other);
+    return diff.numerator.mul(diff.denominator).lt(new BN(0));
   }
 
   reduce() {

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -22,8 +22,15 @@ export class Fraction {
     }
   }
 
+  gt(other: Fraction) {
+    return this.sub(other).toNumber() > 0;
+  }
+
   reduce() {
-    const greatest_common_denominator = gcd(this.numerator, this.denominator);
+    const greatest_common_denominator = gcd(
+      this.numerator.abs(),
+      this.denominator.abs()
+    );
     this.numerator = this.numerator.div(greatest_common_denominator);
     this.denominator = this.denominator.div(greatest_common_denominator);
   }
@@ -75,6 +82,9 @@ export class Fraction {
 
 // https://github.com/AllAlgorithms/typescript/blob/master/math/gcd/gcd.ts
 function gcd(num1: BN, num2: BN): BN {
+  if (num1.isNeg() || num2.isNeg()) {
+    throw new Error("GCD only defined on positive numbers");
+  }
   if (num1.isZero() || num2.isZero()) {
     return new BN(0);
   }

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -5,17 +5,8 @@ export class Fraction {
   private denominator: BN;
 
   constructor(numerator: BN | number, denominator: BN | number) {
-    if (typeof numerator == "number") {
-      this.numerator = new BN(numerator);
-    } else {
-      this.numerator = numerator;
-    }
-
-    if (typeof denominator == "number") {
-      this.denominator = new BN(denominator);
-    } else {
-      this.denominator = denominator;
-    }
+    this.numerator = new BN(numerator);
+    this.denominator = new BN(denominator);
 
     if (this.denominator.isZero()) {
       throw Error("Denominator cannot be zero");
@@ -27,10 +18,7 @@ export class Fraction {
   }
 
   reduce() {
-    const greatest_common_denominator = gcd(
-      this.numerator.abs(),
-      this.denominator.abs()
-    );
+    const greatest_common_denominator = this.numerator.gcd(this.denominator);
     this.numerator = this.numerator.div(greatest_common_denominator);
     this.denominator = this.denominator.div(greatest_common_denominator);
   }
@@ -64,7 +52,7 @@ export class Fraction {
     const result = new Fraction(
       this.numerator
         .mul(other.denominator)
-        .add(other.numerator.mul(this.denominator)),
+        .iadd(other.numerator.mul(this.denominator)),
       this.denominator.mul(other.denominator)
     );
     result.reduce();
@@ -78,21 +66,4 @@ export class Fraction {
   toJSON() {
     return this.toNumber();
   }
-}
-
-// https://github.com/AllAlgorithms/typescript/blob/master/math/gcd/gcd.ts
-function gcd(num1: BN, num2: BN): BN {
-  if (num1.isNeg() || num2.isNeg()) {
-    throw new Error("GCD only defined on positive numbers");
-  }
-  if (num1.isZero() || num2.isZero()) {
-    return new BN(0);
-  }
-  if (num1.eq(num2)) {
-    return num1;
-  }
-  if (num1.gt(num2)) {
-    return gcd(num1.sub(num2), num2);
-  }
-  return gcd(num1, num2.sub(num1));
 }

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -4,6 +4,9 @@ export class Fraction {
 
   constructor(numerator: number, denominator: number) {
     this.numerator = numerator;
+    if (denominator == 0) {
+      throw Error("Denominator cannot be zero");
+    }
     this.denominator = denominator;
   }
 

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -1,6 +1,6 @@
 export class Fraction {
-  numerator: number;
-  denominator: number;
+  private numerator: number;
+  private denominator: number;
 
   constructor(numerator: number, denominator: number) {
     this.numerator = numerator;

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -116,8 +116,8 @@ export class Orderbook {
    */
   inverted() {
     const result = new Orderbook(this.quoteToken, this.baseToken);
-    result.bids = invertFractionPoints(this.asks);
-    result.asks = invertFractionPoints(this.bids);
+    result.bids = invertPricePoints(this.asks);
+    result.asks = invertPricePoints(this.bids);
 
     return result;
   }
@@ -233,7 +233,7 @@ function sortOffersAscending(left: Offer, right: Offer) {
   return left.price.toNumber() - right.price.toNumber();
 }
 
-function invertFractionPoints(prices: Map<number, Offer>) {
+function invertPricePoints(prices: Map<number, Offer>) {
   return new Map(
     Array.from(prices.entries()).map(([_, offer]) => {
       const inverted_price = offer.price.inverted();

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -9,7 +9,7 @@ export class Fraction {
     this.denominator = denominator;
   }
 
-  shorten() {
+  reduce() {
     const greatest_common_denominator = gcd(this.numerator, this.denominator);
     this.numerator /= greatest_common_denominator;
     this.denominator /= greatest_common_denominator;
@@ -28,7 +28,7 @@ export class Fraction {
       this.numerator * other.numerator,
       this.denominator * other.denominator
     );
-    result.shorten();
+    result.reduce();
     return result;
   }
 
@@ -45,7 +45,7 @@ export class Fraction {
       this.numerator * other.denominator + other.numerator * this.denominator,
       this.denominator * other.denominator
     );
-    result.shorten();
+    result.reduce();
     return result;
   }
 

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -134,10 +134,7 @@ export class Orderbook {
       const right_offer_volume_in_left_offer_base_token = right_offer.volume.div(
         left_offer.price
       );
-      if (
-        left_offer.volume.toNumber() >
-        right_offer_volume_in_left_offer_base_token.toNumber()
-      ) {
+      if (left_offer.volume.gt(right_offer_volume_in_left_offer_base_token)) {
         volume = right_offer_volume_in_left_offer_base_token;
         left_offer.volume = left_offer.volume.sub(volume);
         right_next = right_iterator.next();
@@ -173,7 +170,7 @@ function addOffer(offer: Offer, existingOffers: Map<number, Offer>) {
 }
 
 function sortOffersAscending(left: Offer, right: Offer) {
-  return left.price.toNumber() - right.price.toNumber();
+  return left.price.sub(right.price).toNumber();
 }
 
 function invertPricePoints(prices: Map<number, Offer>) {

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -145,7 +145,7 @@ export class Orderbook {
         );
         left_next = left_iterator.next();
         // In case the orders matched perfectly we will move right as well
-        if (right_offer.volume.toNumber() == 0) {
+        if (right_offer.volume.isZero()) {
           right_next = right_iterator.next();
         }
       }
@@ -170,7 +170,13 @@ function addOffer(offer: Offer, existingOffers: Map<number, Offer>) {
 }
 
 function sortOffersAscending(left: Offer, right: Offer) {
-  return left.price.sub(right.price).toNumber();
+  if (left.price.gt(right.price)) {
+    return 1;
+  } else if (left.price.lt(right.price)) {
+    return -1;
+  } else {
+    return 0;
+  }
 }
 
 function invertPricePoints(prices: Map<number, Offer>) {

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -1,62 +1,5 @@
 import {Order} from ".";
-
-export class Fraction {
-  numerator: number;
-  denominator: number;
-
-  constructor(numerator: number, denominator: number) {
-    this.numerator = numerator;
-    this.denominator = denominator;
-  }
-
-  reduce() {
-    const greatest_common_denominator = gcd(this.numerator, this.denominator);
-    this.numerator /= greatest_common_denominator;
-    this.denominator /= greatest_common_denominator;
-  }
-
-  inverted() {
-    return new Fraction(this.denominator, this.numerator);
-  }
-
-  negated() {
-    return new Fraction(this.numerator * -1, this.denominator);
-  }
-
-  mul(other: Fraction) {
-    const result = new Fraction(
-      this.numerator * other.numerator,
-      this.denominator * other.denominator
-    );
-    result.reduce();
-    return result;
-  }
-
-  div(other: Fraction) {
-    return this.mul(other.inverted());
-  }
-
-  sub(other: Fraction) {
-    return this.add(other.negated());
-  }
-
-  add(other: Fraction) {
-    const result = new Fraction(
-      this.numerator * other.denominator + other.numerator * this.denominator,
-      this.denominator * other.denominator
-    );
-    result.reduce();
-    return result;
-  }
-
-  toNumber() {
-    return this.numerator / this.denominator;
-  }
-
-  toJSON() {
-    return this.toNumber();
-  }
-}
+import {Fraction} from "./fraction";
 
 export class Offer {
   price: Fraction;
@@ -244,18 +187,4 @@ function invertPricePoints(prices: Map<number, Offer>) {
       ];
     })
   );
-}
-
-// https://github.com/AllAlgorithms/typescript/blob/master/math/gcd/gcd.ts
-function gcd(num1: number, num2: number): number {
-  if (num1 === 0 || num2 === 0) {
-    return 0;
-  }
-  if (num1 === num2) {
-    return num1;
-  }
-  if (num1 > num2) {
-    return gcd(num1 - num2, num2);
-  }
-  return gcd(num1, num2 - num1);
 }

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -1,4 +1,5 @@
-import {Offer, Orderbook, Fraction} from "../../src/orderbook";
+import {Offer, Orderbook} from "../../src/orderbook";
+import {Fraction} from "../../src/fraction";
 import {assert} from "chai";
 import "mocha";
 

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -1,17 +1,17 @@
-import {Offer, Orderbook, Price} from "../../src/orderbook";
+import {Offer, Orderbook, Fraction} from "../../src/orderbook";
 import {assert} from "chai";
 import "mocha";
 
 describe("Orderbook", () => {
   it("cummulates bids and asks sorted by best bid/best ask", () => {
     const orderbook = new Orderbook("USDC", "DAI");
-    orderbook.addAsk(new Offer(new Price(11, 10), 100));
-    orderbook.addAsk(new Offer(new Price(12, 10), 200));
-    orderbook.addAsk(new Offer(new Price(101, 100), 300));
+    orderbook.addAsk(new Offer(new Fraction(11, 10), 100));
+    orderbook.addAsk(new Offer(new Fraction(12, 10), 200));
+    orderbook.addAsk(new Offer(new Fraction(101, 100), 300));
 
-    orderbook.addBid(new Offer(new Price(9, 10), 50));
-    orderbook.addBid(new Offer(new Price(99, 100), 70));
-    orderbook.addBid(new Offer(new Price(9, 10), 30));
+    orderbook.addBid(new Offer(new Fraction(9, 10), 50));
+    orderbook.addBid(new Offer(new Fraction(99, 100), 70));
+    orderbook.addBid(new Offer(new Fraction(9, 10), 30));
 
     assert.equal(orderbook.baseToken, "USDC");
     assert.equal(orderbook.quoteToken, "DAI");
@@ -36,14 +36,14 @@ describe("Orderbook", () => {
     const orderbook = new Orderbook("USDC", "DAI");
 
     // Offering to sell 100 USDC for 2 DAI each, thus willing to buy 200 DAI for 50ç each
-    orderbook.addAsk(new Offer(new Price(2, 1), 100));
-    orderbook.addAsk(new Offer(new Price(1, 1), 200));
-    orderbook.addAsk(new Offer(new Price(4, 1), 300));
+    orderbook.addAsk(new Offer(new Fraction(2, 1), 100));
+    orderbook.addAsk(new Offer(new Fraction(1, 1), 200));
+    orderbook.addAsk(new Offer(new Fraction(4, 1), 300));
 
     // Offering to buy 50 USDC for 50ç each, thus willing to sell 25 DAI for 2 USDC each
-    orderbook.addBid(new Offer(new Price(1, 2), 50));
-    orderbook.addBid(new Offer(new Price(1, 4), 80));
-    orderbook.addBid(new Offer(new Price(1, 4), 20));
+    orderbook.addBid(new Offer(new Fraction(1, 2), 50));
+    orderbook.addBid(new Offer(new Fraction(1, 4), 80));
+    orderbook.addBid(new Offer(new Fraction(1, 4), 20));
 
     const inverse = orderbook.inverted();
 
@@ -88,16 +88,16 @@ describe("Orderbook", () => {
 
   it("can add another orderbook by combining bids and asks", () => {
     const first_orderbook = new Orderbook("USDC", "DAI");
-    first_orderbook.addAsk(new Offer(new Price(11, 10), 50));
-    first_orderbook.addAsk(new Offer(new Price(12, 10), 150));
-    first_orderbook.addBid(new Offer(new Price(9, 10), 50));
-    first_orderbook.addBid(new Offer(new Price(99, 100), 80));
+    first_orderbook.addAsk(new Offer(new Fraction(11, 10), 50));
+    first_orderbook.addAsk(new Offer(new Fraction(12, 10), 150));
+    first_orderbook.addBid(new Offer(new Fraction(9, 10), 50));
+    first_orderbook.addBid(new Offer(new Fraction(99, 100), 80));
 
     const second_orderbook = new Orderbook("USDC", "DAI");
-    second_orderbook.addAsk(new Offer(new Price(11, 10), 60));
-    second_orderbook.addAsk(new Offer(new Price(13, 10), 200));
-    second_orderbook.addBid(new Offer(new Price(9, 10), 50));
-    second_orderbook.addBid(new Offer(new Price(95, 100), 70));
+    second_orderbook.addAsk(new Offer(new Fraction(11, 10), 60));
+    second_orderbook.addAsk(new Offer(new Fraction(13, 10), 200));
+    second_orderbook.addBid(new Offer(new Fraction(9, 10), 50));
+    second_orderbook.addBid(new Offer(new Fraction(95, 100), 70));
 
     first_orderbook.add(second_orderbook);
 
@@ -129,18 +129,18 @@ describe("Orderbook", () => {
 
   it("Can compute the transitive closure of two orderbooks", () => {
     const first_orderbook = new Orderbook("ETH", "DAI");
-    first_orderbook.addBid(new Offer(new Price(90, 1), 3));
-    first_orderbook.addBid(new Offer(new Price(95, 1), 2));
-    first_orderbook.addBid(new Offer(new Price(99, 1), 1));
-    first_orderbook.addAsk(new Offer(new Price(101, 1), 2));
-    first_orderbook.addAsk(new Offer(new Price(105, 1), 1));
-    first_orderbook.addAsk(new Offer(new Price(110, 1), 3));
+    first_orderbook.addBid(new Offer(new Fraction(90, 1), 3));
+    first_orderbook.addBid(new Offer(new Fraction(95, 1), 2));
+    first_orderbook.addBid(new Offer(new Fraction(99, 1), 1));
+    first_orderbook.addAsk(new Offer(new Fraction(101, 1), 2));
+    first_orderbook.addAsk(new Offer(new Fraction(105, 1), 1));
+    first_orderbook.addAsk(new Offer(new Fraction(110, 1), 3));
 
     const second_orderbook = new Orderbook("DAI", "USDC");
-    second_orderbook.addBid(new Offer(new Price(9, 10), 200));
-    second_orderbook.addBid(new Offer(new Price(99, 100), 100));
-    second_orderbook.addAsk(new Offer(new Price(101, 100), 100));
-    second_orderbook.addAsk(new Offer(new Price(105, 100), 200));
+    second_orderbook.addBid(new Offer(new Fraction(99, 100), 100));
+    second_orderbook.addBid(new Offer(new Fraction(9, 10), 200));
+    second_orderbook.addAsk(new Offer(new Fraction(101, 100), 100));
+    second_orderbook.addAsk(new Offer(new Fraction(105, 100), 200));
 
     const closure = first_orderbook.transitiveClosure(second_orderbook);
 
@@ -149,21 +149,35 @@ describe("Orderbook", () => {
       JSON.stringify(closure.toJSON()),
       JSON.stringify({
         // The best bid eth_dai has enough liquidity on the best dai_usdc bid
-        // with 1 DAI remaining to be matched from the second best eth_dai bid.
-        // The remainder of the second best eth_dai pair gets matched with the second
-        // best dai_usdc pair, leaving 11 DAI for the worst eth_dai bid.
+        // with 1 DAI remaining to be matched from the second best eth_dai bid (190 DAI).
+        // The remainder of the second best eth_dai bid (189 DAI) gets matched with the second
+        // best dai_usdc bid (200 DAI), leaving 11 DAI for the worst eth_dai bid (270 DAI).
+        // The remaining 259 DAI are unmatchable.
         bids: [
           {price: 98.01, volume: 1}, // best eth_dai * best dai_usdc
-          {price: 94.05, volume: 1 / 94.05}, // 2nd best eth_dai * best dai_usdc
-          {price: 85.5, volume: 189 / 85.5}, // 2nd best eth_dai * 2nd best dai_usdc
-          {price: 81, volume: 11 / 81} // 3rd best eth_dai * 2nd best dai usdc
+          {price: 94.05, volume: 1 / 95}, // 2nd best eth_dai * best dai_usdc (190 & 1 DAI remaining at 95 DAI/ETH)
+          {price: 85.5, volume: 189 / 95}, // 2nd best eth_dai * 2nd best dai_usdc (189 & 200 DAI remaining at 95 DAI/ETH)
+          {price: 81, volume: 11 / 90} // 3rd best eth_dai * 2nd best dai usdc (270 & 11 DAI remaining at 90 DAI/ETH)
         ],
+        // The best ask eth_dai has more liquidity (202 DAI) than the best dai_usdc ask (100 DAI),
+        // with 102 DAI remaining to be matched from the second best dai_usdc ask (200 DAI).
+        // The remainder of the second best dai_usd ask (98 DAI) get matched with the second best
+        // eth_dai ask (105 DAI), leaving 7 DAI + the third best eth_dai ask (330 DAI) unmatchable.
         asks: [
-          {price: 102.01, volume: 100 / 102.01},
-          {price: 106.05, volume: 2 - 100 / 102.01},
-          {price: 110.25, volume: (200 - (2 - 100 / 102.01) * 106.05) / 110.25}
+          {price: 102.01, volume: 100 / 101}, // best eth_dai * best dai_usdc
+          {price: 106.05, volume: 102 / 101}, // best eth_dai * 2nd best dai_usdc
+          {price: 110.25, volume: 98 / 105} // 2nd best eth_dai * 2nd best dai_usdc
         ]
       })
     );
+  });
+
+  it("cannot compute the transitive closure for non-transient orderbooks pairs", () => {
+    const first_orderbook = new Orderbook("ETH", "DAI");
+    const second_orderbook = new Orderbook("USDC", "TUSD");
+
+    assert.throws(() => {
+      first_orderbook.transitiveClosure(second_orderbook);
+    });
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -63,5 +63,5 @@
     /* Advanced Options */
     "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts", "./node_modules/bn.js-typings/index.d.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -337,6 +337,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/bn.js@^4.11.6":
+  version "4.11.6"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.6.tgz#c306c70d9358aaea33cd4eda092a742b9505967c"
+  integrity sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/chai@^4.2.11":
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.11.tgz#d3614d6c5f500142358e6ed24e1bf16657536c50"


### PR DESCRIPTION
This PR finally adds the logic to compute the transitive closure of two "connecting" orderbooks (e.g. ETH/DAI & DAI/USDC => ETH/USDC).

I wrote the logic to combine all asks of two orderbooks. I then used inversion and addition to turn the bids into asks and reuse the same logic.

I also added a unit test with an extensive description on what is going on. For me, this was quite hard to grasp cognitively. I'm therefore worried that the review might be hard.

Please take some time to think this through and be generous with suggestions on how to make this easier to understand for future maintainers.

🙏 

In order to avoid rounding errors from multiple inversions I had to make the volume a Fraction (and ended up implementing a bunch of methods on this datatype). If it's easier I can factor this into its own PR.

### Test Plan

Unit test