### PR TITLE
Bump dex-contract to 0.2.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "module": "build/esm/index.js",


### PR DESCRIPTION
This version bump includes an important fix to the order element decoding so that it can accept empty order elements which happens on some pages where all the orders are expired.