### PR TITLE
[Events Orderbook] Implement auction state update fiber

### DIFF
--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -240,7 +240,7 @@ export class StreamedOrderbook {
             this.scheduleUpdate()
           }
         } catch (err) {
-          this.options.logger?.error(`error applying new events: ${err}`)
+          this.options.logger?.error(`error applying new events up to block ${this.state.nextBlock - 1}: ${err}`)
           this.updateError = err
         }
       },

--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -163,8 +163,8 @@ export class StreamedOrderbook {
    * events with multiple queries to retrieve each block page at a time.
    */
   private async applyPastEvents(): Promise<void> {
-    const endBlock = this.options.endBlock ||
-      await this.web3.eth.getBlockNumber()
+    const endBlock = this.options.endBlock ??
+      (await this.web3.eth.getBlockNumber() - this.options.blockConfirmations)
 
     for (
       let fromBlock = this.startBlock;


### PR DESCRIPTION
This PR was moved from gnosis/dex-price-estimator#32

This PR implements initial logic to periodically poll the node for new events and update the account state accordingly.

Closes #718 

### Test Plan

Plan on implementing an integrity test to ensure that the retrieved orderbook matches the onchain filtered orderbook.