### PR TITLE
[Easy/Viewer] Use a more conservative gas buffer when fetching pages

### DIFF
--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -117,8 +117,8 @@ contract BatchExchangeViewer {
         nextPageUserOffset = previousPageUserOffset;
         hasNextPage = true;
         uint256 gasLeftBeforePage = gasleft();
-        // Continue while more pages exist or we used more than 1/2 of remaining gas in previous page
-        while (hasNextPage && 2 * gasleft() > gasLeftBeforePage) {
+        // Continue while more pages exist or we still have 3/5 (60%) of remaining gas from previous page
+        while (hasNextPage && 5 * gasleft() > 3 * gasLeftBeforePage) {
             gasLeftBeforePage = gasleft();
             bytes memory unfiltered = getEncodedOrdersPaginatedWithTokenFilter(
                 tokenFilter,


### PR DESCRIPTION
We ran into issues where the `eth_call` was running out of gas when fetching pages with large sections of expired orders where the variation in gas used was causing the last requested page to run out of gas when the previous page used *just* a little more than half the gas.

This PR updates the ratio to be 40/60, so the previous page can use at most 40% of the remaining gas before we stop trying to fetch additional pages.

Specifically, the price estimator was failing to retrieve an orderbook with a page size of 50 and with 500,000,000 gas where the before last call to `BatchExchangeViewer::getEncodedUserOrdersPaginated` (by looking for the `BatchExchange::getUsersPaginated()` call which happens relatively close to the start) was started at ~14,621,000 gas and and the last one at ~7,267,000. After retrieving the page of orders, during filtering, the call would run out of gas at the 35/50 orders. By looking at the difference in gas between each `BatchExchange::tokenIdToAddress()` map calls done at the start of `BatchExchangeViewer::updateSellTokenBalanceForBatchId` we see that it takes roughly 47,000 gas to filter an order, and so to finish filtering the remaning 15 orders it would take 710,000 gas, or 10% of the remaining gas.

The command used to get a trace of the call was:
```
curl -H "Content-Type: application/json" -X POST https://node.mainnet.gnosisdev.com -d '{"jsonrpc":"2.0","id":25,"method":"trace_call","params":[{"data":"0xe9d98f090000000000000000000000000000000000000000000000000000000000000080000000000000000000000000ebedc29cb0720c742c30d7d727c8faf1bef23974000000000000000000000000000000000000000000000000000000000000000500000000000000000000000000000000000000000000000000000000000000320000000000000000000000000000000000000000000000000000000000000000","to":"0xd7a78a333bae9aaddd5ebe41c209fb5226ea155b"},["trace"]]}'
```

### Test Plan

CI