### PR TITLE
More exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "module": "typescript/esm/index.js",
   "jsnext:main": "typescript/esm/index.js",
-  "types": "typescript/esm/index.d.ts",
+  "types": "src/index.d.ts",
   "directories": {
     "test": "test"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -10,5 +10,7 @@ module.exports = {
   BatchExchange: require("../build/contracts/BatchExchange.json"),
   BatchExchangeViewer: require("../build/contracts/BatchExchangeViewer.json"),
   SnappAuction: require("../build/contracts/SnappAuction.json"),
+  ...require("../typescript/common/fraction.js"),
+  ...require("../typescript/common/orderbook.js"),
   ...require("./encoding.js"),
 }

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -1,5 +1,6 @@
 import {Fraction} from "./fraction";
 import BN from "bn.js";
+import {Order} from ".";
 
 export class Offer {
   price: Fraction;
@@ -97,10 +98,10 @@ export class Orderbook {
         `Cannot add ${orderbook.pair()} orderbook to ${this.pair()} orderbook`
       );
     }
-    orderbook.bids.forEach((bid) => {
+    orderbook.bids.forEach(bid => {
       addOffer(bid, this.bids);
     });
-    orderbook.asks.forEach((ask) => {
+    orderbook.asks.forEach(ask => {
       addOffer(ask, this.asks);
     });
   }
@@ -273,7 +274,7 @@ export function transitiveOrderbook(
   hops: number
 ) {
   const complete_orderbooks = new Map();
-  direct_orderbooks.forEach((book) => {
+  direct_orderbooks.forEach(book => {
     complete_orderbooks.set(book.pair(), book);
     // If inverse pair doesn't exist we will create an empty one
     if (!direct_orderbooks.has(book.inverted().pair())) {
@@ -326,7 +327,7 @@ function transitiveOrderbookRecursive(
 
   // Check for each orderbook that starts with same baseToken, if there exists a connecting book.
   // If yes, build transitive closure
-  orderbooks.forEach((book) => {
+  orderbooks.forEach(book => {
     if (
       book.baseToken === base &&
       !(book.quoteToken === quote) &&
@@ -395,7 +396,7 @@ function invertPricePoints(
       const inverted_volume = offer.volume.mul(price_before_fee);
       return [
         inverted_price.toNumber(),
-        new Offer(inverted_price, inverted_volume),
+        new Offer(inverted_price, inverted_volume)
       ];
     })
   );

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -1,6 +1,5 @@
 import {Fraction} from "./fraction";
 import BN from "bn.js";
-import {Order} from ".";
 
 export class Offer {
   price: Fraction;
@@ -98,10 +97,10 @@ export class Orderbook {
         `Cannot add ${orderbook.pair()} orderbook to ${this.pair()} orderbook`
       );
     }
-    orderbook.bids.forEach(bid => {
+    orderbook.bids.forEach((bid) => {
       addOffer(bid, this.bids);
     });
-    orderbook.asks.forEach(ask => {
+    orderbook.asks.forEach((ask) => {
       addOffer(ask, this.asks);
     });
   }
@@ -274,7 +273,7 @@ export function transitiveOrderbook(
   hops: number
 ) {
   const complete_orderbooks = new Map();
-  direct_orderbooks.forEach(book => {
+  direct_orderbooks.forEach((book) => {
     complete_orderbooks.set(book.pair(), book);
     // If inverse pair doesn't exist we will create an empty one
     if (!direct_orderbooks.has(book.inverted().pair())) {
@@ -327,7 +326,7 @@ function transitiveOrderbookRecursive(
 
   // Check for each orderbook that starts with same baseToken, if there exists a connecting book.
   // If yes, build transitive closure
-  orderbooks.forEach(book => {
+  orderbooks.forEach((book) => {
     if (
       book.baseToken === base &&
       !(book.quoteToken === quote) &&
@@ -396,7 +395,7 @@ function invertPricePoints(
       const inverted_volume = offer.volume.mul(price_before_fee);
       return [
         inverted_price.toNumber(),
-        new Offer(inverted_price, inverted_volume)
+        new Offer(inverted_price, inverted_volume),
       ];
     })
   );


### PR DESCRIPTION
It turns out we need to provide expose the top level types.d.ts for it to be recognized in `dex-price-estimator` and also expose the compiled js files so that they can be found when ts is transpiled to js.

### Test Plan

`yalc publish`

in dependent repo

`yalc add @gnosis.pm/dex-contracts`

Make sure we can import and actually instantiate Fraction and Orderbook types.