### PR TITLE
Change re-exports

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,8 @@
 import BN from "bn.js";
-import {BatchExchangeViewer} from "../build/types/BatchExchangeViewer";
+import { BatchExchangeViewer } from "../build/types/BatchExchangeViewer";
+
+export { BatchExchange } from "../build/types/BatchExchange";
+export { BatchExchangeViewer } from "../build/types/BatchExchangeViewer";
 export * from "./orderbook";
 export * from "./fraction";
 
@@ -54,7 +57,8 @@ export interface ContractArtifact {
   userdoc: any;
 }
 
-export declare const BatchExchange: ContractArtifact;
+export declare const BatchExchangeArtifact: ContractArtifact;
+export declare const BatchExchangeViewerArtifact: ContractArtifact;
 
 export interface Order {
   user: string;

--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@
  */
 
 module.exports = {
-  BatchExchange: require("../build/contracts/BatchExchange.json"),
-  BatchExchangeViewer: require("../build/contracts/BatchExchangeViewer.json"),
+  BatchExchangeArtifact: require("../build/contracts/BatchExchange.json"),
+  BatchExchangeViewerArtifact: require("../build/contracts/BatchExchangeViewer.json"),
   ...require("../build/common/src/fraction.js"),
   ...require("../build/common/src/orderbook.js"),
   ...require("./encoding.js"),


### PR DESCRIPTION
This PR changes how we re-export certain things in the `index.js` file:
- Artifacts are now re-exported as `${ContractName}Artifact`. **Note this is a breaking change**
- The generated contract typings are now re-exported from root as well. This makes using the `dex-contracts` module slightly easier with:
```
import { BatchExchange, BatchExchangeArtifact } from "@gnosis.pm/dex-contracts"

const { abi, networks } = BatchExchangeArtifact
const instance = new web3.eth.Contract(abi, networks[1].address) as BatchExchange
```

### Test Plan

This mostly changes our re-exports and doesn't have any real impact in the contracts code. This was just a pain-point when developing the event based orderbook where I had to dig into the package directory tree to find out where the types actually were.