### PR TITLE
Move transitive orderbook logic to typescript

### DIFF
--- a/scripts/stablex/transitive_orderbook.js
+++ b/scripts/stablex/transitive_orderbook.js
@@ -26,7 +26,7 @@ const argv = require("yargs")
   .demand(["sellToken", "buyToken", "sellAmount"])
   .version(false).argv
 
-const addItemToOrderbooks = function(orderbooks, item) {
+const addItemToOrderbooks = function (orderbooks, item) {
   let orderbook = new Orderbook(item.sellToken, item.buyToken)
   if (!orderbooks.has(orderbook.pair())) {
     orderbooks.set(orderbook.pair(), orderbook)
@@ -40,16 +40,16 @@ const addItemToOrderbooks = function(orderbooks, item) {
   }
 }
 
-const getAllOrderbooks = async function(instance, pageSize) {
+const getAllOrderbooks = async function (instance, pageSize) {
   const elements = await getOpenOrdersPaginated(instance, pageSize)
   const orderbooks = new Map()
-  elements.forEach(item => {
+  elements.forEach((item) => {
     addItemToOrderbooks(orderbooks, item)
   })
   return orderbooks
 }
 
-module.exports = async callback => {
+module.exports = async (callback) => {
   try {
     const sellAmount = new BN(argv.sellAmount)
     const instance = await BatchExchangeViewer.deployed()

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -380,7 +380,7 @@ describe("Orderbook", () => {
 
 describe("transitiveOrderbook", () => {
   it("computes transitive orderbook with 0 hops", () => {
-    const orderbook = new Orderbook("DAI", "USDC");
+    const orderbook = new Orderbook("DAI", "USDC", new Fraction(0, 1));
     orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
 
     const transitive = transitiveOrderbook(
@@ -394,13 +394,13 @@ describe("transitiveOrderbook", () => {
   });
 
   it("computes transitive orderbook with 1 hop", () => {
-    const direct = new Orderbook("DAI", "ETH");
+    const direct = new Orderbook("DAI", "ETH", new Fraction(0, 1));
     direct.addAsk(new Offer(new Fraction(1, 80), 80));
 
-    const first_orderbook = new Orderbook("DAI", "USDC");
+    const first_orderbook = new Orderbook("DAI", "USDC", new Fraction(0, 1));
     first_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
 
-    const second_orderbook = new Orderbook("USDC", "ETH");
+    const second_orderbook = new Orderbook("USDC", "ETH", new Fraction(0, 1));
     second_orderbook.addAsk(new Offer(new Fraction(1, 100), 100));
 
     const transitive = transitiveOrderbook(
@@ -427,16 +427,16 @@ describe("transitiveOrderbook", () => {
   });
 
   it("computes transitive orderbook with 2 hop", () => {
-    const direct = new Orderbook("DAI", "ETH");
+    const direct = new Orderbook("DAI", "ETH", new Fraction(0, 1));
     direct.addAsk(new Offer(new Fraction(1, 80), 80));
 
-    const first_orderbook = new Orderbook("DAI", "USDC");
+    const first_orderbook = new Orderbook("DAI", "USDC", new Fraction(0, 1));
     first_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
 
-    const second_orderbook = new Orderbook("USDC", "USDT");
+    const second_orderbook = new Orderbook("USDC", "USDT", new Fraction(0, 1));
     second_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
 
-    const third_orderbook = new Orderbook("USDT", "ETH");
+    const third_orderbook = new Orderbook("USDT", "ETH", new Fraction(0, 1));
     third_orderbook.addAsk(new Offer(new Fraction(1, 100), 100));
 
     const transitive = transitiveOrderbook(
@@ -464,10 +464,10 @@ describe("transitiveOrderbook", () => {
   });
 
   it("computes transitive orderbook from bids and asks", () => {
-    const first_orderbook = new Orderbook("DAI", "USDC");
+    const first_orderbook = new Orderbook("DAI", "USDC", new Fraction(0, 1));
     first_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
 
-    const second_orderbook = new Orderbook("ETH", "USDC");
+    const second_orderbook = new Orderbook("ETH", "USDC", new Fraction(0, 1));
     second_orderbook.addBid(new Offer(new Fraction(100, 1), 1));
 
     const transitive = transitiveOrderbook(

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -1,4 +1,4 @@
-import {Offer, Orderbook} from "../../src/orderbook";
+import {Offer, Orderbook, transitiveOrderbook} from "../../src/orderbook";
 import {Fraction} from "../../src/fraction";
 import {assert} from "chai";
 import "mocha";
@@ -375,5 +375,117 @@ describe("Orderbook", () => {
         })
       );
     });
+  });
+});
+
+describe("transitiveOrderbook", () => {
+  it("computes transitive orderbook with 0 hops", () => {
+    const orderbook = new Orderbook("DAI", "USDC");
+    orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
+
+    const transitive = transitiveOrderbook(
+      new Map([[orderbook.pair(), orderbook]]),
+      "DAI",
+      "USDC",
+      0
+    );
+
+    assert.equal(JSON.stringify(orderbook), JSON.stringify(transitive));
+  });
+
+  it("computes transitive orderbook with 1 hop", () => {
+    const direct = new Orderbook("DAI", "ETH");
+    direct.addAsk(new Offer(new Fraction(1, 80), 80));
+
+    const first_orderbook = new Orderbook("DAI", "USDC");
+    first_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
+
+    const second_orderbook = new Orderbook("USDC", "ETH");
+    second_orderbook.addAsk(new Offer(new Fraction(1, 100), 100));
+
+    const transitive = transitiveOrderbook(
+      new Map([
+        [direct.pair(), direct],
+        [first_orderbook.pair(), first_orderbook],
+        [second_orderbook.pair(), second_orderbook]
+      ]),
+      "DAI",
+      "ETH",
+      1
+    );
+
+    assert.equal(
+      JSON.stringify(transitive),
+      JSON.stringify({
+        bids: [],
+        asks: [
+          {price: 0.01, volume: 100},
+          {price: 0.0125, volume: 80}
+        ]
+      })
+    );
+  });
+
+  it("computes transitive orderbook with 2 hop", () => {
+    const direct = new Orderbook("DAI", "ETH");
+    direct.addAsk(new Offer(new Fraction(1, 80), 80));
+
+    const first_orderbook = new Orderbook("DAI", "USDC");
+    first_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
+
+    const second_orderbook = new Orderbook("USDC", "USDT");
+    second_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
+
+    const third_orderbook = new Orderbook("USDT", "ETH");
+    third_orderbook.addAsk(new Offer(new Fraction(1, 100), 100));
+
+    const transitive = transitiveOrderbook(
+      new Map([
+        [direct.pair(), direct],
+        [first_orderbook.pair(), first_orderbook],
+        [second_orderbook.pair(), second_orderbook],
+        [third_orderbook.pair(), third_orderbook]
+      ]),
+      "DAI",
+      "ETH",
+      2
+    );
+
+    assert.equal(
+      JSON.stringify(transitive),
+      JSON.stringify({
+        bids: [],
+        asks: [
+          {price: 0.01, volume: 100},
+          {price: 0.0125, volume: 80}
+        ]
+      })
+    );
+  });
+
+  it("computes transitive orderbook from bids and asks", () => {
+    const first_orderbook = new Orderbook("DAI", "USDC");
+    first_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
+
+    const second_orderbook = new Orderbook("ETH", "USDC");
+    second_orderbook.addBid(new Offer(new Fraction(100, 1), 1));
+
+    const transitive = transitiveOrderbook(
+      new Map([
+        [first_orderbook.pair(), first_orderbook],
+        [second_orderbook.pair(), second_orderbook]
+      ]),
+      "DAI",
+      "ETH",
+      1
+    );
+
+    assert.equal(
+      JSON.stringify(transitive),
+      JSON.stringify({
+        bids: [],
+        asks: [{price: 0.01, volume: 100}]
+      })
+    );
   });
 });


### PR DESCRIPTION
This PR move the logic for computing the transitive orderbook from the js script to the orderbook class so it is exported and can be reused in other projects.

Specifically I'm planning to use it in the price estimation service.

### TestPlan

Added unit tests to ensure the computation is right.