### PR TITLE
Make Orderbook serializable

### DIFF
--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -154,19 +154,11 @@ export class Fraction {
     return this.numerator.div(this.denominator);
   }
 
-  toJSON() {
-    return this.toNumber();
-  }
-
   clone() {
     return new Fraction(this.numerator.clone(), this.denominator.clone());
   }
 
-  serialize(): object {
-    return { numerator: this.numerator.toJSON(), denominator: this.denominator.toJSON() };
-  }
-
-  static deserialize(o: any): Fraction {
+  static fromJSON(o: any): Fraction {
     const numerator = new BN(o.numerator, "hex");
     const denominator = new BN(o.denominator, "hex");
     return new Fraction(numerator, denominator);

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -161,4 +161,14 @@ export class Fraction {
   clone() {
     return new Fraction(this.numerator.clone(), this.denominator.clone());
   }
+
+  serialize(): object {
+    return { numerator: this.numerator.toJSON(), denominator: this.denominator.toJSON() };
+  }
+
+  static deserialize(o: any): Fraction {
+    const numerator = new BN(o.numerator, "hex");
+    const denominator = new BN(o.denominator, "hex");
+    return new Fraction(numerator, denominator);
+  }
 }

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -23,9 +23,8 @@ export class Offer {
   }
 }
 
-type OrderbookOptions =
-  { fee: Fraction } |
-  { fee: undefined, remainingFractionAfterFee: Fraction }
+type Fee = { fee: Fraction };
+type RemainingFractionAfterFee = { remainingFractionAfterFee: Fraction }
 
 export class Orderbook {
   readonly baseToken: string;
@@ -37,11 +36,11 @@ export class Orderbook {
   constructor(
     baseToken: string,
     quoteToken: string,
-    options: OrderbookOptions = { fee: new Fraction(1, 1000) },
+    options: Fee | RemainingFractionAfterFee = { fee: new Fraction(1, 1000) },
   ) {
     this.baseToken = baseToken;
     this.quoteToken = quoteToken;
-    if (options.fee != undefined) {
+    if ("fee" in options) {
       this.remainingFractionAfterFee = new Fraction(1, 1).sub(options.fee);
     } else {
       this.remainingFractionAfterFee = options.remainingFractionAfterFee;
@@ -83,7 +82,7 @@ export class Orderbook {
   }
 
   static fromJSON(o: any): Orderbook {
-    const result = new Orderbook(o.baseToken, o.quoteToken, { fee: undefined, remainingFractionAfterFee: Fraction.fromJSON(o.remainingFractionAfterFee) });
+    const result = new Orderbook(o.baseToken, o.quoteToken, { remainingFractionAfterFee: Fraction.fromJSON(o.remainingFractionAfterFee) });
     result.asks = Orderbook.offersFromJSON(o.asks);
     result.bids = Orderbook.offersFromJSON(o.bids);
     return result;

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -41,9 +41,11 @@ export class Orderbook {
   ) {
     this.baseToken = baseToken;
     this.quoteToken = quoteToken;
-    this.remainingFractionAfterFee = options.fee ?
-      new Fraction(1, 1).sub(options.fee) :
-      options.remainingFractionAfterFee;
+    if (options.fee != undefined) {
+      this.remainingFractionAfterFee = new Fraction(1, 1).sub(options.fee);
+    } else {
+      this.remainingFractionAfterFee = options.remainingFractionAfterFee;
+    }
     this.asks = new Map();
     this.bids = new Map();
   }

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -57,34 +57,20 @@ export class Orderbook {
     return { bids, asks };
   }
 
-  static offersToJSON(offers: Map<number, Offer>): object {
-    const o: any = {};
-    offers.forEach((value, key) => { o[key] = value; });
-    return o;
-  }
-
-  private static offersFromJSON(o: any): Map<number, Offer> {
-    const offers = new Map();
-    for (let [key, value] of Object.entries(o)) {
-      offers.set(key, Offer.fromJSON(value));
-    }
-    return offers;
-  }
-
   toJSON() {
     return {
       baseToken: this.baseToken,
       quoteToken: this.quoteToken,
       remainingFractionAfterFee: this.remainingFractionAfterFee,
-      asks: Orderbook.offersToJSON(this.asks),
-      bids: Orderbook.offersToJSON(this.bids)
+      asks: offersToJSON(this.asks),
+      bids: offersToJSON(this.bids)
     };
   }
 
   static fromJSON(o: any): Orderbook {
     const result = new Orderbook(o.baseToken, o.quoteToken, { remainingFractionAfterFee: Fraction.fromJSON(o.remainingFractionAfterFee) });
-    result.asks = Orderbook.offersFromJSON(o.asks);
-    result.bids = Orderbook.offersFromJSON(o.bids);
+    result.asks = offersFromJSON(o.asks);
+    result.bids = offersFromJSON(o.bids);
     return result;
   }
 
@@ -448,4 +434,19 @@ function invertPricePoints(
       ];
     })
   );
+}
+
+
+function offersFromJSON(o: any): Map<number, Offer> {
+  const offers = new Map();
+  for (let [key, value] of Object.entries(o)) {
+    offers.set(key, Offer.fromJSON(value));
+  }
+  return offers;
+}
+
+function offersToJSON(offers: Map<number, Offer>): object {
+  const o: any = {};
+  offers.forEach((value, key) => { o[key] = value; });
+  return o;
 }

--- a/test/models/fraction.spec.ts
+++ b/test/models/fraction.spec.ts
@@ -1,6 +1,6 @@
-import {Fraction} from "../../src/fraction";
+import { Fraction } from "../../src/fraction";
 import BN from "bn.js";
-import {assert} from "chai";
+import { assert } from "chai";
 import "mocha";
 
 const tenPow18 = new BN(10).pow(new BN(18));
@@ -185,7 +185,7 @@ describe("Fraction", () => {
           expected: new Fraction(2, 1)
         }
       ];
-      for (const {number, expected} of testCases)
+      for (const { number, expected } of testCases)
         assert(
           Fraction.fromNumber(number)
             .sub(expected)
@@ -249,11 +249,11 @@ describe("Fraction", () => {
     });
   });
 
-  describe("serialize", () => {
-    it("can be deserialized", () => {
+  describe("fromJSON", () => {
+    it("works", () => {
       const original = new Fraction(10, 1);
-      const serialized = JSON.stringify(original.serialize());
-      const deserialized = Fraction.deserialize(JSON.parse(serialized));
+      const serialized = JSON.stringify(original);
+      const deserialized = Fraction.fromJSON(JSON.parse(serialized));
       assert.equal(JSON.stringify(original), JSON.stringify(deserialized));
     });
   });

--- a/test/models/fraction.spec.ts
+++ b/test/models/fraction.spec.ts
@@ -248,4 +248,13 @@ describe("Fraction", () => {
       assert.equal(JSON.stringify(original), serialized);
     });
   });
+
+  describe("serialize", () => {
+    it("can be deserialized", () => {
+      const original = new Fraction(10, 1);
+      const serialized = JSON.stringify(original.serialize());
+      const deserialized = Fraction.deserialize(JSON.parse(serialized));
+      assert.equal(JSON.stringify(original), JSON.stringify(deserialized));
+    });
+  });
 });

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -432,6 +432,25 @@ describe("Orderbook", () => {
       assert.notDeepEqual(copy, orderbook);
     });
   });
+
+  describe("serialize", () => {
+    it("can be deserialized", () => {
+      const original = new Orderbook("USDC", "DAI", new Fraction(0, 1));
+      original.addAsk(new Offer(new Fraction(11, 10), 100));
+      original.addAsk(new Offer(new Fraction(12, 10), 200));
+      original.addAsk(new Offer(new Fraction(101, 100), 300));
+      original.addBid(new Offer(new Fraction(9, 10), 50));
+      original.addBid(new Offer(new Fraction(99, 100), 70));
+      original.addBid(new Offer(new Fraction(9, 10), 30));
+
+      const serialized = JSON.stringify(original.serialize());
+      const deserialized = Orderbook.deserialize(JSON.parse(serialized));
+      assert.equal(original.baseToken, deserialized.baseToken);
+      assert.equal(original.quoteToken, deserialized.quoteToken);
+      assert.equal(JSON.stringify(original.remainingFractionAfterFee), JSON.stringify(deserialized.remainingFractionAfterFee));
+      assert.equal(JSON.stringify(original), JSON.stringify(deserialized));
+    });
+  });
 });
 
 describe("transitiveOrderbook", () => {

--- a/test/models/orderbook.spec.ts
+++ b/test/models/orderbook.spec.ts
@@ -19,7 +19,7 @@ function assertOffers(orderbook: Orderbook, bids: [Number, Number][], asks: [Num
 
 describe("Orderbook", () => {
   it("cummulates bids and asks sorted by best bid/best ask", () => {
-    const orderbook = new Orderbook("USDC", "DAI", new Fraction(0, 1));
+    const orderbook = new Orderbook("USDC", "DAI", { fee: new Fraction(0, 1) });
     orderbook.addAsk(new Offer(new Fraction(11, 10), 100));
     orderbook.addAsk(new Offer(new Fraction(12, 10), 200));
     orderbook.addAsk(new Offer(new Fraction(101, 100), 300));
@@ -36,7 +36,7 @@ describe("Orderbook", () => {
 
   describe("inverted", () => {
     it("inverts by switching bid/asks and inverting prices", () => {
-      const orderbook = new Orderbook("USDC", "DAI", new Fraction(0, 1));
+      const orderbook = new Orderbook("USDC", "DAI", { fee: new Fraction(0, 1) });
 
       // Offering to sell 100 USDC for 2 DAI each, thus willing to buy 200 DAI for 50ç each
       orderbook.addAsk(new Offer(new Fraction(2, 1), 100));
@@ -62,7 +62,7 @@ describe("Orderbook", () => {
     });
 
     it("does not mutate original orderbook", () => {
-      const orderbook = new Orderbook("USDC", "DAI", new Fraction(0, 1));
+      const orderbook = new Orderbook("USDC", "DAI", { fee: new Fraction(0, 1) });
       orderbook.addAsk(new Offer(new Fraction(2, 1), 100));
       orderbook.addBid(new Offer(new Fraction(1, 4), 20));
 
@@ -74,13 +74,13 @@ describe("Orderbook", () => {
 
   describe("add", () => {
     it("can add another orderbook by combining bids and asks", () => {
-      const first_orderbook = new Orderbook("USDC", "DAI", new Fraction(0, 1));
+      const first_orderbook = new Orderbook("USDC", "DAI", { fee: new Fraction(0, 1) });
       first_orderbook.addAsk(new Offer(new Fraction(11, 10), 50));
       first_orderbook.addAsk(new Offer(new Fraction(12, 10), 150));
       first_orderbook.addBid(new Offer(new Fraction(9, 10), 50));
       first_orderbook.addBid(new Offer(new Fraction(99, 100), 80));
 
-      const second_orderbook = new Orderbook("USDC", "DAI", new Fraction(0, 1));
+      const second_orderbook = new Orderbook("USDC", "DAI", { fee: new Fraction(0, 1) });
       second_orderbook.addAsk(new Offer(new Fraction(11, 10), 60));
       second_orderbook.addAsk(new Offer(new Fraction(13, 10), 200));
       second_orderbook.addBid(new Offer(new Fraction(9, 10), 50));
@@ -102,7 +102,7 @@ describe("Orderbook", () => {
   });
   describe("transitive closure", () => {
     it("Can compute the transitive closure of two orderbooks", () => {
-      const first_orderbook = new Orderbook("ETH", "DAI", new Fraction(0, 1));
+      const first_orderbook = new Orderbook("ETH", "DAI", { fee: new Fraction(0, 1) });
       first_orderbook.addBid(new Offer(new Fraction(90, 1), 3));
       first_orderbook.addBid(new Offer(new Fraction(95, 1), 2));
       first_orderbook.addBid(new Offer(new Fraction(99, 1), 1));
@@ -110,7 +110,7 @@ describe("Orderbook", () => {
       first_orderbook.addAsk(new Offer(new Fraction(105, 1), 1));
       first_orderbook.addAsk(new Offer(new Fraction(110, 1), 3));
 
-      const second_orderbook = new Orderbook("DAI", "USDC", new Fraction(0, 1));
+      const second_orderbook = new Orderbook("DAI", "USDC", { fee: new Fraction(0, 1) });
       second_orderbook.addBid(new Offer(new Fraction(99, 100), 100));
       second_orderbook.addBid(new Offer(new Fraction(9, 10), 200));
       second_orderbook.addAsk(new Offer(new Fraction(101, 100), 100));
@@ -143,7 +143,7 @@ describe("Orderbook", () => {
     });
 
     it("does not modify the original orderbook when computing the closure", () => {
-      const first_orderbook = new Orderbook("ETH", "DAI", new Fraction(0, 1));
+      const first_orderbook = new Orderbook("ETH", "DAI", { fee: new Fraction(0, 1) });
       first_orderbook.addBid(new Offer(new Fraction(90, 1), 3));
       first_orderbook.addBid(new Offer(new Fraction(95, 1), 2));
       first_orderbook.addBid(new Offer(new Fraction(99, 1), 1));
@@ -151,7 +151,7 @@ describe("Orderbook", () => {
       first_orderbook.addAsk(new Offer(new Fraction(105, 1), 1));
       first_orderbook.addAsk(new Offer(new Fraction(110, 1), 3));
 
-      const second_orderbook = new Orderbook("DAI", "USDC", new Fraction(0, 1));
+      const second_orderbook = new Orderbook("DAI", "USDC", { fee: new Fraction(0, 1) });
       second_orderbook.addBid(new Offer(new Fraction(99, 100), 100));
       second_orderbook.addBid(new Offer(new Fraction(9, 10), 200));
       second_orderbook.addAsk(new Offer(new Fraction(101, 100), 100));
@@ -181,7 +181,7 @@ describe("Orderbook", () => {
   });
 
   describe("price estimation", () => {
-    const orderbook = new Orderbook("ETH", "DAI", new Fraction(0, 1));
+    const orderbook = new Orderbook("ETH", "DAI", { fee: new Fraction(0, 1) });
 
     orderbook.addBid(new Offer(new Fraction(90, 1), 3));
     orderbook.addBid(new Offer(new Fraction(95, 1), 2));
@@ -236,7 +236,7 @@ describe("Orderbook", () => {
     });
 
     it("reduces partially overlapping orderbooks", () => {
-      const orderbook = new Orderbook("ETH", "DAI", new Fraction(0, 1));
+      const orderbook = new Orderbook("ETH", "DAI", { fee: new Fraction(0, 1) });
 
       orderbook.addBid(new Offer(new Fraction(101, 1), 2));
       orderbook.addBid(new Offer(new Fraction(102, 1), 1));
@@ -272,7 +272,7 @@ describe("Orderbook", () => {
 
   describe("fee mechanism", () => {
     it("incorporates fee when asks/bids are added", () => {
-      const orderbook = new Orderbook("USDC", "DAI", new Fraction(1, 100));
+      const orderbook = new Orderbook("USDC", "DAI", { fee: new Fraction(1, 100) });
       orderbook.addBid(new Offer(new Fraction(100, 1), 100));
       orderbook.addAsk(new Offer(new Fraction(200, 1), 200));
 
@@ -291,14 +291,14 @@ describe("Orderbook", () => {
       const first_orderbook = new Orderbook(
         "USDC",
         "DAI",
-        new Fraction(1, 100)
+        { fee: new Fraction(1, 100) }
       );
       first_orderbook.addBid(new Offer(new Fraction(100, 1), 100));
 
       const second_orderbook = new Orderbook(
         "USDC",
         "DAI",
-        new Fraction(1, 100)
+        { fee: new Fraction(1, 100) }
       );
       second_orderbook.addBid(new Offer(new Fraction(100, 1), 100));
       first_orderbook.add(second_orderbook);
@@ -307,7 +307,7 @@ describe("Orderbook", () => {
     });
 
     it("Doesn't count fee twice when reducing orderbooks", () => {
-      const orderbook = new Orderbook("USDC", "DAI", new Fraction(1, 100));
+      const orderbook = new Orderbook("USDC", "DAI", { fee: new Fraction(1, 100) });
       orderbook.addBid(new Offer(new Fraction(100, 1), 100));
       orderbook.addAsk(new Offer(new Fraction(200, 1), 200));
 
@@ -319,14 +319,14 @@ describe("Orderbook", () => {
       const first_orderbook = new Orderbook(
         "USDC",
         "DAI",
-        new Fraction(1, 100)
+        { fee: new Fraction(1, 100) }
       );
       first_orderbook.addBid(new Offer(new Fraction(1, 1), 100));
 
       const second_orderbook = new Orderbook(
         "DAI",
         "TUSD",
-        new Fraction(1, 100)
+        { fee: new Fraction(1, 100) }
       );
       second_orderbook.addBid(new Offer(new Fraction(1, 1), 100));
 
@@ -337,7 +337,7 @@ describe("Orderbook", () => {
 
   describe("clone", () => {
     it("Make a deep copy of the original orderbook", () => {
-      const orderbook = new Orderbook("DAI", "USDC", new Fraction(0, 1));
+      const orderbook = new Orderbook("DAI", "USDC", { fee: new Fraction(0, 1) });
       orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
 
       const copy = orderbook.clone();
@@ -350,7 +350,7 @@ describe("Orderbook", () => {
 
   describe("serialize", () => {
     it("can be deserialized", () => {
-      const original = new Orderbook("USDC", "DAI", new Fraction(0, 1));
+      const original = new Orderbook("USDC", "DAI", { fee: new Fraction(0, 1) });
       original.addAsk(new Offer(new Fraction(11, 10), 100));
       original.addAsk(new Offer(new Fraction(12, 10), 200));
       original.addAsk(new Offer(new Fraction(101, 100), 300));
@@ -367,7 +367,7 @@ describe("Orderbook", () => {
 
 describe("transitiveOrderbook", () => {
   it("computes transitive orderbook with 0 hops", () => {
-    const orderbook = new Orderbook("DAI", "USDC", new Fraction(0, 1));
+    const orderbook = new Orderbook("DAI", "USDC", { fee: new Fraction(0, 1) });
     orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
 
     const transitive = transitiveOrderbook(
@@ -381,13 +381,13 @@ describe("transitiveOrderbook", () => {
   });
 
   it("computes transitive orderbook with 1 hop", () => {
-    const direct = new Orderbook("DAI", "ETH", new Fraction(0, 1));
+    const direct = new Orderbook("DAI", "ETH", { fee: new Fraction(0, 1) });
     direct.addAsk(new Offer(new Fraction(1, 80), 80));
 
-    const first_orderbook = new Orderbook("DAI", "USDC", new Fraction(0, 1));
+    const first_orderbook = new Orderbook("DAI", "USDC", { fee: new Fraction(0, 1) });
     first_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
 
-    const second_orderbook = new Orderbook("USDC", "ETH", new Fraction(0, 1));
+    const second_orderbook = new Orderbook("USDC", "ETH", { fee: new Fraction(0, 1) });
     second_orderbook.addAsk(new Offer(new Fraction(1, 100), 100));
 
     const transitive = transitiveOrderbook(
@@ -405,16 +405,16 @@ describe("transitiveOrderbook", () => {
   });
 
   it("computes transitive orderbook with 2 hop", () => {
-    const direct = new Orderbook("DAI", "ETH", new Fraction(0, 1));
+    const direct = new Orderbook("DAI", "ETH", { fee: new Fraction(0, 1) });
     direct.addAsk(new Offer(new Fraction(1, 80), 80));
 
-    const first_orderbook = new Orderbook("DAI", "USDC", new Fraction(0, 1));
+    const first_orderbook = new Orderbook("DAI", "USDC", { fee: new Fraction(0, 1) });
     first_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
 
-    const second_orderbook = new Orderbook("USDC", "USDT", new Fraction(0, 1));
+    const second_orderbook = new Orderbook("USDC", "USDT", { fee: new Fraction(0, 1) });
     second_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
 
-    const third_orderbook = new Orderbook("USDT", "ETH", new Fraction(0, 1));
+    const third_orderbook = new Orderbook("USDT", "ETH", { fee: new Fraction(0, 1) });
     third_orderbook.addAsk(new Offer(new Fraction(1, 100), 100));
 
     const transitive = transitiveOrderbook(
@@ -433,10 +433,10 @@ describe("transitiveOrderbook", () => {
   });
 
   it("computes transitive orderbook from bids and asks", () => {
-    const first_orderbook = new Orderbook("DAI", "USDC", new Fraction(0, 1));
+    const first_orderbook = new Orderbook("DAI", "USDC", { fee: new Fraction(0, 1) });
     first_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
 
-    const second_orderbook = new Orderbook("ETH", "USDC", new Fraction(0, 1));
+    const second_orderbook = new Orderbook("ETH", "USDC", { fee: new Fraction(0, 1) });
     second_orderbook.addBid(new Offer(new Fraction(100, 1), 1));
 
     const transitive = transitiveOrderbook(
@@ -453,19 +453,19 @@ describe("transitiveOrderbook", () => {
   });
 
   it("does not modify the underlying orderbooks", () => {
-    const direct = new Orderbook("DAI", "ETH", new Fraction(0, 1));
+    const direct = new Orderbook("DAI", "ETH", { fee: new Fraction(0, 1) });
     direct.addAsk(new Offer(new Fraction(1, 80), 80));
     const direct_serialized = JSON.stringify(direct);
 
-    const first_orderbook = new Orderbook("DAI", "USDC", new Fraction(0, 1));
+    const first_orderbook = new Orderbook("DAI", "USDC", { fee: new Fraction(0, 1) });
     first_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
     const first_serialized = JSON.stringify(first_orderbook);
 
-    const second_orderbook = new Orderbook("USDC", "DAI", new Fraction(0, 1));
+    const second_orderbook = new Orderbook("USDC", "DAI", { fee: new Fraction(0, 1) });
     second_orderbook.addAsk(new Offer(new Fraction(1, 1), 100));
     const second_serialized = JSON.stringify(second_orderbook);
 
-    const third_orderbook = new Orderbook("USDT", "ETH", new Fraction(0, 1));
+    const third_orderbook = new Orderbook("USDT", "ETH", { fee: new Fraction(0, 1) });
     third_orderbook.addAsk(new Offer(new Fraction(1, 100), 100));
     const third_serialized = JSON.stringify(third_orderbook);
 


### PR DESCRIPTION
This allows storing the orderbook as text and recreating it from text which we need in dex-price-estimator.

I had to remove the `readonly` to allow changing the members when
deserializing the orderbook without changing the existing constructor.