### PR TITLE
Revert "[BatchExchangeViewer] Allow token filter for getEncodedOrders"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
   - yarn build
   - solium -d contracts/
   - yarn coverage && cat ./coverage/lcov.info | coveralls
-  - yarn test-js --grep @skip-on-coverage
+  - yarn test-js ./test/stablex_large_example.js
   - yarn test-ts
 before_deploy:
   - export PACKAGE_VERSION=$(jq -r '.version' package.json)

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.10;
+pragma solidity ^0.5.0;
 
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
@@ -120,18 +120,17 @@ contract BatchExchangeViewer {
         // Continue while more pages exist or we still have 3/5 (60%) of remaining gas from previous page
         while (hasNextPage && 5 * gasleft() > 3 * gasLeftBeforePage) {
             gasLeftBeforePage = gasleft();
-            bytes memory unfiltered = getEncodedOrdersPaginatedWithTokenFilter(
-                tokenFilter,
-                nextPageUser,
-                nextPageUserOffset,
-                maxPageSize
-            );
+            bytes memory unfiltered = getEncodedOrdersPaginated(nextPageUser, nextPageUserOffset, maxPageSize);
             hasNextPage = unfiltered.length / AUCTION_ELEMENT_WIDTH == maxPageSize;
             for (uint16 index = 0; index < unfiltered.length / AUCTION_ELEMENT_WIDTH; index++) {
                 // make sure we don't overflow index * AUCTION_ELEMENT_WIDTH
                 bytes memory element = unfiltered.slice(uint256(index) * AUCTION_ELEMENT_WIDTH, AUCTION_ELEMENT_WIDTH);
                 element = updateSellTokenBalanceForBatchId(element, batchIds[2]);
-                if (batchIds[0] >= getValidFrom(element) && batchIds[1] <= getValidUntil(element)) {
+                if (
+                    batchIds[0] >= getValidFrom(element) &&
+                    batchIds[1] <= getValidUntil(element) &&
+                    matchesTokenFilter(getBuyToken(element), getSellToken(element), tokenFilter)
+                ) {
                     copyInPlace(element, elements, elementCount * AUCTION_ELEMENT_WIDTH);
                     elementCount += 1;
                 }
@@ -165,15 +164,6 @@ contract BatchExchangeViewer {
         view
         returns (bytes memory)
     {
-        return getEncodedOrdersPaginatedWithTokenFilter(ALL_TOKEN_FILTER, previousPageUser, previousPageUserOffset, pageSize);
-    }
-
-    function getEncodedOrdersPaginatedWithTokenFilter(
-        uint16[] memory tokenFilter,
-        address previousPageUser,
-        uint16 previousPageUserOffset,
-        uint256 pageSize
-    ) public view returns (bytes memory) {
         bytes memory elements = new bytes(pageSize * AUCTION_ELEMENT_WIDTH);
         bytes memory users = batchExchange.getUsersPaginated(previousPageUser, uint16(pageSize));
         uint16 currentOffset = previousPageUserOffset;
@@ -181,15 +171,10 @@ contract BatchExchangeViewer {
         uint256 orderIndex = 0;
         uint256 userIndex = 0;
         while (orderIndex < pageSize) {
-            // There is no way of getting the number of orders a user has, thus "try" fetching the next order and
-            // check if the static call succeeded. Otherwise move on to the next user. Limit the amount of gas as
-            // in the failure case IVALID_OPCODE consumes all remaining gas.
-            (bool success, bytes memory order) = address(batchExchange).staticcall.gas(5000)(
-                abi.encodeWithSignature("orders(address,uint256)", currentUser, currentOffset)
-            );
-            if (success) {
+            bytes memory element = batchExchange.getEncodedUserOrdersPaginated(currentUser, currentOffset, 1);
+            if (element.length > 0) {
                 currentOffset += 1;
-                encodeAuctionElement(tokenFilter, currentUser, order, elements, orderIndex * AUCTION_ELEMENT_WIDTH);
+                copyInPlace(element, elements, orderIndex * AUCTION_ELEMENT_WIDTH);
                 orderIndex += 1;
             } else {
                 currentOffset = 0;
@@ -299,47 +284,6 @@ contract BatchExchangeViewer {
     function copyInPlace(bytes memory source, bytes memory destination, uint256 offset) public pure {
         for (uint256 i = 0; i < source.length; i++) {
             destination[offset + i] = source[i];
-        }
-    }
-
-    /** @dev Encodes the auction elements in the same format as BatchExchange.encodeAuctionElement with
-     * the only difference that order with tokens that match the token filter will be 0 serialized
-     * (as if they were deleted)
-     */
-    function encodeAuctionElement(
-        uint16[] memory tokenFilter,
-        address user,
-        bytes memory order,
-        bytes memory target,
-        uint256 offset
-    ) private view {
-        (
-            uint16 buyToken,
-            uint16 sellToken,
-            uint32 validFrom,
-            uint32 validUntil,
-            uint128 priceNumerator,
-            uint128 priceDenominator,
-            uint128 usedAmount
-        ) = abi.decode(order, (uint16, uint16, uint32, uint32, uint128, uint128, uint128));
-        if (matchesTokenFilter(buyToken, sellToken, tokenFilter)) {
-            uint128 remainingAmount = priceDenominator - usedAmount;
-            uint256 sellTokenBalance = batchExchange.getBalance(user, batchExchange.tokenIdToAddressMap(sellToken));
-            copyInPlace(
-                abi.encodePacked(
-                    user,
-                    sellTokenBalance,
-                    buyToken,
-                    sellToken,
-                    validFrom,
-                    validUntil,
-                    priceNumerator,
-                    priceDenominator,
-                    remainingAmount
-                ),
-                target,
-                offset
-            );
         }
     }
 }

--- a/test/batch_exchange_viewer.js
+++ b/test/batch_exchange_viewer.js
@@ -3,7 +3,6 @@ const BatchExchangeViewer = artifacts.require("BatchExchangeViewer")
 const MockContract = artifacts.require("MockContract")
 
 const BN = require("bn.js")
-const truffleAssert = require("truffle-assertions")
 
 const { decodeOrdersBN } = require("../src/encoding")
 const { closeAuction } = require("../scripts/utilities.js")
@@ -11,10 +10,7 @@ const { setupGenericStableX } = require("./stablex_utils")
 
 const zero_address = "0x0000000000000000000000000000000000000000"
 
-// The contract can't be profiled with solcover as we rely on invoking a staticcall with
-// minimal gas amount (which gets burned in case the call fails). Coverage adds solidity
-// instructions to determine which lines were touched which increases the amount of gas used.
-contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
+contract("BatchExchangeViewer", (accounts) => {
   const [user_1, user_2, user_3] = accounts
   let batchExchange, token_1, token_2
   beforeEach(async () => {
@@ -326,25 +322,6 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       assert.equal(page[0].user, user_1.toLowerCase())
       assert.equal(page[1].user, user_2.toLowerCase())
       assert.equal(page[2].user, user_3.toLowerCase())
-    })
-  })
-  describe("getEncodedOrdersPaginatedWithTokenFilter", () => {
-    it("Does not query balance for filtered tokens", async () => {
-      await token_1.givenAnyReturnBool(true)
-      const batchId = await batchExchange.getCurrentBatchId()
-      await batchExchange.placeOrder(2, 1, batchId + 10, 200, 300)
-      await batchExchange.deposit(token_1.address, new BN(2).pow(new BN(255)))
-      await closeAuction(batchExchange)
-      // getBalance(token1) now reverts due to math overflow
-      await batchExchange.deposit(token_1.address, new BN(2).pow(new BN(255)))
-      await closeAuction(batchExchange)
-
-      const viewer = await BatchExchangeViewer.new(batchExchange.address)
-      await truffleAssert.reverts(viewer.getEncodedOrdersPaginatedWithTokenFilter([], zero_address, 0, 10))
-      const result = decodeOrdersBN(await viewer.getEncodedOrdersPaginatedWithTokenFilter([0, 2], zero_address, 0, 10))
-      // Filtered orders still show up as 0s to preserve order indices
-      assert.equal(result.length, 1)
-      assert.equal(result[0].user, zero_address)
     })
   })
 })

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -16,7 +16,7 @@ if (!privateKey && !mnemonic) {
 
 // Solc
 let solcUseDocker = process.env.SOLC_USE_DOCKER === "true" || false
-let solcVersion = "<0.5.11"
+let solcVersion = "<0.5.7"
 
 // Gas price
 const gasPriceGWei = process.env.GAS_PRICE_GWEI || DEFAULT_GAS_PRICE_GWEI
@@ -34,7 +34,6 @@ const urlDevelopment = process.env.GANACHE_HOST || "localhost"
 const infuraKey = process.env.INFURA_KEY || "9408f47dedf04716a03ef994182cf150"
 
 const { gas: gasLog } = require("minimist")(process.argv.slice(2), { alias: { gas: "g" } })
-const { grep: grep } = require("minimist")(process.argv.slice(2))
 
 module.exports = {
   ...truffleConfig({
@@ -59,7 +58,6 @@ module.exports = {
       gasPrice: 20,
       showTimeSpent: true,
     },
-    grep,
   },
   test_file_extension_regexp: /.*\.js$/,
   plugins: ["truffle-plugin-verify", "solidity-coverage"],


### PR DESCRIPTION
Reverts gnosis/dex-contracts#663

There is a bug in this PR in that we write the 0 address if the order doesn't match our token filter. This messes up pagination logic (we start paging from the beginning).