### PR TITLE
[BatchExchangeViewer] Serialize orderId when querying orders with filter

### DIFF
--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -10,6 +10,8 @@ contract BatchExchangeViewer {
     using SafeMath for uint256;
 
     uint8 public constant AUCTION_ELEMENT_WIDTH = 112;
+    // Contains the orderId on top of the normal auction element data
+    uint8 public constant INDEXED_AUCTION_ELEMENT_WIDTH = AUCTION_ELEMENT_WIDTH + 2;
     uint8 public constant ADDRESS_WIDTH = 20;
     uint16 public constant LARGE_PAGE_SIZE = 5000;
     // Can be used by external contracts to indicate no filter as it doesn't seem possible
@@ -28,7 +30,10 @@ contract BatchExchangeViewer {
      */
     function getOpenOrderBook(address[] memory tokenFilter) public view returns (bytes memory) {
         (bytes memory elements, , , ) = getOpenOrderBookPaginated(tokenFilter, address(0), 0, LARGE_PAGE_SIZE);
-        require(elements.length < LARGE_PAGE_SIZE * AUCTION_ELEMENT_WIDTH, "Orderbook too large, use paginated view functions");
+        require(
+            elements.length < uint256(LARGE_PAGE_SIZE) * INDEXED_AUCTION_ELEMENT_WIDTH,
+            "Orderbook too large, use paginated view functions"
+        );
         return elements;
     }
 
@@ -44,16 +49,7 @@ contract BatchExchangeViewer {
         address previousPageUser,
         uint16 previousPageUserOffset,
         uint16 maxPageSize
-    )
-        public
-        view
-        returns (
-            bytes memory elements,
-            bool hasNextPage,
-            address nextPageUser,
-            uint16 nextPageUserOffset
-        )
-    {
+    ) public view returns (bytes memory elements, bool hasNextPage, address nextPageUser, uint16 nextPageUserOffset) {
         uint32 batch = batchExchange.getCurrentBatchId();
         return
             getFilteredOrdersPaginated(
@@ -71,7 +67,10 @@ contract BatchExchangeViewer {
      */
     function getFinalizedOrderBook(address[] memory tokenFilter) public view returns (bytes memory) {
         (bytes memory elements, , , ) = getFinalizedOrderBookPaginated(tokenFilter, address(0), 0, LARGE_PAGE_SIZE);
-        require(elements.length < LARGE_PAGE_SIZE * AUCTION_ELEMENT_WIDTH, "Orderbook too large, use paginated view functions");
+        require(
+            elements.length < uint256(LARGE_PAGE_SIZE) * INDEXED_AUCTION_ELEMENT_WIDTH,
+            "Orderbook too large, use paginated view functions"
+        );
         return elements;
     }
 
@@ -87,16 +86,7 @@ contract BatchExchangeViewer {
         address previousPageUser,
         uint16 previousPageUserOffset,
         uint16 maxPageSize
-    )
-        public
-        view
-        returns (
-            bytes memory elements,
-            bool hasNextPage,
-            address nextPageUser,
-            uint16 nextPageUserOffset
-        )
-    {
+    ) public view returns (bytes memory elements, bool hasNextPage, address nextPageUser, uint16 nextPageUserOffset) {
         uint32 batch = batchExchange.getCurrentBatchId();
         return
             getFilteredOrdersPaginated(
@@ -128,17 +118,8 @@ contract BatchExchangeViewer {
         address previousPageUser,
         uint16 previousPageUserOffset,
         uint16 maxPageSize
-    )
-        public
-        view
-        returns (
-            bytes memory elements,
-            bool hasNextPage,
-            address nextPageUser,
-            uint16 nextPageUserOffset
-        )
-    {
-        elements = new bytes(maxPageSize * AUCTION_ELEMENT_WIDTH);
+    ) public view returns (bytes memory elements, bool hasNextPage, address nextPageUser, uint16 nextPageUserOffset) {
+        elements = new bytes(maxPageSize * INDEXED_AUCTION_ELEMENT_WIDTH);
         uint256 elementCount = 0;
         nextPageUser = previousPageUser;
         nextPageUserOffset = previousPageUserOffset;
@@ -158,10 +139,6 @@ contract BatchExchangeViewer {
                 // make sure we don't overflow index * AUCTION_ELEMENT_WIDTH
                 bytes memory element = unfiltered.slice(uint256(index) * AUCTION_ELEMENT_WIDTH, AUCTION_ELEMENT_WIDTH);
                 element = updateSellTokenBalanceForBatchId(element, batchIds[2]);
-                if (batchIds[0] >= getValidFrom(element) && batchIds[1] <= getValidUntil(element)) {
-                    copyInPlace(element, elements, elementCount * AUCTION_ELEMENT_WIDTH);
-                    elementCount += 1;
-                }
                 // Update pagination info
                 address user = getUser(element);
                 if (user == nextPageUser) {
@@ -169,6 +146,16 @@ contract BatchExchangeViewer {
                 } else {
                     nextPageUserOffset = 1;
                     nextPageUser = user;
+                }
+                if (batchIds[0] >= getValidFrom(element) && batchIds[1] <= getValidUntil(element)) {
+                    copyInPlace(element, elements, elementCount * INDEXED_AUCTION_ELEMENT_WIDTH);
+                    // Append index so order information can be used to construct solutions
+                    copyInPlace(
+                        abi.encodePacked(nextPageUserOffset - 1),
+                        elements,
+                        (elementCount * INDEXED_AUCTION_ELEMENT_WIDTH) + AUCTION_ELEMENT_WIDTH
+                    );
+                    elementCount += 1;
                 }
                 if (elementCount >= maxPageSize) {
                     // We are at capacity, return
@@ -179,7 +166,7 @@ contract BatchExchangeViewer {
                 }
             }
         }
-        setLength(elements, elementCount * AUCTION_ELEMENT_WIDTH);
+        setLength(elements, elementCount * INDEXED_AUCTION_ELEMENT_WIDTH);
         return (elements, hasNextPage, nextPageUser, nextPageUserOffset);
     }
 
@@ -190,11 +177,11 @@ contract BatchExchangeViewer {
      * @param pageSize uint determining the count of orders to be returned per page
      * @return encoded bytes representing a page of orders ordered by (user, index)
      */
-    function getEncodedOrdersPaginated(
-        address previousPageUser,
-        uint16 previousPageUserOffset,
-        uint256 pageSize
-    ) public view returns (bytes memory) {
+    function getEncodedOrdersPaginated(address previousPageUser, uint16 previousPageUserOffset, uint256 pageSize)
+        public
+        view
+        returns (bytes memory)
+    {
         return getEncodedOrdersPaginatedWithTokenFilter(ALL_TOKEN_FILTER, previousPageUser, previousPageUserOffset, pageSize);
     }
 
@@ -235,11 +222,7 @@ contract BatchExchangeViewer {
         return elements;
     }
 
-    function matchesTokenFilter(
-        uint16 buyToken,
-        uint16 sellToken,
-        uint16[] memory filter
-    ) public pure returns (bool) {
+    function matchesTokenFilter(uint16 buyToken, uint16 sellToken, uint16[] memory filter) public pure returns (bool) {
         // An empty filter is interpreted as "select all"
         if (filter.length == 0) {
             return true;
@@ -330,11 +313,7 @@ contract BatchExchangeViewer {
         }
     }
 
-    function copyInPlace(
-        bytes memory source,
-        bytes memory destination,
-        uint256 offset
-    ) public pure {
+    function copyInPlace(bytes memory source, bytes memory destination, uint256 offset) public pure {
         for (uint256 i = 0; i < source.length; i++) {
             destination[offset + i] = source[i];
         }

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -49,7 +49,16 @@ contract BatchExchangeViewer {
         address previousPageUser,
         uint16 previousPageUserOffset,
         uint16 maxPageSize
-    ) public view returns (bytes memory elements, bool hasNextPage, address nextPageUser, uint16 nextPageUserOffset) {
+    )
+        public
+        view
+        returns (
+            bytes memory elements,
+            bool hasNextPage,
+            address nextPageUser,
+            uint16 nextPageUserOffset
+        )
+    {
         uint32 batch = batchExchange.getCurrentBatchId();
         return
             getFilteredOrdersPaginated(
@@ -86,7 +95,16 @@ contract BatchExchangeViewer {
         address previousPageUser,
         uint16 previousPageUserOffset,
         uint16 maxPageSize
-    ) public view returns (bytes memory elements, bool hasNextPage, address nextPageUser, uint16 nextPageUserOffset) {
+    )
+        public
+        view
+        returns (
+            bytes memory elements,
+            bool hasNextPage,
+            address nextPageUser,
+            uint16 nextPageUserOffset
+        )
+    {
         uint32 batch = batchExchange.getCurrentBatchId();
         return
             getFilteredOrdersPaginated(
@@ -118,7 +136,16 @@ contract BatchExchangeViewer {
         address previousPageUser,
         uint16 previousPageUserOffset,
         uint16 maxPageSize
-    ) public view returns (bytes memory elements, bool hasNextPage, address nextPageUser, uint16 nextPageUserOffset) {
+    )
+        public
+        view
+        returns (
+            bytes memory elements,
+            bool hasNextPage,
+            address nextPageUser,
+            uint16 nextPageUserOffset
+        )
+    {
         elements = new bytes(maxPageSize * INDEXED_AUCTION_ELEMENT_WIDTH);
         uint256 elementCount = 0;
         nextPageUser = previousPageUser;
@@ -177,11 +204,11 @@ contract BatchExchangeViewer {
      * @param pageSize uint determining the count of orders to be returned per page
      * @return encoded bytes representing a page of orders ordered by (user, index)
      */
-    function getEncodedOrdersPaginated(address previousPageUser, uint16 previousPageUserOffset, uint256 pageSize)
-        public
-        view
-        returns (bytes memory)
-    {
+    function getEncodedOrdersPaginated(
+        address previousPageUser,
+        uint16 previousPageUserOffset,
+        uint256 pageSize
+    ) public view returns (bytes memory) {
         return getEncodedOrdersPaginatedWithTokenFilter(ALL_TOKEN_FILTER, previousPageUser, previousPageUserOffset, pageSize);
     }
 
@@ -222,7 +249,11 @@ contract BatchExchangeViewer {
         return elements;
     }
 
-    function matchesTokenFilter(uint16 buyToken, uint16 sellToken, uint16[] memory filter) public pure returns (bool) {
+    function matchesTokenFilter(
+        uint16 buyToken,
+        uint16 sellToken,
+        uint16[] memory filter
+    ) public pure returns (bool) {
         // An empty filter is interpreted as "select all"
         if (filter.length == 0) {
             return true;
@@ -313,7 +344,11 @@ contract BatchExchangeViewer {
         }
     }
 
-    function copyInPlace(bytes memory source, bytes memory destination, uint256 offset) public pure {
+    function copyInPlace(
+        bytes memory source,
+        bytes memory destination,
+        uint256 offset
+    ) public pure {
         for (uint256 i = 0; i < source.length; i++) {
             destination[offset + i] = source[i];
         }

--- a/src/encoding.js
+++ b/src/encoding.js
@@ -9,6 +9,56 @@
 const assert = require("assert")
 const BN = require("bn.js")
 
+class OrderBuffer {
+  constructor(bytes) {
+    this.bytes = bytes
+    this.index = 2 // skip '0x'
+
+    this.readBytes = (size) => this.bytes.slice(this.index, (this.index += size * 2))
+
+    this.decodeAddr = () => `0x${this.readBytes(20)}`
+    this.decodeInt = (size) => new BN(this.readBytes(size / 8), 16).toString()
+
+    return this
+  }
+}
+
+function decodeOrder(bytes) {
+  return {
+    user: bytes.decodeAddr(),
+    sellTokenBalance: bytes.decodeInt(256),
+    buyToken: bytes.decodeInt(16),
+    sellToken: bytes.decodeInt(16),
+    validFrom: bytes.decodeInt(32),
+    validUntil: bytes.decodeInt(32),
+    priceNumerator: bytes.decodeInt(128),
+    priceDenominator: bytes.decodeInt(128),
+    remainingAmount: bytes.decodeInt(128),
+  }
+}
+
+function decodeIndexedOrder(bytes) {
+  return {
+    ...decodeOrder(bytes),
+    orderId: bytes.decodeInt(16),
+  }
+}
+
+function decodeOrdersInternal(bytes, decodeFunction, width) {
+  if (bytes === null || bytes === undefined || bytes.length === 0) {
+    return []
+  }
+  assert(typeof bytes === "string" || bytes instanceof String, "bytes parameter must be a string")
+  assert((bytes.length - 2) % width === 0, "malformed bytes")
+
+  const buffer = new OrderBuffer(bytes)
+  const result = []
+  while (buffer.index < buffer.bytes.length) {
+    result.push(decodeFunction(buffer))
+  }
+  return result
+}
+
 /**
  * Decodes a byte-encoded variable length array of orders. This can be used to
  * decode the result of `BatchExchange.getEncodedUserOrders` and
@@ -17,33 +67,7 @@ const BN = require("bn.js")
  * @return {Object[]} The decoded array of orders
  */
 function decodeOrders(bytes) {
-  if (bytes === null || bytes === undefined || bytes.length === 0) {
-    return []
-  }
-  assert(typeof bytes === "string" || bytes instanceof String, "bytes parameter must be a string")
-  assert((bytes.length - 2) % 112 === 0, "malformed bytes")
-
-  let index = 2 // skip '0x'
-  const readBytes = (size) => bytes.slice(index, (index += size * 2))
-
-  const decodeAddr = () => `0x${readBytes(20)}`
-  const decodeInt = (size) => new BN(readBytes(size / 8), 16).toString()
-
-  const result = []
-  while (index < bytes.length) {
-    result.push({
-      user: decodeAddr(),
-      sellTokenBalance: decodeInt(256),
-      buyToken: decodeInt(16),
-      sellToken: decodeInt(16),
-      validFrom: decodeInt(32),
-      validUntil: decodeInt(32),
-      priceNumerator: decodeInt(128),
-      priceDenominator: decodeInt(128),
-      remainingAmount: decodeInt(128),
-    })
-  }
-  return result
+  return decodeOrdersInternal(bytes, decodeOrder, 112)
 }
 
 function decodeOrdersBN(bytes) {
@@ -60,7 +84,35 @@ function decodeOrdersBN(bytes) {
   }))
 }
 
+/**
+ * Decodes a byte-encoded variable length array of orders and their indices.
+ * This can be used to decode the result of `BatchExchangeViewer.getOpenOrderBook` and
+ * `BatchExchangeViewer.getFinalizedOrderBook`.
+ * @param {string} bytes The encoded bytes in hex in the form '0x...'
+ * @return {Object[]} The decoded array of orders and their orderIds
+ */
+function decodeIndexedOrders(bytes) {
+  return decodeOrdersInternal(bytes, decodeIndexedOrder, 114)
+}
+
+function decodeIndexedOrdersBN(bytes) {
+  return decodeIndexedOrders(bytes).map((e) => ({
+    user: e.user,
+    orderId: parseInt(e.orderId),
+    sellTokenBalance: new BN(e.sellTokenBalance),
+    buyToken: parseInt(e.buyToken),
+    sellToken: parseInt(e.sellToken),
+    validFrom: parseInt(e.validFrom),
+    validUntil: parseInt(e.validUntil),
+    priceNumerator: new BN(e.priceNumerator),
+    priceDenominator: new BN(e.priceDenominator),
+    remainingAmount: new BN(e.remainingAmount),
+  }))
+}
+
 module.exports = {
   decodeOrders,
   decodeOrdersBN,
+  decodeIndexedOrders,
+  decodeIndexedOrdersBN,
 }

--- a/src/onchain_reading.js
+++ b/src/onchain_reading.js
@@ -1,4 +1,4 @@
-const { decodeOrdersBN } = require("./encoding")
+const { decodeOrdersBN, decodeIndexedOrdersBN } = require("./encoding")
 
 /**
  * Returns an iterator yielding an item for each page of order in the orderbook that is currently being collected.
@@ -12,7 +12,7 @@ const getOpenOrdersPaginated = async function* (contract, pageSize) {
 
   while (hasNextPage) {
     const page = await contract.methods.getOpenOrderBookPaginated([], nextPageUser, nextPageUserOffset, pageSize).call()
-    const elements = decodeOrdersBN(page.elements)
+    const elements = decodeIndexedOrdersBN(page.elements)
     yield elements
 
     //Update page info

--- a/test/batch_exchange_viewer.js
+++ b/test/batch_exchange_viewer.js
@@ -255,7 +255,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       // We are querying two subpages which contain 6 elements in total, but due to our
       // page size constraint only return 5. Thus we should have a nextPage.
       const result = await viewer.getFilteredOrdersPaginated([batchId, batchId, batchId], [1, 2], zero_address, 0, 5)
-      assert.equal(decodeOrdersBN(result.elements).length, 5)
+      assert.equal(decodeIndexedOrdersBN(result.elements).length, 5)
       assert.equal(result.hasNextPage, true)
     }),
   ])
@@ -390,7 +390,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
       const result = await viewer.getFilteredOrdersPaginated([batchId, batchId, batchId], [1, 2], accounts[0], 0, 1)
-      assert.equal(decodeOrdersBN(result.elements).length, 1)
+      assert.equal(decodeIndexedOrdersBN(result.elements).length, 1)
     })
   })
 })


### PR DESCRIPTION
It would be nice to use the filtered orderbook for querying inside dex-services. This should reduce the amount of data we are sending over the wire and thus speed up the fetching time.

The thing that is preventing this at the moment is that from a filtered orderbook we cannot reconstruct the orderId (it's not incrementing as there might be gaps) and thus we cannot use this order information for `submitSolution`.

This PR changes that. It appends the orderId (index of this order in all of the user's orders) to the bytes returned from any of the filtering methods (such as `getOpenOrderBook`, `getFinalizedOrderBook`). It also updated the decode methods to comply with the new format.

### Test Plan

Adjusted unit test to assert filter logic based on orderId.