### PR TITLE
fix the 'places multiple orders' test

### DIFF
--- a/test/batch_exchange.js
+++ b/test/batch_exchange.js
@@ -205,15 +205,11 @@ contract("BatchExchange", async (accounts) => {
     it("places multiple orders with sepcified validFrom", async () => {
       const batchExchange = await setupGenericStableX()
       const currentBatch = (await batchExchange.getCurrentBatchId()).toNumber()
-      const ids = (await batchExchange.placeValidFromOrders.call(
-        [0, 1],
-        [1, 0],
-        [currentBatch, currentBatch],
-        [3, 4],
-        [10, 11],
-        [20, 21],
-        { from: user_1 }
-      )).map((x) => x.toNumber())
+      const ids = (
+        await batchExchange.placeValidFromOrders.call([0, 1], [1, 0], [currentBatch, currentBatch], [3, 4], [10, 11], [20, 21], {
+          from: user_1,
+        })
+      ).map((x) => x.toNumber())
       await batchExchange.placeValidFromOrders([0, 1], [1, 0], [currentBatch, currentBatch], [3, 4], [10, 11], [20, 21], {
         from: user_1,
       })

--- a/test/batch_exchange.js
+++ b/test/batch_exchange.js
@@ -206,13 +206,19 @@ contract("BatchExchange", async (accounts) => {
       const batchExchange = await setupGenericStableX()
       const currentBatch = (await batchExchange.getCurrentBatchId()).toNumber()
       const ids = (
-        await batchExchange.placeValidFromOrders.call([0, 1], [1, 0], [currentBatch, currentBatch], [3, 4], [10, 11], [20, 21], {
-          from: user_1,
-        })
+        await sendTxAndGetReturnValue(
+          batchExchange.placeValidFromOrders,
+          [0, 1],
+          [1, 0],
+          [currentBatch, currentBatch],
+          [3, 4],
+          [10, 11],
+          [20, 21],
+          {
+            from: user_1,
+          }
+        )
       ).map((x) => x.toNumber())
-      await batchExchange.placeValidFromOrders([0, 1], [1, 0], [currentBatch, currentBatch], [3, 4], [10, 11], [20, 21], {
-        from: user_1,
-      })
 
       // sanity check the IDs returned from the call before testing the orders with particular IDs
       assert.deepEqual(ids, [0, 1])


### PR DESCRIPTION
Hello,

At one point, when exploring code, I noticed that one of the tests in `batch_exchange.js` was void because of 1/ comparing an int to an array, which caused strange behavior of the `for` loop 2/ doing twice the same assertion instead of iterating through a list of 2 distinct objects to expect.

This can be seen here: https://github.com/gnosis/dex-contracts/compare/master...pdobacz:fix_place_orders_test?expand=1#diff-4a40656b5d71cefbaf39971c88e64257L221-L222

(at least this is as far as my js-lore goes, but some experiments confirmed it).

Here is a small fix to that test, which I finally got down to write down. I dumbed it down by unrolling the assertion loop, to not overthink this. Hope this makes sense :).