### PR TITLE
[Orderbook] Reduce overlapping orderbooks

### DIFF
--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -104,6 +104,56 @@ export class Orderbook {
   }
 
   /**
+   * Removes any overlapping bid/asks which could be matched in the current orderbook
+   * @return A new instance of the orderbook with no more overlapping orders.
+   */
+  reduced() {
+    const result = new Orderbook(this.baseToken, this.quoteToken);
+
+    const bids = Array.from(this.bids.values());
+    bids.sort(sortOffersDescending);
+    const asks = Array.from(this.asks.values());
+    asks.sort(sortOffersAscending);
+
+    const bid_iterator = bids.values();
+    const ask_iterator = asks.values();
+
+    let best_bid = bid_iterator.next();
+    let best_ask = ask_iterator.next();
+    while (
+      !(best_bid.done || best_ask.done) &&
+      !best_bid.value.price.lt(best_ask.value.price)
+    ) {
+      // We have an overlapping bid/ask. Subtract the smaller from the larger and remove the smaller
+      if (best_bid.value.volume.gt(best_ask.value.volume)) {
+        best_bid.value.volume = best_bid.value.volume.sub(
+          best_ask.value.volume
+        );
+        best_ask = ask_iterator.next();
+      } else {
+        best_ask.value.volume = best_ask.value.volume.sub(
+          best_bid.value.volume
+        );
+        best_bid = bid_iterator.next();
+        // In case the orders matched perfectly we will move ask as well
+        if (best_ask.value.volume.isZero()) {
+          best_ask = ask_iterator.next();
+        }
+      }
+    }
+    //Add remaining bids/asks to result
+    while (!best_ask.done) {
+      result.addAsk(best_ask.value);
+      best_ask = ask_iterator.next();
+    }
+    while (!best_bid.done) {
+      result.addBid(best_bid.value);
+      best_bid = bid_iterator.next();
+    }
+    return result;
+  }
+
+  /**
    * Computes the transitive closure of this orderbook (e.g. ETH/DAI) with another one (e.g. DAI/USDC).
    * Throws if the orderbooks cannot be combined (baseToken is not equal to quoteToken)
    * @param orderbook The orderbook for which the transitive closure will be computed

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -126,13 +126,15 @@ export class Orderbook {
     ) {
       // We have an overlapping bid/ask. Subtract the smaller from the larger and remove the smaller
       if (best_bid.value.volume.gt(best_ask.value.volume)) {
-        best_bid.value.volume = best_bid.value.volume.sub(
-          best_ask.value.volume
+        best_bid.value = new Offer(
+          best_bid.value.price,
+          best_bid.value.volume.sub(best_ask.value.volume)
         );
         best_ask = ask_iterator.next();
       } else {
-        best_ask.value.volume = best_ask.value.volume.sub(
-          best_bid.value.volume
+        best_ask.value = new Offer(
+          best_ask.value.price,
+          best_ask.value.volume.sub(best_bid.value.volume)
         );
         best_bid = bid_iterator.next();
         // In case the orders matched perfectly we will move ask as well

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -221,4 +221,54 @@ describe("Orderbook", () => {
       assert.isUndefined(orderbook.priceToBuyBaseToken(7));
     });
   });
+
+  describe("reduce", () => {
+    it("returns an exact copy if orderbook is not overlapping", () => {
+      const orderbook = new Orderbook("ETH", "DAI");
+
+      orderbook.addBid(new Offer(new Fraction(95, 1), 2));
+      orderbook.addBid(new Offer(new Fraction(99, 1), 1));
+      orderbook.addAsk(new Offer(new Fraction(101, 1), 2));
+      orderbook.addAsk(new Offer(new Fraction(105, 1), 1));
+
+      assert.equal(
+        JSON.stringify(orderbook.reduced().toJSON()),
+        JSON.stringify(orderbook.toJSON())
+      );
+    });
+
+    it("reduces partially overlapping orderbooks", () => {
+      const orderbook = new Orderbook("ETH", "DAI");
+
+      orderbook.addBid(new Offer(new Fraction(101, 1), 2));
+      orderbook.addBid(new Offer(new Fraction(102, 1), 1));
+      orderbook.addAsk(new Offer(new Fraction(101, 1), 2));
+      orderbook.addAsk(new Offer(new Fraction(105, 1), 1));
+
+      assert.equal(
+        JSON.stringify(orderbook.reduced().toJSON()),
+        JSON.stringify({
+          bids: [{price: 101, volume: 1}],
+          asks: [{price: 105, volume: 1}]
+        })
+      );
+    });
+
+    it("reduces completely overlapping orderbooks", () => {
+      const orderbook = new Orderbook("ETH", "DAI");
+
+      orderbook.addBid(new Offer(new Fraction(101, 1), 2));
+      orderbook.addBid(new Offer(new Fraction(105, 1), 1));
+      orderbook.addAsk(new Offer(new Fraction(95, 1), 2));
+      orderbook.addAsk(new Offer(new Fraction(99, 1), 1));
+
+      assert.equal(
+        JSON.stringify(orderbook.reduced().toJSON()),
+        JSON.stringify({
+          bids: [],
+          asks: []
+        })
+      );
+    });
+  });
 });

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -270,5 +270,17 @@ describe("Orderbook", () => {
         })
       );
     });
+
+    it("does not modify original orderbook", () => {
+      const orderbook = new Orderbook("ETH", "DAI");
+
+      orderbook.addBid(new Offer(new Fraction(102, 1), 1));
+      orderbook.addAsk(new Offer(new Fraction(101, 1), 2));
+
+      const original_serialized = JSON.stringify(orderbook.toJSON());
+      orderbook.reduced();
+
+      assert.equal(JSON.stringify(orderbook.toJSON()), original_serialized);
+    });
   });
 });


### PR DESCRIPTION
This PR adds functionality to remove overlaps in orderbooks. This is useful when estimating prices as it can account for counter orders (which already remove liquidity)


### Test Plan

unit tests