### PR TITLE
[Easy] Pin coveralls to 3.0.9 because of CI failures.

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "axios": "^0.19.2",
     "bignumber.js": "^9.0.0",
     "chai": "^4.2.0",
-    "coveralls": "^3.0.11",
+    "coveralls": "=3.0.9",
     "dotenv": "^8.0.0",
     "es6-promise": "^4.2.8",
     "eslint": "^6.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2234,15 +2234,15 @@ cosmiconfig@^6.0.0:
     path-type "^4.0.0"
     yaml "^1.7.2"
 
-coveralls@^3.0.11:
-  version "3.0.11"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.11.tgz#e141da0922b632fcc66620f334460c3f0026a4ce"
-  integrity sha512-LZPWPR2NyGKyaABnc49dR0fpeP6UqhvGq4B5nUrTQ1UBy55z96+ga7r+/ChMdMJUwBgyJDXBi88UBgz2rs9IiQ==
+coveralls@=3.0.9:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.0.9.tgz#8cfc5a5525f84884e2948a0bf0f1c0e90aac0420"
+  integrity sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==
   dependencies:
     js-yaml "^3.13.1"
     lcov-parse "^1.0.0"
     log-driver "^1.2.7"
-    minimist "^1.2.5"
+    minimist "^1.2.0"
     request "^2.88.0"
 
 create-ecdh@^4.0.0:


### PR DESCRIPTION
This PR pins coveralls to 3.0.9 to work around the CI failures we've been seeing.