### PR TITLE
[Viewer] Ensure memory is 0-ed for orders that are filtered by token

### DIFF
--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -409,6 +409,12 @@ contract BatchExchangeViewer {
                 target,
                 offset + ADDRESS_WIDTH
             );
+        } else {
+            // NOTE: Ensure we write 0-s to the target memory location as we are
+            // reusing buffer and want to avoid stale data being left behind.
+            for (uint256 i = ADDRESS_WIDTH; i < AUCTION_ELEMENT_WIDTH; i++) {
+                target[i] = 0;
+            }
         }
     }
 }

--- a/test/batch_exchange_viewer.js
+++ b/test/batch_exchange_viewer.js
@@ -280,11 +280,11 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
         [0, 1],
         zero_address,
         0,
-        2,
+        2
       )
       const orders = decodeIndexedOrdersBN(result.elements)
       assert.equal(orders.length, 1, `unexpected second order ${JSON.stringify(orders[1])}`)
-    })
+    }),
   ])
 
   describe("getEncodedOrdersPaginated", async () => {

--- a/test/batch_exchange_viewer.js
+++ b/test/batch_exchange_viewer.js
@@ -259,7 +259,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       assert.equal(result.hasNextPage, true)
     }),
 
-    it.only("zeros the unfilted order page buffer for filtered tokens", async () => {
+    it("zeros the unfilted order page buffer for filtered tokens", async () => {
       const batchId = await batchExchange.getCurrentBatchId()
       await batchExchange.placeValidFromOrders(
         Array(3).fill(0), //buyToken

--- a/test/batch_exchange_viewer.js
+++ b/test/batch_exchange_viewer.js
@@ -258,6 +258,33 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       assert.equal(decodeIndexedOrdersBN(result.elements).length, 5)
       assert.equal(result.hasNextPage, true)
     }),
+
+    it.only("zeros the unfilted order page buffer for filtered tokens", async () => {
+      const batchId = await batchExchange.getCurrentBatchId()
+      await batchExchange.placeValidFromOrders(
+        Array(3).fill(0), //buyToken
+        [1, 1, 2], //sellToken
+        Array(3).fill(batchId), //validFrom
+        [batchId.addn(1), batchId, batchId.addn(1)], //validTo
+        [0, 1, 2], //buyAmounts
+        Array(3).fill(0) //sellAmounts
+      )
+      const viewer = await BatchExchangeViewer.new(batchExchange.address)
+
+      // We want to make sure that the order with token ID 2 that should be
+      // filtered indeed is. If the unfiltered order buffer was not getting 0-ed
+      // when an order was filtered by token ID then the following request would
+      // return 2 orders (the second one having duplicate data of first order).
+      const result = await viewer.getFilteredOrdersPaginated(
+        [batchId, batchId.addn(1), batchId.addn(1)],
+        [0, 1],
+        zero_address,
+        0,
+        2,
+      )
+      const orders = decodeIndexedOrdersBN(result.elements)
+      assert.equal(orders.length, 1, `unexpected second order ${JSON.stringify(orders[1])}`)
+    })
   ])
 
   describe("getEncodedOrdersPaginated", async () => {


### PR DESCRIPTION
This PR addresses an issue where the buffer used for unfiltered orders was not being 0-ed between requests in the paginated orderbook. This caused to the buffer to contain stale data and have orders that otherwise should be filtered not be.

To address the issue, this PR writes 0's to the order buffer when it is filtered by token.

### Test Plan

- CHeckout `c66da0e` that contains the new test and run it with `yarn test`. Observe than a second order was retrieved that shouldn't and that its data is the stale data of the first order:
- Checkout the head of this branch and run the test again and observe that this is no longer the case.