### PR TITLE
Bump dex-contracts deployment pipeline to v0.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,6 @@ after_deploy:
   - >
     curl -X POST
     -F "token=$GITLAB_TOKEN"
-    -F "ref=v0.1.1"
+    -F "ref=v0.1.2"
     -F "variables[PACKAGE_VERSION]=$PACKAGE_VERSION"
     https://gitlab.gnosisdev.com/api/v4/projects/$GITLAB_PROJECT/trigger/pipeline


### PR DESCRIPTION
This fixes the issues with the deployment still using the incorrect AWS region.

### Test Plan

Deploy a new version and have it deploy automatically.