### PR TITLE
[Orderbook] Allow to estimate prices on a given orderbook

### DIFF
--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -193,17 +193,17 @@ describe("Orderbook", () => {
     orderbook.addAsk(new Offer(new Fraction(105, 1), 1));
     orderbook.addAsk(new Offer(new Fraction(110, 1), 3));
 
-    it("returns best bid's price if buy volume is sufficient", () => {
+    it("returns best bid's price if bid volume is sufficient", () => {
       const price = orderbook.priceToSellBaseToken(1);
       assert.equal((price as Fraction).toNumber(), 99);
     });
 
-    it("returns n-th bid's for which biy volume is sufficient", () => {
+    it("returns n-th bid's for which cumulative bid volume is sufficient", () => {
       const price = orderbook.priceToSellBaseToken(4);
       assert.equal((price as Fraction).toNumber(), 90);
     });
 
-    it("returns undefined if there is not enough buy liquidity", () => {
+    it("returns undefined if there is not enough bid liquidity", () => {
       assert.isUndefined(orderbook.priceToSellBaseToken(7));
     });
 
@@ -212,12 +212,12 @@ describe("Orderbook", () => {
       assert.equal((price as Fraction).toNumber(), 101);
     });
 
-    it("returns n-th bid's for which biy volume is sufficient", () => {
+    it("returns n-th bid's for which cumulative ask volume is sufficient", () => {
       const price = orderbook.priceToBuyBaseToken(4);
       assert.equal((price as Fraction).toNumber(), 110);
     });
 
-    it("returns undefined if there is not enough sell liquidity", () => {
+    it("returns undefined if there is not enough ask liquidity", () => {
       assert.isUndefined(orderbook.priceToBuyBaseToken(7));
     });
   });

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -181,4 +181,44 @@ describe("Orderbook", () => {
       first_orderbook.transitiveClosure(second_orderbook);
     });
   });
+
+  describe("price estimation", () => {
+    const orderbook = new Orderbook("ETH", "DAI");
+
+    orderbook.addBid(new Offer(new Fraction(90, 1), 3));
+    orderbook.addBid(new Offer(new Fraction(95, 1), 2));
+    orderbook.addBid(new Offer(new Fraction(99, 1), 1));
+
+    orderbook.addAsk(new Offer(new Fraction(101, 1), 2));
+    orderbook.addAsk(new Offer(new Fraction(105, 1), 1));
+    orderbook.addAsk(new Offer(new Fraction(110, 1), 3));
+
+    it("returns best bid's price if buy volume is sufficient", () => {
+      const price = orderbook.priceToSellBaseToken(1);
+      assert.equal((price as Fraction).toNumber(), 99);
+    });
+
+    it("returns n-th bid's for which biy volume is sufficient", () => {
+      const price = orderbook.priceToSellBaseToken(4);
+      assert.equal((price as Fraction).toNumber(), 90);
+    });
+
+    it("returns undefined if there is not enough buy liquidity", () => {
+      assert.isUndefined(orderbook.priceToSellBaseToken(7));
+    });
+
+    it("returns best asks's price if ask volume is sufficient", () => {
+      const price = orderbook.priceToBuyBaseToken(1);
+      assert.equal((price as Fraction).toNumber(), 101);
+    });
+
+    it("returns n-th bid's for which biy volume is sufficient", () => {
+      const price = orderbook.priceToBuyBaseToken(4);
+      assert.equal((price as Fraction).toNumber(), 110);
+    });
+
+    it("returns undefined if there is not enough sell liquidity", () => {
+      assert.isUndefined(orderbook.priceToBuyBaseToken(7));
+    });
+  });
 });


### PR DESCRIPTION
This PR adds price estimation to the orderbook class. Given some instance (which could potentially have been computed from combining many transitive hulls) we iterate over the bids/asks until we have enough volume to match the desired amount. We then return that price.

### Test Plan

unit tests