### PR TITLE
Need to include transpiled js artifacts in final build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "module": "typescript/esm/index.js",
@@ -50,6 +50,7 @@
     "build/contracts/SnappBaseCore.json",
     "build/contracts/TokenConservation.json",
     "build/types",
+    "typescript/common",
     "networks.json",
     "src"
   ],


### PR DESCRIPTION
v0.2.5 was bad (I deprecated it) because it was missing the transpiled orderbook.js file. I'm not sure why it was working when using yalc locally. I assume it is some kind of caching issue.

### Test Plan

yalc publish and verify that `typescript/common/{orderbook|fraction}.js` are present