### PR TITLE
[Bugfix] Make decodeOrders work on empty bytes/null

### DIFF
--- a/src/encoding.js
+++ b/src/encoding.js
@@ -17,6 +17,9 @@ const BN = require("bn.js")
  * @return {Object[]} The decoded array of orders
  */
 function decodeOrders(bytes) {
+  if (!bytes) {
+    return []
+  }
   assert(typeof bytes === "string" || bytes instanceof String, "bytes parameter must be a string")
   assert((bytes.length - 2) % 112 === 0, "malformed bytes")
 

--- a/src/encoding.js
+++ b/src/encoding.js
@@ -17,7 +17,7 @@ const BN = require("bn.js")
  * @return {Object[]} The decoded array of orders
  */
 function decodeOrders(bytes) {
-  if (!bytes) {
+  if (bytes === null || bytes === undefined || bytes.length === 0) {
     return []
   }
   assert(typeof bytes === "string" || bytes instanceof String, "bytes parameter must be a string")


### PR DESCRIPTION
As our orderbooks get more sparse in terms of valid orders (EFrontier and synthetix market making bot) are constantly placing orders that are only valid for one batch, the method `getOpenOrderbookPaginated` might return completely empty pages (just progressing the page information).

This currently leads to invoking the `decodeOrder` with `null` which tuns into the following error:

> Failed to fetch Orderbooks: AssertionError [ERR_ASSERTION]: bytes parameter must be a string

This PR makes it so that we can decode an empty payload into an empty array of orders.

### Test Plan

Make sure that we can fetch the full orderbook at the moment with a page size of 500.