### PR TITLE
[Trivial] Version bump to v0.2.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "module": "typescript/esm/index.js",


### PR DESCRIPTION
We need to release a new version so that the price estimation logic is available via npm to be used in the dex-price-estimation service.

### Test Plan

CI