### PR TITLE
[HotFix] always set hasNextPage when returning a full page

### DIFF
--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -144,6 +144,9 @@ contract BatchExchangeViewer {
                 }
                 if (elementCount >= maxPageSize) {
                     // We are at capacity, return
+                    // Note, that we might indicate a nextPage although we exactly made it to the end.
+                    // However, since the inner call to fetch unfiltered orders might also indicate a next
+                    // page even though it is right at the end, this cannot really be avoided.
                     return (elements, true, nextPageUser, nextPageUserOffset);
                 }
             }

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -144,7 +144,7 @@ contract BatchExchangeViewer {
                 }
                 if (elementCount >= maxPageSize) {
                     // We are at capacity, return
-                    return (elements, hasNextPage, nextPageUser, nextPageUserOffset);
+                    return (elements, true, nextPageUser, nextPageUserOffset);
                 }
             }
         }


### PR DESCRIPTION
@fedgiac noticed that some of his liquidity strategy orders were not showing up in the orderbook. 

This PR addresses the rootcause of this bug:

In order to decide if we have a next page or not, we count the number of items returned from `getEncodedUsersPaginated` and if we receive less than the amount requested we know there are no more orders, thus no more pages. 
**However**, we also return the list of filtered elements early, in case our filtered item count (previous subpages + last subpage) reaches the user specified external pageSize. 
Now, if this happens towards the end of our orderlist (we have fetched the last page of the unfiltered orderbook, but the additional items matching our filter exceed the remaining slots requested by the user) we return the truncated list **and** `hasNextPage=false` as we have reached the end of the orderbook.
Yet there might be items from that last page missing that didn't make it in our filtered list (due to capacity issues).

The fix is simple, if we return because we are at capacity we should always have a next page.

The concrete impact is that the orderbook and price estimate might at the moment miss up to the last PAGE_SIZE (currently 500) orders because it thinks it has reached the end even though there are valid orders remaining on the last unfiltered page.

### Test Plan

Added a regression test showing the problem.