### PR TITLE
Query onchain orders without concatenating buffer

### DIFF
--- a/.solhintignore
+++ b/.solhintignore
@@ -1,4 +1,6 @@
 contracts/Migrations.sol
+contracts/BatchExchangeViewer.sol
+
 .solhint.json
 .solhintignore
 .soliumignore

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -172,11 +172,7 @@ contract BatchExchangeViewer {
                 }
             }
         }
-        //setLength(elements, index * AUCTION_ELEMENT_WIDTH);
-        uint256 total = index * AUCTION_ELEMENT_WIDTH;
-        assembly {
-            mstore(elements, total)
-        }
+        setLength(elements, index * AUCTION_ELEMENT_WIDTH);
         return elements;
     }
 

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -260,6 +260,11 @@ contract BatchExchangeViewer {
         return updateSellTokenBalance(element, sellTokenBalance);
     }
 
+    /**
+     * @dev Sets the length of the given buffer (truncating any items exceeding the length).
+     * Note, that this can lead to memory leakage or undefined behavior if length  is larger than the size
+     * that was originally allocated by the buffer.
+     */
     function setLength(bytes memory buffer, uint256 length) public pure {
         assembly {
             mstore(buffer, length)

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -27,6 +27,7 @@ contract BatchExchangeViewer {
      */
     function getOpenOrderBook(address[] memory tokenFilter) public view returns (bytes memory) {
         (bytes memory elements, , ) = getOpenOrderBookPaginated(tokenFilter, address(0), 0, LARGE_PAGE_SIZE);
+        require(elements.length < LARGE_PAGE_SIZE * AUCTION_ELEMENT_WIDTH, "Orderbook too large, use paginated view functions");
         return elements;
     }
 
@@ -62,6 +63,7 @@ contract BatchExchangeViewer {
      */
     function getFinalizedOrderBook(address[] memory tokenFilter) public view returns (bytes memory) {
         (bytes memory elements, , ) = getFinalizedOrderBookPaginated(tokenFilter, address(0), 0, LARGE_PAGE_SIZE);
+        require(elements.length < LARGE_PAGE_SIZE * AUCTION_ELEMENT_WIDTH, "Orderbook too large, use paginated view functions");
         return elements;
     }
 

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.10;
+pragma solidity ^0.5.0;
 
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -145,6 +145,13 @@ contract BatchExchangeViewer {
         return (elements, nextPageUser, nextPageUserOffset);
     }
 
+    /** @dev View returning byte-encoded sell orders in paginated form. It has the same behavior as
+     * BatchExchange.getEncodedUsersPaginated but uses less memory and thus is more gas efficient.
+     * @param previousPageUser address of last user received in the previous page (address(0) for first page)
+     * @param previousPageUserOffset the number of orders received for the last user on the previous page (0 for first page).
+     * @param pageSize uint determining the count of orders to be returned per page
+     * @return encoded bytes representing a page of orders ordered by (user, index)
+     */
     function getEncodedOrdersPaginated(address previousPageUser, uint16 previousPageUserOffset, uint256 pageSize)
         public
         view

--- a/test/stablex/batch_exchange_viewer.js
+++ b/test/stablex/batch_exchange_viewer.js
@@ -2,12 +2,16 @@ const BatchExchange = artifacts.require("BatchExchange")
 const BatchExchangeViewer = artifacts.require("BatchExchangeViewer")
 const MockContract = artifacts.require("MockContract")
 
+const BN = require("bn.js")
+
 const { decodeOrdersBN } = require("../../src/encoding")
 const { closeAuction } = require("../../scripts/stablex/utilities.js")
+const { setupGenericStableX } = require("./stablex_utils")
 
 const zero_address = "0x0000000000000000000000000000000000000000"
 
 contract("BatchExchangeViewer", (accounts) => {
+  const [user_1, user_2, user_3] = accounts
   let batchExchange, token_1, token_2
   beforeEach(async () => {
     const feeToken = await MockContract.new()
@@ -214,6 +218,110 @@ contract("BatchExchangeViewer", (accounts) => {
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
       const result = decodeOrdersBN(await viewer.getFinalizedOrderBook([token_1.address, token_2.address]))
       assert.equal(result.filter((e) => e.validFrom == batchId).length, 5)
+    })
+  })
+
+  describe("getEncodedOrdersPaginated", async () => {
+    it("returns empty bytes when no users", async () => {
+      const batchExchange = await setupGenericStableX()
+      const viewer = await BatchExchangeViewer.new(batchExchange.address)
+
+      const auctionElements = await viewer.getEncodedOrdersPaginated(zero_address, 0, 10)
+      assert.equal(auctionElements, null)
+    })
+    it("returns three orders one per page", async () => {
+      const batchExchange = await setupGenericStableX(3)
+      const viewer = await BatchExchangeViewer.new(batchExchange.address)
+
+      const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
+      await batchExchange.placeOrder(0, 1, batchId + 10, 100, 100, { from: user_1 })
+      await batchExchange.placeOrder(1, 2, batchId + 10, 100, 100, { from: user_1 })
+      await batchExchange.placeOrder(0, 1, batchId + 10, 100, 100, { from: user_2 })
+
+      const firstPage = decodeOrdersBN(await viewer.getEncodedOrdersPaginated(zero_address, 0, 1))
+      assert.equal(
+        JSON.stringify(firstPage),
+        JSON.stringify([
+          {
+            user: user_1.toLowerCase(),
+            sellTokenBalance: new BN(0),
+            buyToken: 0,
+            sellToken: 1,
+            validFrom: batchId,
+            validUntil: batchId + 10,
+            priceNumerator: new BN(100),
+            priceDenominator: new BN(100),
+            remainingAmount: new BN(100),
+          },
+        ])
+      )
+
+      const secondPage = decodeOrdersBN(await viewer.getEncodedOrdersPaginated(user_1, 1, 1))
+      assert.equal(
+        JSON.stringify(secondPage),
+        JSON.stringify([
+          {
+            user: user_1.toLowerCase(),
+            sellTokenBalance: new BN(0),
+            buyToken: 1,
+            sellToken: 2,
+            validFrom: batchId,
+            validUntil: batchId + 10,
+            priceNumerator: new BN(100),
+            priceDenominator: new BN(100),
+            remainingAmount: new BN(100),
+          },
+        ])
+      )
+
+      const thirdPage = decodeOrdersBN(await viewer.getEncodedOrdersPaginated(user_1, 2, 1))
+      assert.equal(
+        JSON.stringify(thirdPage),
+        JSON.stringify([
+          {
+            user: user_2.toLowerCase(),
+            sellTokenBalance: new BN(0),
+            buyToken: 0,
+            sellToken: 1,
+            validFrom: batchId,
+            validUntil: batchId + 10,
+            priceNumerator: new BN(100),
+            priceDenominator: new BN(100),
+            remainingAmount: new BN(100),
+          },
+        ])
+      )
+
+      // 4th page is empty
+      assert.equal(await viewer.getEncodedOrdersPaginated(user_2, 1, 1), null)
+    })
+    it("returns three orders when page size is overlapping users", async () => {
+      const batchExchange = await setupGenericStableX(3)
+      const viewer = await BatchExchangeViewer.new(batchExchange.address)
+
+      const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
+      await batchExchange.placeOrder(0, 1, batchId + 10, 100, 100, { from: user_1 })
+      await batchExchange.placeOrder(1, 2, batchId + 10, 100, 100, { from: user_1 })
+      await batchExchange.placeOrder(0, 1, batchId + 10, 100, 100, { from: user_2 })
+
+      const page = decodeOrdersBN(await viewer.getEncodedOrdersPaginated(user_1, 1, 2))
+      assert.equal(page[0].user, user_1.toLowerCase())
+      assert.equal(page[1].user, user_2.toLowerCase())
+    })
+    it("returns three orders from three users with larger page size", async () => {
+      const batchExchange = await setupGenericStableX(3)
+      const viewer = await BatchExchangeViewer.new(batchExchange.address)
+
+      const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
+      await batchExchange.placeOrder(0, 1, batchId + 10, 100, 100, { from: user_1 })
+      await batchExchange.placeOrder(1, 2, batchId + 10, 100, 100, { from: user_2 })
+      await batchExchange.placeOrder(0, 1, batchId + 10, 100, 100, { from: user_3 })
+
+      const page = decodeOrdersBN(await viewer.getEncodedOrdersPaginated(zero_address, 0, 5))
+      assert.equal(page.length, 3)
+      assert.equal(page[0].user, user_1.toLowerCase())
+      assert.equal(page[1].user, user_2.toLowerCase())
+      assert.equal(page[2].user, user_3.toLowerCase())
     })
   })
 })

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -16,7 +16,7 @@ if (!privateKey && !mnemonic) {
 
 // Solc
 let solcUseDocker = process.env.SOLC_USE_DOCKER === "true" || false
-let solcVersion = "<0.5.11"
+let solcVersion = "<0.5.7"
 
 // Gas price
 const gasPriceGWei = process.env.GAS_PRICE_GWEI || DEFAULT_GAS_PRICE_GWEI

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -16,7 +16,7 @@ if (!privateKey && !mnemonic) {
 
 // Solc
 let solcUseDocker = process.env.SOLC_USE_DOCKER === "true" || false
-let solcVersion = "<0.5.7"
+let solcVersion = "<0.5.11"
 
 // Gas price
 const gasPriceGWei = process.env.GAS_PRICE_GWEI || DEFAULT_GAS_PRICE_GWEI


### PR DESCRIPTION
Follow up for #577 

This PR makes it so that we allocate a fixed sized buffer for our encoded order data instead of concatenating our results with each other (which turned out to copy a lot of memory consuming a ton of gas).

We can mutate a specific byte in the pre-allocated buffer using `buffer[index]` and in the end "fix" the resulting buffers length property using assembly (trimming the pre-allocated array to the actual size).

The results are a ~8x increase in query capacity per page (rinkeby currently has 2700 orders which we can query using 300/500 million available gas). The gas consumption now has a much more linear shape:

<img width="583" alt="Screen Shot 2020-03-30 at 19 55 15" src="https://user-images.githubusercontent.com/1200333/77945106-6874e500-72c0-11ea-96f0-16363047ccce.png">

### Test Plan

I copied the unit tests from the unoptimized `getEncodedUsers/OrdersPaginated` from `BatchExchange` + changed the filtered orderbook method to reuse the optimized one and making sure all other unit tests still work.