### PR TITLE
[Easy] Add offset to target buffer

### DIFF
--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -413,7 +413,7 @@ contract BatchExchangeViewer {
             // NOTE: Ensure we write 0-s to the target memory location as we are
             // reusing buffer and want to avoid stale data being left behind.
             for (uint256 i = ADDRESS_WIDTH; i < AUCTION_ELEMENT_WIDTH; i++) {
-                target[i] = 0;
+                target[i + offset] = 0;
             }
         }
     }

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -413,7 +413,8 @@ contract BatchExchangeViewer {
             // NOTE: Ensure we write 0-s to the target memory location as we are
             // reusing buffer and want to avoid stale data being left behind.
             for (uint256 i = ADDRESS_WIDTH; i < AUCTION_ELEMENT_WIDTH; i++) {
-                target[i + offset] = 0;
+                target[i] = 0;
+                // target[i + offset] = 0;
             }
         }
     }

--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -413,8 +413,7 @@ contract BatchExchangeViewer {
             // NOTE: Ensure we write 0-s to the target memory location as we are
             // reusing buffer and want to avoid stale data being left behind.
             for (uint256 i = ADDRESS_WIDTH; i < AUCTION_ELEMENT_WIDTH; i++) {
-                target[i] = 0;
-                // target[i + offset] = 0;
+                target[i + offset] = 0;
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,3 +1,4 @@
+
 {
   "name": "@gnosis.pm/dex-contracts",
   "version": "0.2.13",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,3 @@
-
 {
   "name": "@gnosis.pm/dex-contracts",
   "version": "0.2.13",

--- a/test/batch_exchange_viewer.js
+++ b/test/batch_exchange_viewer.js
@@ -259,7 +259,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       assert.equal(result.hasNextPage, true)
     }),
 
-    it.only("zeros the unfilted order page buffer for filtered tokens", async () => {
+    it("zeros the unfilted order page buffer for filtered tokens", async () => {
       const batchId = await batchExchange.getCurrentBatchId()
       const nextBatchId = batchId.addn(1)
       await batchExchange.placeValidFromOrders(
@@ -277,13 +277,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       // 0-ed when an order was filtered by token ID then the following request
       // would return 3 orders (the third one having duplicate data of first two
       // orders).
-      const result = await viewer.getFilteredOrdersPaginated(
-        [batchId, nextBatchId, nextBatchId],
-        [0, 1],
-        zero_address,
-        0,
-        3
-      )
+      const result = await viewer.getFilteredOrdersPaginated([batchId, nextBatchId, nextBatchId], [0, 1], zero_address, 0, 3)
       const orders = decodeIndexedOrdersBN(result.elements)
       assert.equal(orders.length, 2, `unexpected third order ${JSON.stringify(orders[2])}`)
     }),

--- a/test/batch_exchange_viewer.js
+++ b/test/batch_exchange_viewer.js
@@ -259,31 +259,33 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       assert.equal(result.hasNextPage, true)
     }),
 
-    it("zeros the unfilted order page buffer for filtered tokens", async () => {
+    it.only("zeros the unfilted order page buffer for filtered tokens", async () => {
       const batchId = await batchExchange.getCurrentBatchId()
+      const nextBatchId = batchId.addn(1)
       await batchExchange.placeValidFromOrders(
-        Array(3).fill(0), //buyToken
-        [1, 1, 2], //sellToken
-        Array(3).fill(batchId), //validFrom
-        [batchId.addn(1), batchId, batchId.addn(1)], //validTo
-        [0, 1, 2], //buyAmounts
-        Array(3).fill(0) //sellAmounts
+        Array(6).fill(0), //buyToken
+        [1, 1, 1, 2, 2, 2], //sellToken
+        Array(6).fill(batchId), //validFrom
+        [nextBatchId, batchId, nextBatchId, nextBatchId, nextBatchId, nextBatchId], //validTo
+        [0, 1, 2, 3, 4, 5], //buyAmounts
+        Array(6).fill(0) //sellAmounts
       )
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
 
-      // We want to make sure that the order with token ID 2 that should be
-      // filtered indeed is. If the unfiltered order buffer was not getting 0-ed
-      // when an order was filtered by token ID then the following request would
-      // return 2 orders (the second one having duplicate data of first order).
+      // We want to make sure that the orders with token ID 2 that should be
+      // filtered indeed are. If the unfiltered order buffer was not getting
+      // 0-ed when an order was filtered by token ID then the following request
+      // would return 3 orders (the third one having duplicate data of first two
+      // orders).
       const result = await viewer.getFilteredOrdersPaginated(
-        [batchId, batchId.addn(1), batchId.addn(1)],
+        [batchId, nextBatchId, nextBatchId],
         [0, 1],
         zero_address,
         0,
-        2
+        3
       )
       const orders = decodeIndexedOrdersBN(result.elements)
-      assert.equal(orders.length, 1, `unexpected second order ${JSON.stringify(orders[1])}`)
+      assert.equal(orders.length, 2, `unexpected third order ${JSON.stringify(orders[2])}`)
     }),
   ])
 


### PR DESCRIPTION
#698 introduced a bug where the target buffer was getting zeroed out in the first position and not in the position where the element was being encoded.

### Test Plan

Checkout `d6414f7` and see the test fail with order ID 5 not getting correctly filtered (and having duplicate data to order ID 2)

Checkout `fix_buffer_zeroing` and see the test now succeeds.