### PR TITLE
[Viewer] Stop fetching more sub-pages when running low on gas

### DIFF
--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -26,7 +26,7 @@ contract BatchExchangeViewer {
      *  @return encoded bytes representing orders, maxed at 5000 elements
      */
     function getOpenOrderBook(address[] memory tokenFilter) public view returns (bytes memory) {
-        (bytes memory elements, , ) = getOpenOrderBookPaginated(tokenFilter, address(0), 0, LARGE_PAGE_SIZE);
+        (bytes memory elements, , , ) = getOpenOrderBookPaginated(tokenFilter, address(0), 0, LARGE_PAGE_SIZE);
         require(elements.length < LARGE_PAGE_SIZE * AUCTION_ELEMENT_WIDTH, "Orderbook too large, use paginated view functions");
         return elements;
     }
@@ -35,15 +35,15 @@ contract BatchExchangeViewer {
      *  @param tokenFilter all returned order will have buy *and* sell token from this list (leave empty for "no filter")
      *  @param previousPageUser address taken from nextPageUser return value from last page (address(0) for first page)
      *  @param previousPageUserOffset offset taken nextPageUserOffset return value from last page (0 for first page)
-     *  @param pageSize count of elements to be returned per page (same value is used for subqueries on the exchange)
+     *  @param maxPageSize count of elements to be returned per page (same value is used for subqueries on the exchange)
      *  @return encoded bytes representing orders and page information for next page
      */
     function getOpenOrderBookPaginated(
         address[] memory tokenFilter,
         address previousPageUser,
         uint16 previousPageUserOffset,
-        uint16 pageSize
-    ) public view returns (bytes memory elements, address nextPageUser, uint16 nextPageUserOffset) {
+        uint16 maxPageSize
+    ) public view returns (bytes memory elements, bool hasNextPage, address nextPageUser, uint16 nextPageUserOffset) {
         uint32 batch = batchExchange.getCurrentBatchId();
         return
             getFilteredOrdersPaginated(
@@ -53,7 +53,7 @@ contract BatchExchangeViewer {
                 getTokenIdsFromAdresses(tokenFilter),
                 previousPageUser,
                 previousPageUserOffset,
-                pageSize
+                maxPageSize
             );
     }
 
@@ -62,7 +62,7 @@ contract BatchExchangeViewer {
      *  @return encoded bytes representing orders, maxed at 5000 elements
      */
     function getFinalizedOrderBook(address[] memory tokenFilter) public view returns (bytes memory) {
-        (bytes memory elements, , ) = getFinalizedOrderBookPaginated(tokenFilter, address(0), 0, LARGE_PAGE_SIZE);
+        (bytes memory elements, , , ) = getFinalizedOrderBookPaginated(tokenFilter, address(0), 0, LARGE_PAGE_SIZE);
         require(elements.length < LARGE_PAGE_SIZE * AUCTION_ELEMENT_WIDTH, "Orderbook too large, use paginated view functions");
         return elements;
     }
@@ -71,15 +71,15 @@ contract BatchExchangeViewer {
      *  @param tokenFilter all returned order will have buy *and* sell token from this list (leave empty for "no filter")
      *  @param previousPageUser address taken from nextPageUser return value from last page (address(0) for first page)
      *  @param previousPageUserOffset offset taken nextPageUserOffset return value from last page (0 for first page)
-     *  @param pageSize count of elements to be returned per page (same value is used for subqueries on the exchange)
+     *  @param maxPageSize count of elements to be returned per page (same value is used for subqueries on the exchange)
      *  @return encoded bytes representing orders and page information for next page
      */
     function getFinalizedOrderBookPaginated(
         address[] memory tokenFilter,
         address previousPageUser,
         uint16 previousPageUserOffset,
-        uint16 pageSize
-    ) public view returns (bytes memory elements, address nextPageUser, uint16 nextPageUserOffset) {
+        uint16 maxPageSize
+    ) public view returns (bytes memory elements, bool hasNextPage, address nextPageUser, uint16 nextPageUserOffset) {
         uint32 batch = batchExchange.getCurrentBatchId();
         return
             getFilteredOrdersPaginated(
@@ -89,7 +89,7 @@ contract BatchExchangeViewer {
                 getTokenIdsFromAdresses(tokenFilter),
                 previousPageUser,
                 previousPageUserOffset,
-                pageSize
+                maxPageSize
             );
     }
 
@@ -101,8 +101,9 @@ contract BatchExchangeViewer {
      *  @param tokenFilter all returned order will have buy *and* sell token from this list (leave empty for "no filter")
      *  @param previousPageUser address taken from nextPageUser return value from last page (address(0) for first page)
      *  @param previousPageUserOffset offset taken nextPageUserOffset return value from last page (0 for first page)
-     *  @param pageSize count of elements to be returned per page (same value is used for subqueries on the exchange)
-     *  @return encoded bytes representing orders and page information for next page
+     *  @param maxPageSize maximum count of elements to be returned per page (same value is used for subqueries on the exchange)
+     *  @return encoded bytes representing orders and page information for next page. Result can contain less elements than
+     *  maxPageSize if remaining gas is low.
      */
     function getFilteredOrdersPaginated(
         uint32 maxValidFrom,
@@ -111,14 +112,17 @@ contract BatchExchangeViewer {
         uint16[] memory tokenFilter,
         address previousPageUser,
         uint16 previousPageUserOffset,
-        uint16 pageSize
-    ) public view returns (bytes memory elements, address nextPageUser, uint16 nextPageUserOffset) {
+        uint16 maxPageSize
+    ) public view returns (bytes memory elements, bool hasNextPage, address nextPageUser, uint16 nextPageUserOffset) {
         nextPageUser = previousPageUser;
         nextPageUserOffset = previousPageUserOffset;
-        bool hasNextPage = true;
-        while (hasNextPage) {
-            bytes memory unfiltered = getEncodedOrdersPaginated(nextPageUser, nextPageUserOffset, pageSize);
-            hasNextPage = unfiltered.length / AUCTION_ELEMENT_WIDTH == pageSize;
+        hasNextPage = true;
+        uint256 gasLeftBeforePage = gasleft();
+        // Continue while more pages exist or we used more than 1/2 of remaining gas in previous page
+        while (hasNextPage && 2 * gasleft() > gasLeftBeforePage) {
+            gasLeftBeforePage = gasleft();
+            bytes memory unfiltered = getEncodedOrdersPaginated(nextPageUser, nextPageUserOffset, maxPageSize);
+            hasNextPage = unfiltered.length / AUCTION_ELEMENT_WIDTH == maxPageSize;
             for (uint16 index = 0; index < unfiltered.length / AUCTION_ELEMENT_WIDTH; index++) {
                 // make sure we don't overflow index * AUCTION_ELEMENT_WIDTH
                 bytes memory element = unfiltered.slice(uint256(index) * AUCTION_ELEMENT_WIDTH, AUCTION_ELEMENT_WIDTH);
@@ -138,32 +142,32 @@ contract BatchExchangeViewer {
                     nextPageUserOffset = 1;
                     nextPageUser = user;
                 }
-                if (elements.length / AUCTION_ELEMENT_WIDTH >= pageSize) {
+                if (elements.length / AUCTION_ELEMENT_WIDTH >= maxPageSize) {
                     // We are at capacity, return
-                    return (elements, nextPageUser, nextPageUserOffset);
+                    return (elements, hasNextPage, nextPageUser, nextPageUserOffset);
                 }
             }
         }
-        return (elements, nextPageUser, nextPageUserOffset);
+        return (elements, hasNextPage, nextPageUser, nextPageUserOffset);
     }
 
     /** @dev View returning byte-encoded sell orders in paginated form. It has the same behavior as
      * BatchExchange.getEncodedUsersPaginated but uses less memory and thus is more gas efficient.
      * @param previousPageUser address of last user received in the previous page (address(0) for first page)
      * @param previousPageUserOffset the number of orders received for the last user on the previous page (0 for first page).
-     * @param pageSize uint determining the count of orders to be returned per page
+     * @param maxPageSize uint determining the count of orders to be returned per page
      * @return encoded bytes representing a page of orders ordered by (user, index)
      */
-    function getEncodedOrdersPaginated(address previousPageUser, uint16 previousPageUserOffset, uint256 pageSize)
+    function getEncodedOrdersPaginated(address previousPageUser, uint16 previousPageUserOffset, uint256 maxPageSize)
         public
         view
         returns (bytes memory)
     {
-        bytes memory elements = new bytes(pageSize * AUCTION_ELEMENT_WIDTH);
+        bytes memory elements = new bytes(maxPageSize * AUCTION_ELEMENT_WIDTH);
         uint16 currentOffset = previousPageUserOffset;
         uint256 index = 0;
         address currentUser = previousPageUser;
-        while (index < pageSize) {
+        while (index < maxPageSize) {
             bytes memory element = batchExchange.getEncodedUserOrdersPaginated(currentUser, currentOffset, 1);
             if (element.length > 0) {
                 currentOffset += 1;

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -155,19 +155,19 @@ contract BatchExchangeViewer {
      * BatchExchange.getEncodedUsersPaginated but uses less memory and thus is more gas efficient.
      * @param previousPageUser address of last user received in the previous page (address(0) for first page)
      * @param previousPageUserOffset the number of orders received for the last user on the previous page (0 for first page).
-     * @param maxPageSize uint determining the count of orders to be returned per page
+     * @param pageSize uint determining the count of orders to be returned per page
      * @return encoded bytes representing a page of orders ordered by (user, index)
      */
-    function getEncodedOrdersPaginated(address previousPageUser, uint16 previousPageUserOffset, uint256 maxPageSize)
+    function getEncodedOrdersPaginated(address previousPageUser, uint16 previousPageUserOffset, uint256 pageSize)
         public
         view
         returns (bytes memory)
     {
-        bytes memory elements = new bytes(maxPageSize * AUCTION_ELEMENT_WIDTH);
+        bytes memory elements = new bytes(pageSize * AUCTION_ELEMENT_WIDTH);
         uint16 currentOffset = previousPageUserOffset;
         uint256 index = 0;
         address currentUser = previousPageUser;
-        while (index < maxPageSize) {
+        while (index < pageSize) {
             bytes memory element = batchExchange.getEncodedUserOrdersPaginated(currentUser, currentOffset, 1);
             if (element.length > 0) {
                 currentOffset += 1;

--- a/src/onchain_reading.js
+++ b/src/onchain_reading.js
@@ -8,15 +8,15 @@ const { decodeOrdersBN } = require("./encoding")
 const getOpenOrdersPaginated = async function* (contract, pageSize) {
   let nextPageUser = "0x0000000000000000000000000000000000000000"
   let nextPageUserOffset = 0
-  let lastPageSize = pageSize
+  let hasNextPage = true
 
-  while (lastPageSize == pageSize) {
+  while (hasNextPage) {
     const page = await contract.methods.getOpenOrderBookPaginated([], nextPageUser, nextPageUserOffset, pageSize).call()
     const elements = decodeOrdersBN(page.elements)
     yield elements
 
     //Update page info
-    lastPageSize = elements.length
+    hasNextPage = page.hasNextPage
     nextPageUser = page.nextPageUser
     nextPageUserOffset = page.nextPageUserOffset
   }


### PR DESCRIPTION
We are running into issues when paginating over filtering BatchExchangeViewer methods such as `getOpenOrderBookPaginated`. The reason is that in order to fill an entire pageSize (e.g. 100) we might have to do many subqueries to the unfiltered `getEncodedOrdersPaginated`. This can make us run out of gas even for small page sizes if one account (e.g. our e2e test account on rinkeby or the EFrontier account on mainnet) has a lot of expired orders which don't match our filter.

This PR therefore changes the logic to make `pageSize` a `maxPageSize` and measure in each loop how much gas was used for the subquery. If the last call used more than half of the remaining gas it is unlikely that another iteration is not possible and we return early with what we have found so far.

Note, that this requires to add another flag to the returned page information as we can no longer count the elements returned and compare it to the page size.

An alternative implementation could hard-code the page size for the subquery based on the amount of `gasleft()` but this would require careful estimation of the gas cost which and might be brittle to changes in gas cost per operation (cf. Istanbul increase for SLOAD operation).

### Test Plan

To see the difference between the old and the new implementation, do the following:

```bash
npx truffle migrate -f 3 --network rinkeby
npx truffle console --network rinkeby
```
In the console:
```js
let viewer = await BatchExchangeViewer.deployed()
let old = await BatchExchangeViewer.at("0x3Cc80340Cb9C2C865c44b0f491968ACb9EaD2b48") // current version on rinkeby
await old.getOpenOrderBookPaginated([], "0x0000000000000000000000000000000000000000", 0, 50) // this will run out of gas
await viewer.getOpenOrderBookPaginated([], "0x0000000000000000000000000000000000000000", 0, 50) // this will work
```