### PR TITLE
Add region to travis S3 deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ deploy:
   secret_access_key: $AWS_SECRET_ACCESS_KEY
   local_dir: deploy
   skip_cleanup: true
+  region: $AWS_REGION
   on:
     tags: true
 after_deploy:


### PR DESCRIPTION
Set region for S3.
Requires set `AWS_REGION` on Travis.