### PR TITLE
[Events Orderbook] Apply Events to Auction State

### DIFF
--- a/src/streamed/events.ts
+++ b/src/streamed/events.ts
@@ -43,20 +43,3 @@ export type EventDiscriminant<
   event: T,
   returnValues: EventValues<C["events"][T]>,
 } : never
-
-/*
-import { BatchExchange } from "../.."
-export function tester() {
-  const eventData: AnyEvent<BatchExchange> = {} as any
-  switch (eventData.event) {
-  case "Token":
-    break
-  case "OrderPlacement":
-    eventData.returnValues.buyToken = "asdf"
-    break
-  case "Withdraw":
-    eventData.returnValues.buyToken = "asdf"
-    break
-  }
-}
-*/

--- a/src/streamed/events.ts
+++ b/src/streamed/events.ts
@@ -4,7 +4,7 @@ import { ContractEvent } from "../../build/types/types"
 /**
  * Event type specified by name.
  */
-type Event<
+export type Event<
   C extends Contract,
   T extends Exclude<keyof C["events"], "allEvents">,
 > = EventMetadata & EventDiscriminant<C, T>
@@ -17,6 +17,7 @@ type Event<
  * the `returnValues` property based on `event` property checks. For example:
  * ```
  * const eventData: AnyEvent<BatchExchange> = ...
+ * switch (eventData.event) {
  * case "Token":                              // ERR: 2678: Type '"Token"' is not comparable to type
  *                                            // '"OrderPlacement" | "TokenListing" | ...'
  *   break
@@ -30,14 +31,32 @@ type Event<
  * }
  * ```
  */
-type AnyEvent<C extends Contract> = EventMetadata & EventDiscriminant<C, Exclude<keyof C["events"], "allEvents">>
+export type AnyEvent<C extends Contract> = EventMetadata & EventDiscriminant<C, Exclude<keyof C["events"], "allEvents">>
 
-type EventMetadata = Omit<EventData, "event" | "returnValues">
-type EventValues<T> = T extends ContractEvent<infer U> ? U : never
-type EventDiscriminant<
+export type EventMetadata = Omit<EventData, "event" | "returnValues">
+export type EventName<C extends Contract> = Exclude<keyof C["events"], "allEvents">
+export type EventValues<T> = T extends ContractEvent<infer U> ? U : never
+export type EventDiscriminant<
   C extends Contract,
-  T extends Exclude<keyof C["events"], "allEvents">,
-> = T extends any ? {
+  T extends EventName<C>,
+> = T extends {} ? {
   event: T,
   returnValues: EventValues<C["events"][T]>,
 } : never
+
+/*
+import { BatchExchange } from "../.."
+export function tester() {
+  const eventData: AnyEvent<BatchExchange> = {} as any
+  switch (eventData.event) {
+  case "Token":
+    break
+  case "OrderPlacement":
+    eventData.returnValues.buyToken = "asdf"
+    break
+  case "Withdraw":
+    eventData.returnValues.buyToken = "asdf"
+    break
+  }
+}
+*/

--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -16,7 +16,7 @@
 import Web3 from "web3"
 import { TransactionReceipt } from "web3-core"
 import { BatchExchange, BatchExchangeArtifact } from "../.."
-import { AccountState } from "./state"
+import { AuctionState } from "./state"
 
 /**
  * Configuration options for the streamed orderbook.
@@ -78,7 +78,7 @@ export const BATCH_DURATION = 300
  * account state.
  */
 export class StreamedOrderbook {
-  private readonly state: AccountState;
+  private readonly state: AuctionState;
 
   private constructor(
     private readonly web3: Web3,
@@ -86,7 +86,7 @@ export class StreamedOrderbook {
     private readonly startBlock: number,
     private readonly options: OrderbookOptions,
   ) {
-    this.state = new AccountState(options)
+    this.state = new AuctionState(options)
   }
 
   /**

--- a/src/streamed/state.ts
+++ b/src/streamed/state.ts
@@ -1,32 +1,443 @@
-import assert from 'assert'
-import { EventData } from 'web3-eth-contract'
-import { OrderbookOptions } from '.'
+import assert from "assert"
+import { EventData } from "web3-eth-contract"
+import { OrderbookOptions } from "."
 
 /**
- * Manage the exchange's account state by incrementally applying events.
+ * An ethereum address.
  */
-export class AccountState {
+type Address = string;
+
+/**
+ * An exchange token ID.
+ */
+type TokenId = number;
+
+/**
+ * Internal representation of a user account.
+ */
+interface Account {
+  /**
+   * Mapping from a token address to an amount representing the account's total
+   * balance in the exchange.
+   *
+   * @remarks
+   * Pending withdrawal amounts are not included in this balance although they
+   * affect the available balance of the account.
+   */
+  balances: Map<Address, bigint>,
+
+  /**
+   * Mapping from a token address to a pending withdrawal.
+   */
+  pendingWithdrawals: Map<Address, PendingWithdrawal>,
+
+  /**
+   * All user orders including valid, invalid, cancelled and deleted orders.
+   *
+   * @remarks
+   * Since user order IDs increase by 1 for each new order, an order can be
+   * retrieved by ID for an account with `account.orders[orderId]`.
+   */
+  orders: Order[],
+}
+
+/**
+ * Internal representation of a pending withdrawal.
+ */
+interface PendingWithdrawal {
+  /**
+   * The batch ID when the withdrawal request matures, i.e. the amount is no
+   * longer included in the account's available balance and up to the amount can
+   * be withdrawn by the user.
+   */
+  batchId: number,
+
+  /**
+   * The requested withdrawal amount.
+   */
+  amount: bigint,
+}
+
+/**
+ * Internal representation of an order.
+ */
+interface Order {
+  buyToken: TokenId,
+  sellToken: TokenId,
+  validFrom: number,
+  validUntil: number | null,
+  priceNumerator: bigint,
+  priceDenominator: bigint,
+  remainingAmount: bigint,
+}
+
+/**
+ * Amount used to signal that an order is an unlimited order.
+ */
+const UNLIMITED_ORDER_AMOUNT = BigInt(2 ** 128) - BigInt(1)
+
+/**
+ * JSON representation of the account state.
+ */
+export interface AuctionStateJson {
+  tokens: { [key: string]: string },
+  accounts: {
+    [key: string]: {
+      balances: { [key: string]: string },
+      pendingWithdrawals: { [key: string]: { batchId: number, amount: string } },
+      orders: {
+        buyToken: TokenId,
+        sellToken: TokenId,
+        validFrom: number,
+        validUntil: number | null,
+        priceNumerator: string,
+        priceDenominator: string,
+        remainingAmount: string,
+      }[],
+    }
+  },
+}
+
+/**
+ * Manage the exchange's auction state by incrementally applying events.
+ */
+export class AuctionState {
   private lastBlock: number = -1;
+
+  private readonly tokens: Map<TokenId, Address> = new Map();
+  private readonly accounts: Map<Address, Account> = new Map();
+  private lastSolution?: { submitter: Address, burntFees: bigint };
 
   constructor(
     private readonly options: OrderbookOptions,
   ) {}
 
   /**
-   * Apply specified ordered events.
+   * Create an object representation of the current account state for JSON
+   * serialization.
+   */
+  public toJSON(): AuctionStateJson {
+    function map2obj<K extends { toString: () => string }, V, T>(
+      map: Map<K, V>,
+      convert: (value: V) => T,
+    ): { [key: string]: T } {
+      const result: { [key: string]: T } = {}
+      for (const [key, value] of map.entries()) {
+        result[key.toString()] = convert(value)
+      }
+      return result
+    }
+
+    return {
+      tokens: map2obj(this.tokens, addr => addr),
+      accounts: map2obj(this.accounts, account => ({
+        balances: map2obj(account.balances, balance => balance.toString()),
+        pendingWithdrawals: map2obj(
+          account.pendingWithdrawals,
+          withdrawal => ({
+            ...withdrawal,
+            amount: withdrawal.amount.toString(),
+          }),
+        ),
+        orders: account.orders.map(order => ({
+          ...order,
+          priceNumerator: order.priceNumerator.toString(),
+          priceDenominator: order.priceDenominator.toString(),
+          remainingAmount: order.remainingAmount.toString(),
+        })),
+      })),
+    }
+  }
+
+  /**
+   * Retrieves block number the account state is accepting events for.
+   */
+  public get nextBlock(): number {
+    return this.lastBlock + 1
+  }
+
+  /**
+   * Apply all specified ordered events.
    *
    * @remarks
    * This method expects that once events have been applied up until a certain
-   * block, then no new events from that block (or an earlier block) will be
-   * applied.
+   * block number, then no new events for that block number (or an earlier block
+   * number) are applied.
+   *
    */
-  public applyEvents(events: EventData[]): void {
+  public applyEvents(events: EventData[]) {
     if (this.options.strict) {
       assertEventsAreAfterBlockAndOrdered(this.lastBlock, events)
     }
-    this.lastBlock = events[events.length - 1]?.blockNumber || this.lastBlock
+    this.lastBlock = events[events.length - 1]?.blockNumber ?? this.lastBlock
 
-    // TODO(nlordell): Actually apply events to state.
+    for (const ev of events) {
+      const data = ev.returnValues
+      switch (ev.event) {
+      case "Deposit":
+        this.updateBalance(
+          data.user,
+          data.token,
+          amount => amount + BigInt(data.amount),
+        )
+        break
+      case "OrderCancellation":
+        this.order(data.owner, parseInt(data.id)).validUntil = null
+        break
+      case "OrderDeletion":
+        this.deleteOrder(data.owner, parseInt(data.id))
+        break
+      case "OrderPlacement":
+        this.addOrder(data.owner, {
+          buyToken: parseInt(data.buyToken),
+          sellToken: parseInt(data.sellToken),
+          validFrom: parseInt(data.validFrom),
+          validUntil: parseInt(data.validUntil),
+          priceNumerator: BigInt(data.priceNumerator),
+          priceDenominator: BigInt(data.priceDenominator),
+          remainingAmount: BigInt(data.priceDenominator),
+        })
+        break
+      case "SolutionSubmission":
+        /* eslint-disable no-case-declarations */
+        const submitter = data.submitter
+        const burntFees = BigInt(data.burntFees)
+        this.updateBalance(submitter, 0, amount => amount + burntFees)
+        this.lastSolution = { submitter, burntFees }
+        break
+      case "TokenListing":
+        this.addToken(parseInt(data.id), data.token)
+        break
+      case "Trade":
+        this.lastSolution = undefined
+        this.updateBalance(
+          data.owner,
+          parseInt(data.sellToken),
+          amount => amount - BigInt(data.executedSellAmount),
+        )
+        this.updateOrderRemainingAmount(
+          data.owner,
+          parseInt(data.orderId),
+          amount => amount - BigInt(data.executedSellAmount),
+        )
+        this.updateBalance(
+          data.owner,
+          parseInt(data.buyToken),
+          amount => amount + BigInt(data.executedBuyAmount),
+        )
+        break
+      case "TradeReversion":
+        if (this.lastSolution !== undefined) {
+          const { submitter, burntFees } = this.lastSolution
+          this.updateBalance(submitter, 0, amount => amount - burntFees)
+          this.lastSolution = undefined
+        }
+        this.updateBalance(
+          data.owner,
+          parseInt(data.sellToken),
+          amount => amount + BigInt(data.executedSellAmount),
+        )
+        this.updateOrderRemainingAmount(
+          data.owner,
+          parseInt(data.orderId),
+          amount => amount + BigInt(data.executedSellAmount),
+        )
+        this.updateBalance(
+          data.owner,
+          parseInt(data.buyToken),
+          amount => amount - BigInt(data.executedBuyAmount),
+        )
+        break
+      case "WithdrawRequest":
+        this.setPendingWithdrawal(
+          data.user,
+          data.token,
+          parseInt(data.batchId),
+          BigInt(data.amount),
+        )
+        break
+      case "Withdraw":
+        const newBalance = this.updateBalance(
+          data.user,
+          data.token,
+          amount => amount - BigInt(data.amount),
+        )
+        if (this.options.strict) {
+          assert(
+            newBalance >= BigInt(0),
+            `overdrew user ${data.user} token ${data.token} balance`,
+          )
+        }
+        this.clearPendingWithdrawal(data.user, data.token)
+        break
+      default:
+        throw new UnhandledEventError(ev)
+      }
+    }
+
+    if (this.options.strict) {
+      assertAccountsAreValid(this.lastBlock, this.accounts.entries())
+    }
+  }
+
+  /**
+   * Adds a token to the account state.
+   *
+   * @throws If a token with the same ID has already been added.
+   */
+  private addToken(id: TokenId, addr: Address): void {
+    this.tokens.set(id, addr)
+  }
+
+  /**
+   * Normalizes a token ID or address to a token address.
+   *
+   * @throws If the token address is an invalid address or if the token id is
+   * not registered. This is done because event token IDs and addresses are both
+   * strings and can both be parsed into integers which is hard to enforce with
+   * just type-safety.
+   */
+  private tokenAddr(token: TokenId | Address): Address {
+    if (typeof token === "string") {
+      assert(
+        token.startsWith("0x") && token.length === 42,
+        `invalid token address ${token}`,
+      )
+      return token
+    } else {
+      const tokenAddr = this.tokens.get(token)
+      assert(tokenAddr, `missing token ${token}`)
+      return tokenAddr!
+    }
+  }
+
+  /**
+   * Gets the account data for the specified user, creating an empty one if it
+   * does not already exist.
+   */
+  private account(user: Address): Account {
+    let account = this.accounts.get(user)
+    if (account === undefined) {
+      account = {
+        balances: new Map(),
+        pendingWithdrawals: new Map(),
+        orders: [],
+      }
+      this.accounts.set(user, account)
+    }
+
+    return account
+  }
+
+  /**
+   * Updates a user's account balance.
+   */
+  private updateBalance(
+    user: Address,
+    token: TokenId | Address,
+    update: (amount: bigint) => bigint,
+  ): bigint {
+    const tokenAddr = this.tokenAddr(token)
+    const balances = this.account(user).balances
+    const newBalance = update(balances.get(tokenAddr) || BigInt(0))
+    balances.set(tokenAddr, newBalance)
+    return newBalance
+  }
+
+  /**
+   * Sets a pending withdrawal for a user for the specified token and amount.
+   */
+  private setPendingWithdrawal(
+    user: Address,
+    token: TokenId | Address,
+    batchId: number,
+    amount: bigint,
+  ): void {
+    const tokenAddr = this.tokenAddr(token)
+    if (this.options.strict) {
+      const existingBatch = this.account(user).pendingWithdrawals.get(tokenAddr)?.batchId
+      assert(
+        existingBatch === undefined || existingBatch === batchId,
+        `pending withdrawal for user ${user} modified from batch ${existingBatch} to ${batchId}`,
+      )
+    }
+    this.account(user).pendingWithdrawals.set(tokenAddr, { batchId, amount })
+  }
+
+  /**
+   * Clears a pending withdrawal.
+   */
+  private clearPendingWithdrawal(
+    user: Address,
+    token: TokenId | Address,
+  ): void {
+    const tokenAddr = this.tokenAddr(token)
+    this.account(user).pendingWithdrawals.delete(tokenAddr)
+  }
+
+  /**
+   * Adds a user order and returns the order ID of the newly created order.
+   */
+  private addOrder(user: Address, order: Order): number {
+    const userOrders = this.account(user).orders
+    userOrders.push(order)
+    return userOrders.length - 1
+  }
+
+  /**
+   * Retrieves an existing user order by user address and order ID.
+   *
+   * @throws If the order does not exist.
+   */
+  private order(user: Address, orderId: number): Order {
+    const order = this.account(user).orders[orderId]
+    assert(order, `attempted to retrieve missing order ${orderId} for user ${user}`)
+    return order
+  }
+
+  /**
+   * Updates a user's order's remaining amount. For unlimited orders, the
+   * remaining amount remains unchanged.
+   *
+   * @throws If the order does not exist.
+   */
+  private updateOrderRemainingAmount(
+    user: Address,
+    orderId: number,
+    update: (amount: bigint) => bigint,
+  ) {
+    const order = this.order(user, orderId)
+    if (
+      order.priceNumerator !== UNLIMITED_ORDER_AMOUNT &&
+      order.priceDenominator !== UNLIMITED_ORDER_AMOUNT
+    ) {
+      order.remainingAmount = update(order.remainingAmount)
+    }
+  }
+
+  /**
+   * Sets a user's order to all 0's.
+   *
+   * @throws If the order does not exist.
+   */
+  private deleteOrder(user: Address, orderId: number): void {
+    const order = this.order(user, orderId)
+    order.buyToken = 0
+    order.sellToken = 0
+    order.validFrom = 0
+    order.validUntil = 0
+    order.priceNumerator = BigInt(0)
+    order.priceDenominator = BigInt(0)
+    order.remainingAmount = BigInt(0)
+  }
+}
+
+/**
+ * An error that is thrown on a unhandled contract event.
+ */
+export class UnhandledEventError extends Error {
+  constructor(public readonly ev: EventData) {
+    super(`unhandled ${ev.event} event`)
   }
 }
 
@@ -48,5 +459,30 @@ function assertEventsAreAfterBlockAndOrdered(block: number, events: EventData[])
     )
     blockNumber = ev.blockNumber
     logIndex = ev.logIndex
+  }
+}
+
+/**
+ * Asserts that all accounts are valid by ensuring that all token balances and
+ * order remaining amounts are positive
+ *
+ * @throws If an account has an invalid amount.
+ */
+function assertAccountsAreValid(blockNumber: number, accounts: Iterable<[Address, Account]>) {
+  for (const [user, { balances, orders }] of accounts) {
+    for (const [token, balance] of balances.entries()) {
+      assert(
+        balance >= BigInt(0),
+        `user ${user} token ${token} is negative at block ${blockNumber}`,
+      )
+    }
+
+    for (let id = 0; id < orders.length; id++) {
+      const order = orders[id]
+      assert(
+        order.remainingAmount >= BigInt(0),
+        `user ${user} order ${id} is negative at block ${blockNumber}`,
+      )
+    }
   }
 }

--- a/test/models/streamed/state.spec.ts
+++ b/test/models/streamed/state.spec.ts
@@ -1,0 +1,203 @@
+import { expect } from "chai"
+import { BatchExchange } from "../../../src"
+import { DEFAULT_ORDERBOOK_OPTIONS } from "../../../src/streamed"
+import { AuctionState } from "../../../src/streamed/state"
+import { AnyEvent, EventName, EventValues } from "../../../src/streamed/events"
+
+function auctionState(): AuctionState {
+  return new AuctionState(
+    { ...DEFAULT_ORDERBOOK_OPTIONS, strict: true },
+  )
+}
+
+type Named<T> = Pick<T, keyof T & string>
+
+function event<
+  K extends EventName<BatchExchange>,
+  V extends BatchExchange["events"][K],
+>(
+  block: number,
+  name: K,
+  data:  Named<EventValues<V>>,
+  index: number = 0,
+): AnyEvent<BatchExchange> {
+  // NOTE: Cast to `any` as there are missing event data properties that the
+  // account state doesn't care about.
+  return {
+    event: name,
+    blockNumber: block,
+    returnValues: data,
+    logIndex: index || 0,
+  } as any
+}
+
+function addr(lowerBits: number): string {
+  return `0x${lowerBits.toString(16).padStart(40, "0")}`
+}
+
+describe("Account State", () => {
+  describe("applyEventsUntilBatch", () => {
+    it("Updates the batch ID", async () => {
+      const state = auctionState()
+      state.applyEvents([
+        event(0, "TokenListing", { id: "0", token: addr(1) }),
+      ])
+      expect(state.nextBlock).to.equal(1)
+    })
+
+    it("Throws when past block is applied", async () => {
+      const state = auctionState()
+      state.applyEvents([
+        event(10, "TokenListing", { id: "0", token: addr(1) }),
+      ])
+      expect(() => state.applyEvents([
+        event(1, "TokenListing", { id: "1", token: addr(1) }),
+      ])).to.throw()
+    })
+
+    it("Throws when events are out of order", async () => {
+      const state = auctionState()
+      expect(() => state.applyEvents([
+        event(2, "TokenListing", { id: "0", token: addr(1) }),
+        event(1, "TokenListing", { id: "0", token: addr(1) }),
+      ])).to.throw()
+    })
+  })
+
+  describe("OrderPlacement > OrderCancellation > OrderDeletion", () => {
+    it("Sets the order valid until to null", async () => {
+      const state = auctionState()
+      state.applyEvents([
+        event(1, "TokenListing", { id: "0", token: addr(0) }, 1),
+        event(1, "TokenListing", { id: "1", token: addr(1) }, 2),
+        event(1, "OrderPlacement", {
+          owner: addr(3),
+          index: "0",
+          buyToken: "0",
+          sellToken: "1",
+          validFrom: "2",
+          validUntil: "99999",
+          priceNumerator: "100000",
+          priceDenominator: "100000",
+        }, 3),
+      ])
+      expect(state.toJSON().accounts[addr(3)].orders[0].remainingAmount).to.equal("100000")
+
+      state.applyEvents([
+        event(3, "OrderCancellation", { owner: addr(3), id: "0" }),
+      ])
+      expect(state.toJSON().accounts[addr(3)].orders[0].validUntil).to.be.null
+
+      state.applyEvents([
+        event(6, "OrderDeletion", { owner: addr(3), id: "0" }),
+      ])
+      expect(state.toJSON().accounts[addr(3)].orders[0]).to.deep.equal({
+        buyToken: 0,
+        sellToken: 0,
+        validFrom: 0,
+        validUntil: 0,
+        priceNumerator: "0",
+        priceDenominator: "0",
+        remainingAmount: "0",
+      })
+    })
+
+    it("throws for nonexistent order", async () => {
+      const state = auctionState()
+      expect(() => state.applyEvents([
+        event(0, "OrderCancellation", { owner: addr(3), id: "0" }),
+      ])).to.throw()
+
+      expect(() => state.applyEvents([
+        event(0, "OrderDeletion", { owner: addr(3), id: "0" }),
+      ])).to.throw()
+    })
+  })
+
+  describe("Deposit", () => {
+    it("Adds a user balance and updates it if already existing", async () => {
+      const state = auctionState()
+      state.applyEvents([
+        event(0, "Deposit", {
+          user: addr(1),
+          token: addr(0),
+          amount: "100000",
+          batchId: "1",
+        }),
+      ])
+      expect(state.toJSON().accounts[addr(1)].balances[addr(0)]).to.equal("100000")
+
+      state.applyEvents([
+        event(1, "Deposit", {
+          user: addr(1),
+          token: addr(0),
+          amount: "100000",
+          batchId: "1",
+        }),
+      ])
+      expect(state.toJSON().accounts[addr(1)].balances[addr(0)]).to.equal("200000")
+    })
+  })
+
+  describe("WithdrawalRequest > Withdraw", () => {
+    it("Updates balance on withdraw", async () => {
+      const state = auctionState()
+      state.applyEvents([
+        event(0, "Deposit", {
+          user: addr(1),
+          token: addr(0),
+          amount: "100000",
+          batchId: "1",
+        }),
+        event(1, "WithdrawRequest", {
+          user: addr(1),
+          token: addr(0),
+          amount: "100000",
+          batchId: "1",
+        }),
+      ])
+      expect(state.toJSON().accounts[addr(1)].pendingWithdrawals[addr(0)]).to.deep.equal({
+        batchId: 1,
+        amount: "100000",
+      })
+
+      state.applyEvents([
+        event(2, "Withdraw", {
+          user: addr(1),
+          token: addr(0),
+          amount: "50000",
+        }),
+      ])
+      expect(state.toJSON().accounts[addr(1)].balances[addr(0)]).to.equal("50000")
+      expect(state.toJSON().accounts[addr(1)].pendingWithdrawals[addr(0)]).to.be.undefined
+    })
+
+    it("Always works when withdrawing 0", async () => {
+      const state = auctionState()
+      state.applyEvents([
+        event(1, "Withdraw", {
+          user: addr(1),
+          token: addr(0),
+          amount: "0",
+        }),
+      ])
+    })
+
+    it("Throws when there is not enough balance", async () => {
+      const state = auctionState()
+      expect(() => state.applyEvents([
+        event(1, "WithdrawRequest", {
+          user: addr(1),
+          token: addr(0),
+          amount: "100000",
+          batchId: "100",
+        }),
+        event(2, "Withdraw", {
+          user: addr(1),
+          token: addr(0),
+          amount: "100000",
+        }),
+      ])).to.throw()
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     /* Basic Options */
     // "incremental": true,                   /* Enable incremental compilation */
-    "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+    "target": "es2015" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "commonjs" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */


### PR DESCRIPTION
This PR was moved from gnosis/dex-price-estimator#24, gnosis/dex-price-estimator#25, gnosis/dex-price-estimator#31

This PR implements the logic for updating the auction state based on incoming events.

Closes #717

Note that there are some outstanding comments from the original PRs that I have copied over to here.

### Test Plan

Unit tests to verify the account state updating logic. Run the event based orderbook e2e to see the orderbook get constructed from events.
```
yarn test-streamed-orderbook
```