### PR TITLE
[BatchExchangeViewer] Allow token filter for getEncodedOrders

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - yarn build
   - solium -d contracts/
   - yarn coverage && cat ./coverage/lcov.info | coveralls
-  - yarn test-js ./test/stablex_large_example.js
+  - yarn test-js --grep @skip-on-coverage
   - yarn test-ts
 before_deploy:
   - export PACKAGE_VERSION=$(jq -r '.version' package.json)

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -181,6 +181,9 @@ contract BatchExchangeViewer {
         uint256 orderIndex = 0;
         uint256 userIndex = 0;
         while (orderIndex < pageSize) {
+            // There is no way of getting the number of orders a user has, thus "try" fetching the next order and
+            // check if the static call succeeded. Otherwise move on to the next user. Limit the amount of gas as
+            // in the failure case IVALID_OPCODE consumes all remaining gas.
             (bool success, bytes memory order) = address(batchExchange).staticcall.gas(5000)(
                 abi.encodeWithSignature("orders(address,uint256)", currentUser, currentOffset)
             );

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.5.10;
 
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";

--- a/test/batch_exchange_viewer.js
+++ b/test/batch_exchange_viewer.js
@@ -11,7 +11,10 @@ const { setupGenericStableX } = require("./stablex_utils")
 
 const zero_address = "0x0000000000000000000000000000000000000000"
 
-contract("BatchExchangeViewer", (accounts) => {
+// The contract can't be profiled with solcover as we rely on invoking a staticcall with
+// minimal gas amount (which gets burned in case the call fails). Coverage adds solidity
+// instructions to determine which lines were touched which increases the amount of gas used.
+contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
   const [user_1, user_2, user_3] = accounts
   let batchExchange, token_1, token_2
   beforeEach(async () => {

--- a/test/batch_exchange_viewer.js
+++ b/test/batch_exchange_viewer.js
@@ -3,6 +3,7 @@ const BatchExchangeViewer = artifacts.require("BatchExchangeViewer")
 const MockContract = artifacts.require("MockContract")
 
 const BN = require("bn.js")
+const truffleAssert = require("truffle-assertions")
 
 const { decodeOrdersBN } = require("../src/encoding")
 const { closeAuction } = require("../scripts/utilities.js")
@@ -322,6 +323,25 @@ contract("BatchExchangeViewer", (accounts) => {
       assert.equal(page[0].user, user_1.toLowerCase())
       assert.equal(page[1].user, user_2.toLowerCase())
       assert.equal(page[2].user, user_3.toLowerCase())
+    })
+  })
+  describe("getEncodedOrdersPaginatedWithTokenFilter", () => {
+    it("Does not query balance for filtered tokens", async () => {
+      await token_1.givenAnyReturnBool(true)
+      const batchId = await batchExchange.getCurrentBatchId()
+      await batchExchange.placeOrder(2, 1, batchId + 10, 200, 300)
+      await batchExchange.deposit(token_1.address, new BN(2).pow(new BN(255)))
+      await closeAuction(batchExchange)
+      // getBalance(token1) now reverts due to math overflow
+      await batchExchange.deposit(token_1.address, new BN(2).pow(new BN(255)))
+      await closeAuction(batchExchange)
+
+      const viewer = await BatchExchangeViewer.new(batchExchange.address)
+      await truffleAssert.reverts(viewer.getEncodedOrdersPaginatedWithTokenFilter([], zero_address, 0, 10))
+      const result = decodeOrdersBN(await viewer.getEncodedOrdersPaginatedWithTokenFilter([0, 2], zero_address, 0, 10))
+      // Filtered orders still show up as 0s to preserve order indices
+      assert.equal(result.length, 1)
+      assert.equal(result[0].user, zero_address)
     })
   })
 })

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -16,7 +16,7 @@ if (!privateKey && !mnemonic) {
 
 // Solc
 let solcUseDocker = process.env.SOLC_USE_DOCKER === "true" || false
-let solcVersion = "<0.5.7"
+let solcVersion = "<0.5.11"
 
 // Gas price
 const gasPriceGWei = process.env.GAS_PRICE_GWEI || DEFAULT_GAS_PRICE_GWEI

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -34,6 +34,7 @@ const urlDevelopment = process.env.GANACHE_HOST || "localhost"
 const infuraKey = process.env.INFURA_KEY || "9408f47dedf04716a03ef994182cf150"
 
 const { gas: gasLog } = require("minimist")(process.argv.slice(2), { alias: { gas: "g" } })
+const { grep: grep } = require("minimist")(process.argv.slice(2))
 
 module.exports = {
   ...truffleConfig({
@@ -58,6 +59,7 @@ module.exports = {
       gasPrice: 20,
       showTimeSpent: true,
     },
+    grep,
   },
   test_file_extension_regexp: /.*\.js$/,
   plugins: ["truffle-plugin-verify", "solidity-coverage"],


### PR DESCRIPTION
This PR addresses an issue that @e00E mentioned in slack. When a user has an invalid sellBalance (e.g. from listing a fake ERC20 token that has no reasonable supply) our current way of fetching the on-chain orderbook via a smart contract would fail.

This PR adds a unit-test outlining the issue and implements a filtered version of `getEncodedOrdersPaginated`. For this we reimplement the encode logic as well as the fetching logic inside BatchExchangeViewer but wrap it around a token filter check before invoking getBalance.

Note, that there is no good way of computing the number of orders a certain user has, thus we need to "try" fetching the next order of a given use and inspect the return flag if the static call succeeded.

### Test Plan

Added a unit test and did some high tenderly testing that the implementation is using around the same gas as the current one.