### PR TITLE
Adding a script to estimate prices

### DIFF
--- a/scripts/stablex/transitive_orderbook.js
+++ b/scripts/stablex/transitive_orderbook.js
@@ -1,0 +1,115 @@
+const BatchExchangeViewer = artifacts.require("BatchExchangeViewer")
+const { decodeOrdersBN } = require("../../src/encoding.js")
+const BN = require("bn.js")
+
+const { Orderbook, Offer } = require("../../typescript/common/orderbook.js")
+const { Fraction } = require("../../typescript/common/fraction.js")
+
+const argv = require("yargs")
+  .option("sellToken", {
+    describe: "the token you are looking to sell",
+  })
+  .option("buyToken", {
+    describe: "the token you are looking to sell",
+  })
+  .option("sellAmount", {
+    describe: "the amount you are looking to sell",
+  })
+  .option("pageSize", {
+    default: 100,
+    describe: "The page  size for the function getOrdersPaginated",
+  })
+  .demand(["sellToken", "buyToken", "sellAmount"])
+  .version(false).argv
+
+const addItemToOrderbooks = function(orderbooks, item) {
+  let orderbook = new Orderbook(item.sellToken, item.buyToken)
+  if (!orderbooks.has(orderbook.pair())) {
+    orderbooks.set(orderbook.pair(), orderbook)
+  }
+  orderbook = orderbooks.get(orderbook.pair())
+  const price = new Fraction(item.priceNumerator, item.priceDenominator)
+  const volume = new Fraction(item.remainingAmount.gt(item.sellTokenBalance) ? item.sellTokenBalance : item.remainingAmount, 1)
+  // Smaller orders cannot be matched anyways
+  if (volume.gt(new Fraction(10000, 1))) {
+    orderbook.addAsk(new Offer(price, volume))
+  }
+}
+
+const getAllOrderbooks = async function(instance, pageSize) {
+  let nextPageUser = "0x0000000000000000000000000000000000000000"
+  let nextPageUserOffset = 0
+  let lastPageSize = pageSize
+
+  const orderbooks = new Map() // Mapping orderbook.pair => {bids, asks}
+
+  while (lastPageSize == pageSize) {
+    console.log("Fetching Page")
+    const page = await instance.getOpenOrderBookPaginated([], nextPageUser, nextPageUserOffset, pageSize)
+    const elements = decodeOrdersBN(page.elements)
+    // Split elements in buy and sell
+    elements.forEach(item => {
+      addItemToOrderbooks(orderbooks, item)
+    })
+
+    //Update page info
+    lastPageSize = elements.length
+    nextPageUser = page.nextPageUser
+    nextPageUserOffset = page.nextPageUserOffset
+  }
+  return orderbooks
+}
+
+const transitiveOrderbook = function(orderbooks, start, end) {
+  const result = new Orderbook(start, end)
+  // Add the direct book if it exists
+  if (orderbooks.has(result.pair)) {
+    result.add(orderbooks.get(result.pair))
+  }
+
+  // Check for each orderbook that starts with same baseToken, if there exists a connecting book.
+  // If yes, build transitive closure
+  orderbooks.forEach(book => {
+    const otherBook = orderbooks.get(new Orderbook(book.quoteToken, end).pair())
+    if (book.baseToken === start && otherBook) {
+      const closure = book.transitiveClosure(otherBook)
+      result.add(closure)
+    }
+  })
+  return result
+}
+
+module.exports = async callback => {
+  try {
+    const sellAmount = new BN(argv.sellAmount)
+    const instance = await BatchExchangeViewer.deployed()
+    const orderbooks = await getAllOrderbooks(instance, argv.pageSize)
+
+    // complete ask-only orderbooks with bid information
+    for (const [, book] of orderbooks) {
+      if (!orderbooks.has(book.inverted().pair())) {
+        const empty_book = new Orderbook(book.quoteToken, book.baseToken)
+        orderbooks.set(empty_book.pair(), empty_book)
+      }
+    }
+    for (const [pair, book] of orderbooks) {
+      const inverse = book.inverted()
+      const inverse_pair = inverse.pair()
+
+      // Only update one of the two sides
+      if (pair > inverse_pair) {
+        orderbooks.get(inverse_pair).add(inverse)
+        orderbooks.set(pair, orderbooks.get(inverse_pair).inverted())
+      }
+    }
+
+    const transitive_book = transitiveOrderbook(orderbooks, argv.sellToken, argv.buyToken)
+    const price = transitive_book.priceToSellBaseToken(sellAmount)
+    console.log(
+      `Suggested price to sell ${argv.sellAmount} of token ${argv.sellToken} for token ${argv.buyToken} is: ${price.toNumber()}`
+    )
+    callback()
+  } catch (error) {
+    callback(error)
+  }
+}

--- a/scripts/stablex/transitive_orderbook.js
+++ b/scripts/stablex/transitive_orderbook.js
@@ -1,5 +1,5 @@
 const BatchExchangeViewer = artifacts.require("BatchExchangeViewer")
-const { decodeOrdersBN } = require("../../src/encoding.js")
+const { getOpenOrdersPaginated } = require("./utilities.js")
 const BN = require("bn.js")
 
 const { Orderbook, Offer } = require("../../typescript/common/orderbook.js")
@@ -37,26 +37,11 @@ const addItemToOrderbooks = function(orderbooks, item) {
 }
 
 const getAllOrderbooks = async function(instance, pageSize) {
-  let nextPageUser = "0x0000000000000000000000000000000000000000"
-  let nextPageUserOffset = 0
-  let lastPageSize = pageSize
-
-  const orderbooks = new Map() // Mapping orderbook.pair => {bids, asks}
-
-  while (lastPageSize == pageSize) {
-    console.log("Fetching Page")
-    const page = await instance.getOpenOrderBookPaginated([], nextPageUser, nextPageUserOffset, pageSize)
-    const elements = decodeOrdersBN(page.elements)
-    // Split elements in buy and sell
-    elements.forEach(item => {
-      addItemToOrderbooks(orderbooks, item)
-    })
-
-    //Update page info
-    lastPageSize = elements.length
-    nextPageUser = page.nextPageUser
-    nextPageUserOffset = page.nextPageUserOffset
-  }
+  const elements = await getOpenOrdersPaginated(instance, pageSize)
+  const orderbooks = new Map()
+  elements.forEach(item => {
+    addItemToOrderbooks(orderbooks, item)
+  })
   return orderbooks
 }
 

--- a/scripts/stablex/transitive_orderbook.js
+++ b/scripts/stablex/transitive_orderbook.js
@@ -63,8 +63,8 @@ const getAllOrderbooks = async function(instance, pageSize) {
 const transitiveOrderbook = function(orderbooks, start, end) {
   const result = new Orderbook(start, end)
   // Add the direct book if it exists
-  if (orderbooks.has(result.pair)) {
-    result.add(orderbooks.get(result.pair))
+  if (orderbooks.has(result.pair())) {
+    result.add(orderbooks.get(result.pair()))
   }
 
   // Check for each orderbook that starts with same baseToken, if there exists a connecting book.

--- a/scripts/stablex/utilities.js
+++ b/scripts/stablex/utilities.js
@@ -120,6 +120,27 @@ const getOrdersPaginated = async (instance, pageSize) => {
   return orders
 }
 
+const getOpenOrdersPaginated = async function(instance, pageSize) {
+  const { decodeOrdersBN } = require("../../src/encoding")
+  let orders = []
+  let nextPageUser = "0x0000000000000000000000000000000000000000"
+  let nextPageUserOffset = 0
+  let lastPageSize = pageSize
+
+  while (lastPageSize == pageSize) {
+    console.log("Fetching Page")
+    const page = await instance.getOpenOrderBookPaginated([], nextPageUser, nextPageUserOffset, pageSize)
+    const elements = decodeOrdersBN(page.elements)
+    orders = orders.concat(elements)
+
+    //Update page info
+    lastPageSize = elements.length
+    nextPageUser = page.nextPageUser
+    nextPageUserOffset = page.nextPageUserOffset
+  }
+  return orders
+}
+
 const sendLiquidityOrders = async function(
   instance,
   tokenIds,
@@ -261,6 +282,7 @@ module.exports = {
   fetchTokenInfo,
   sendLiquidityOrders,
   getOrdersPaginated,
+  getOpenOrdersPaginated,
   maxUint32,
   setAllowances,
   mintOwl,


### PR DESCRIPTION
The day has finally come. This is a script that estimates prices based on the transitive closure as computated by the orderbook class.

We basically fetch all currently active orders and create all possible orderbooks. We then find all orderbooks "in between" our sell and buy token (e.g. DAI for WETH would look at DAI/CHAI CHAIWETH, DAI/USDC USDC/WETH etc).
We sum app all the transitive closures (each of which represent part of the DAI/WETH liquidity) and then run our price estimation against the combined orderbook.

### Test Plan

```
export GAS_LIMIT=500000000
yarn tsc:commonjs
npx truffle exec scripts/stablex/transitive_orderbook.js --network mainnet --sellToken 7 --buyToken 1 --sellAmount 2000000000000000000000 --pageSize 50
```

This will tell you the price for selling 2000 DAI for ETH on current mainnet