### PR TITLE
[Viewer] Only update order balance if it isn't filtered out

### DIFF
--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -130,8 +130,8 @@ contract BatchExchangeViewer {
             for (uint16 index = 0; index < unfiltered.length / AUCTION_ELEMENT_WIDTH; index++) {
                 // make sure we don't overflow index * AUCTION_ELEMENT_WIDTH
                 bytes memory element = unfiltered.slice(uint256(index) * AUCTION_ELEMENT_WIDTH, AUCTION_ELEMENT_WIDTH);
-                element = updateSellTokenBalanceForBatchId(element, batchIds[2]);
                 if (batchIds[0] >= getValidFrom(element) && batchIds[1] <= getValidUntil(element)) {
+                    element = updateSellTokenBalanceForBatchId(element, batchIds[2]);
                     copyInPlace(element, elements, elementCount * AUCTION_ELEMENT_WIDTH);
                     elementCount += 1;
                 }


### PR DESCRIPTION
This PR updates an order balance only if it is considered valid (i.e. matches the token filter or is valid for the specified batch) for some super awesome gas savings.

### Test Plan

Deployed on Rinkeby and was able to go through [7 pages of unfiltered orders](https://dashboard.tenderly.dev/nlordell/project/simulator/781ea834-e198-41c2-935f-9e771dfb885f) compared to [3 pages of unfiltered orders](https://dashboard.tenderly.dev/nlordell/project/simulator/a86f88e6-cd04-43bf-9ca3-3e07658f670b). We identify calls to `getEncodedUserOrders` by calls to `getUsersPaginated` since it is only used there.