### PR TITLE
Make transitive orderbook calculation not mutate underlying book

### DIFF
--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -77,4 +77,8 @@ export class Fraction {
   toJSON() {
     return this.toNumber();
   }
+
+  clone() {
+    return new Fraction(this.numerator.clone(), this.denominator.clone());
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,8 +9,8 @@
 module.exports = {
   BatchExchange: require("../build/contracts/BatchExchange.json"),
   BatchExchangeViewer: require("../build/contracts/BatchExchangeViewer.json"),
-  ...require("../build/common/fraction.js"),
-  ...require("../build/common/orderbook.js"),
+  ...require("../build/common/src/fraction.js"),
+  ...require("../build/common/src/orderbook.js"),
   ...require("./encoding.js"),
   ...require("./onchain_reading.js"),
 }

--- a/test/models/fraction.spec.ts
+++ b/test/models/fraction.spec.ts
@@ -117,10 +117,7 @@ describe("Fraction", () => {
       const f2 = new Fraction(tenPow18, tenPow18);
 
       assert.equal(
-        f1
-          .sub(f2)
-          .toBN()
-          .toString(),
+        f1.sub(f2).toBN().toString(),
         tenPow18.sub(new BN(1)).toString()
       );
     });
@@ -151,6 +148,17 @@ describe("Fraction", () => {
     it("Can serialize large number", () => {
       const f = new Fraction(tenPow18, 1);
       assert.equal(f.toNumber(), 1e18);
+    });
+  });
+
+  describe("clone", () => {
+    it("creates a deep copy", () => {
+      const original = new Fraction(1, 2);
+      const serialized = JSON.stringify(original);
+
+      const clone = original.clone();
+      clone.mul(new Fraction(1, 2));
+      assert.equal(JSON.stringify(original), serialized);
     });
   });
 });


### PR DESCRIPTION
There is a bug in the transitive orderbook-computation in that it has side-effects on the underlying orderbook, which was noticed by @alfetopito when reviewing https://github.com/gnosis/dex-react/pull/813.

To see the bug in action checkout https://czii9.csb.app/ and "reload" the orderbook for e.g. ETH<->DAI multiple times. You will see that the orderbook is changing on each load.

The reason is that our transitive orderbook computation has sideffects to the underlying datastructure.

In this PR I'm removing those side effects and adding unit tests to make sure our operations don't have any unless desired (e.g `orderbook.add`)

I briefly experimented with making the bid/ask map a readonly property but typescript will still allow me to mutate its contents via `get/set`, thus it doesn't solve the underlying problem here.

The main contribution is a `clone()` method on our datatypes which allows to make deep copies of orderbooks/offers/prices when desired.

### Test Plan

Added unit tests + yalcing the patched version into the price estimator where I also added an e2e test making sure that two consecutive queries return the same orderbook.