### PR TITLE
[BatchExchangeViewer] Fix buffer length calculation

### DIFF
--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -146,9 +146,9 @@ contract BatchExchangeViewer {
             uint16 nextPageUserOffset
         )
     {
-        elements = new bytes(maxPageSize * AUCTION_ELEMENT_WIDTH);
+        elements = new bytes(uint256(maxPageSize) * INDEXED_AUCTION_ELEMENT_WIDTH);
         setLength(elements, 0);
-        bytes memory unfiltered = new bytes(maxPageSize * AUCTION_ELEMENT_WIDTH);
+        bytes memory unfiltered = new bytes(uint256(maxPageSize) * AUCTION_ELEMENT_WIDTH);
         nextPageUser = previousPageUser;
         nextPageUserOffset = previousPageUserOffset;
         hasNextPage = true;


### PR DESCRIPTION
In #669 we incorrectly merged the computation of elements length inside `getFilteredOrdersPaginated`. Since this method returns filtered elements it will include the order index and therefore it's buffer length should be computed based on `INDEXED_AUCTION_ELEMENT_WIDTH` not `AUCTION_ELEMENT_WIDTH`.

Moreover, it's safer to cast pageSize (which is a u16) to u256 before doing the multiplication to avoid that we overflow at the 2**16 boundary.

### Test Plan

Making sure that the redeployed version can be used for fetching the orderbook. Should probably also add a unit test to prevent regressions.