### PR TITLE
Export orderbook logic in top level npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "ts": "yarn run ts-contracts && yarn run ts-check && yarn run tsc:commonjs && yarn run tsc:esm",
     "tsc:commonjs": "rimraf typescript/common && tsc --outDir typescript/common",
     "tsc:esm": "rimraf typescript/esm && tsc -m es6 -t esnext --outDir typescript/esm",
-    "ts-check": "tsc src/index.d.ts",
-    "ts-contracts": "typechain --target web3-v1 --outDir build/types build/contracts/{BatchExchange,SnappAuction}.json",
+    "ts-check": "tsc --esModuleInterop --noEmit src/index.d.ts",
+    "ts-contracts": "typechain --target web3-v1 --outDir build/types \"build/contracts/{BatchExchange,SnappAuction,BatchExchangeViewer}.json\"",
     "ganache": "ganache-cli -h 0.0.0.0 --gasLimit 8e6 --deterministic"
   },
   "repository": {
@@ -41,6 +41,7 @@
   },
   "files": [
     "build/contracts/BatchExchange.json",
+    "build/contracts/BatchExchangeViewer.json",
     "build/contracts/EpochTokenLocker.json",
     "build/contracts/IERC20.json",
     "build/contracts/Migrations.json",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -71,10 +71,10 @@ export interface Order {
 export interface OrderBN {
   user: string;
   sellTokenBalance: BN;
-  buyToken: string;
-  sellToken: string;
-  validFrom: string;
-  validUntil: string;
+  buyToken: number;
+  sellToken: number;
+  validFrom: number;
+  validUntil: number;
   priceNumerator: BN;
   priceDenominator: BN;
   remainingAmount: BN;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,7 @@
+import BN from "bn.js";
+export * from "./orderbook";
+export * from "./fraction";
+
 export interface ContractAbiEntry {
   type: string;
   name?: string;
@@ -53,15 +57,28 @@ export declare const BatchExchange: ContractArtifact;
 export declare const SnappAuction: ContractArtifact;
 
 export interface Order {
-  user: string,
-  sellTokenBalance: string,
-  buyToken: string,
-  sellToken: string,
-  validFrom: string,
-  validUntil: string,
-  priceNumerator: string,
-  priceDenominator: string,
-  remainingAmount: string,
+  user: string;
+  sellTokenBalance: string;
+  buyToken: string;
+  sellToken: string;
+  validFrom: string;
+  validUntil: string;
+  priceNumerator: string;
+  priceDenominator: string;
+  remainingAmount: string;
+}
+
+export interface OrderBN {
+  user: string;
+  sellTokenBalance: BN;
+  buyToken: string;
+  sellToken: string;
+  validFrom: string;
+  validUntil: string;
+  priceNumerator: BN;
+  priceDenominator: BN;
+  remainingAmount: BN;
 }
 
 export declare function decodeOrders(bytes: string): Order[];
+export declare function decodeOrdersBN(bytes: string): OrderBN[];

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@
 
 module.exports = {
   BatchExchange: require("../build/contracts/BatchExchange.json"),
+  BatchExchangeViewer: require("../build/contracts/BatchExchangeViewer.json"),
   SnappAuction: require("../build/contracts/SnappAuction.json"),
   ...require("./encoding.js"),
 }


### PR DESCRIPTION
This PR makes it so that we export all the relevant components to use the transitive orderbook in another repo.

### Test Plan

I used [yalc](https://www.npmjs.com/package/yalc) to dryrun a v0.2.5 release locally

`yalc publish`

Then inside the dependent repo, run:

`yalc add @gnosis.pm/dex-contracts && yarn install`

And make sure everything you need is exported correctly.