### PR TITLE
[Fraction] Allow to convert large fractions to number

### DIFF
--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -64,15 +64,10 @@ export class Fraction {
   }
 
   toNumber() {
-    let numerator = this.numerator;
-    let denominator = this.denominator;
-    if (numerator.bitLength() > 53 || denominator.bitLength() > 53) {
-      const overhead =
-        Math.max(numerator.bitLength(), denominator.bitLength()) - 53;
-      numerator = numerator.shrn(overhead);
-      denominator = denominator.shrn(overhead);
-    }
-    return numerator.toNumber() / denominator.toNumber();
+    return (
+      parseInt(this.numerator.toString()) /
+      parseInt(this.denominator.toString())
+    );
   }
 
   toBN() {

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -64,7 +64,15 @@ export class Fraction {
   }
 
   toNumber() {
-    return this.numerator.toNumber() / this.denominator.toNumber();
+    let numerator = this.numerator;
+    let denominator = this.denominator;
+    if (numerator.bitLength() > 53 || denominator.bitLength() > 53) {
+      const overhead =
+        Math.max(numerator.bitLength(), denominator.bitLength()) - 53;
+      numerator = numerator.shrn(overhead);
+      denominator = denominator.shrn(overhead);
+    }
+    return numerator.toNumber() / denominator.toNumber();
   }
 
   toBN() {

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -26,9 +26,9 @@ export class Fraction {
   }
 
   reduce() {
-    const greatest_common_denominator = this.numerator.gcd(this.denominator);
-    this.numerator = this.numerator.div(greatest_common_denominator);
-    this.denominator = this.denominator.div(greatest_common_denominator);
+    const greatest_common_divisor = this.numerator.gcd(this.denominator);
+    this.numerator = this.numerator.div(greatest_common_divisor);
+    this.denominator = this.denominator.div(greatest_common_divisor);
   }
 
   inverted() {

--- a/test/models/fraction.spec.ts
+++ b/test/models/fraction.spec.ts
@@ -137,4 +137,15 @@ describe("Fraction", () => {
       assert.equal(f1.sub(f2).toNumber(), 0.00000001);
     });
   });
+
+  describe("toNumber", () => {
+    it("Can serialize large coprime Fractions", () => {
+      // Using two prime number ~10**18
+      const f = new Fraction(
+        new BN("1000000000000000003", 10),
+        new BN("1000000000000000009", 10)
+      );
+      assert.equal(f.toNumber(), 1);
+    });
+  });
 });

--- a/test/models/fraction.spec.ts
+++ b/test/models/fraction.spec.ts
@@ -148,7 +148,7 @@ describe("Fraction", () => {
       assert.equal(f.toNumber(), 1);
     });
 
-    it("Can serialize large number to Infinity", () => {
+    it("Can serialize large number", () => {
       const f = new Fraction(tenPow18, 1);
       assert.equal(f.toNumber(), 1e18);
     });

--- a/test/models/fraction.spec.ts
+++ b/test/models/fraction.spec.ts
@@ -147,5 +147,10 @@ describe("Fraction", () => {
       );
       assert.equal(f.toNumber(), 1);
     });
+
+    it("Can serialize large number to Infinity", () => {
+      const f = new Fraction(tenPow18, 1);
+      assert.equal(f.toNumber(), Infinity);
+    });
   });
 });

--- a/test/models/fraction.spec.ts
+++ b/test/models/fraction.spec.ts
@@ -150,7 +150,7 @@ describe("Fraction", () => {
 
     it("Can serialize large number to Infinity", () => {
       const f = new Fraction(tenPow18, 1);
-      assert.equal(f.toNumber(), Infinity);
+      assert.equal(f.toNumber(), 1e18);
     });
   });
 });


### PR DESCRIPTION
I was running into issue when trying to print prices after some operations saying that number can only safely store up to 53 bits.

This is when we multiply a bunch of prices that have no common denominator. In this case it probably makes sense to shift the numbers by the amount of bits they have too many and then divide the remaingin (approximated amount). Since this is only used to get a number approximation that should be fine.

### Test Plan

Added unit test with two large primes.