### PR TITLE
[Events Orderbook] Refactor `applyEvent` Logic

### DIFF
--- a/src/streamed/events.ts
+++ b/src/streamed/events.ts
@@ -2,12 +2,12 @@ import { Contract, EventData } from "web3-eth-contract"
 import { ContractEvent } from "../../build/types/types"
 
 /**
- * Event type specified by name.
+ * Event data type specified by name.
  */
 export type Event<
   C extends Contract,
   T extends Exclude<keyof C["events"], "allEvents">,
-> = EventMetadata & EventDiscriminant<C, T>
+> = EventValues<C["events"][T]>
 
 /**
  * Concrete event type with known properties based on the event name.
@@ -41,5 +41,5 @@ export type EventDiscriminant<
   T extends EventName<C>,
 > = T extends {} ? {
   event: T,
-  returnValues: EventValues<C["events"][T]>,
+  returnValues: Event<C, T>,
 } : never

--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -149,7 +149,7 @@ export class StreamedOrderbook {
         endBlock,
       )
 
-      this.options.logger?.debug(`fetching page ${fromBlock}-${toBlock}`)
+      this.options.logger?.debug(`fetching past events from ${fromBlock}-${toBlock}`)
       const events = await this.getPastEvents({ fromBlock, toBlock })
 
       this.options.logger?.debug(`applying ${events.length} past events`)
@@ -188,7 +188,7 @@ export class StreamedOrderbook {
     if (confirmedEvents.length > 0) {
       this.options.logger?.debug(`applying ${confirmedEvents.length} confirmed events until block ${confirmedBlock}`)
       try {
-        this.state.applyEvents(confirmedEvents as any)
+        this.state.applyEvents(confirmedEvents)
       } catch (err) {
         this.invalidState = new InvalidAuctionStateError(confirmedBlock, err)
         this.options.logger?.error(this.invalidState.message)

--- a/src/streamed/state.ts
+++ b/src/streamed/state.ts
@@ -82,7 +82,7 @@ const UNLIMITED_ORDER_AMOUNT = BigInt(2 ** 128) - BigInt(1)
  * JSON representation of the account state.
  */
 export interface AuctionStateJson {
-  tokens: { [key: string]: string },
+  tokens: string[],
   accounts: {
     [key: string]: {
       balances: { [key: string]: string },
@@ -106,7 +106,7 @@ export interface AuctionStateJson {
 export class AuctionState {
   private lastBlock: number = -1;
 
-  private readonly tokens: Map<TokenId, Address> = new Map();
+  private readonly tokens: Address[] = [];
   private readonly accounts: Map<Address, Account> = new Map();
   private lastSolution?: Event<BatchExchange, "SolutionSubmission">;
 
@@ -131,7 +131,7 @@ export class AuctionState {
     }
 
     return {
-      tokens: map2obj(this.tokens, addr => addr),
+      tokens: this.tokens.slice(0),
       accounts: map2obj(this.accounts, account => ({
         balances: map2obj(account.balances, balance => balance.toString()),
         pendingWithdrawals: map2obj(
@@ -315,15 +315,14 @@ export class AuctionState {
    * In strict mode, throws if the token has already been listed.
    */
   private applyTokenListing({ id, token }: Event<BatchExchange, "TokenListing">) {
-    const tokenId = parseInt(id)
     if (this.options.strict) {
       assert(
-        this.tokens.get(tokenId) === undefined,
-        `token ${tokenId} has already been listed`,
+        this.tokens.length === parseInt(id),
+        `token ${token} with ID ${id} added as the ${this.tokens.length} token`,
       )
     }
 
-    this.tokens.set(parseInt(id), token)
+    this.tokens.push(token)
   }
 
   /**
@@ -436,9 +435,9 @@ export class AuctionState {
       )
       return token
     } else {
-      const tokenAddr = this.tokens.get(token)
-      assert(tokenAddr, `missing token ${token}`)
-      return tokenAddr!
+      const tokenAddr = this.tokens[token]
+      assert(tokenAddr !== undefined, `missing token ${token}`)
+      return tokenAddr
     }
   }
 

--- a/src/streamed/state.ts
+++ b/src/streamed/state.ts
@@ -302,7 +302,7 @@ export class AuctionState {
     if (this.options.strict) {
       for (const [user, { balances }] of this.accounts.entries()) {
         for (const [token, balance] of balances.entries()) {
-          assert(balance >= BigInt(0), `user ${user} token ${token} is negative`)
+          assert(balance >= BigInt(0), `user ${user} token ${token} balance is negative`)
         }
       }
     }
@@ -506,7 +506,7 @@ export class AuctionState {
       if (this.options.strict) {
         assert(
           order.remainingAmount >= BigInt(0),
-          `user ${user} order ${orderId} is negative`,
+          `user ${user} order ${orderId} remaining amount is negative`,
         )
       }
     }

--- a/src/streamed/state.ts
+++ b/src/streamed/state.ts
@@ -396,8 +396,8 @@ export class AuctionState {
    * Applies a withdraw request event to the auction state.
    *
    * @throws
-   * In strict mode, throws if the withdraw request is placed in the over top of
-   * and existing unapplied request.
+   * In strict mode, throws if the withdraw request is placed over top of an
+   * existing unapplied request.
    */
   private applyWithdrawRequest(
     { user, token, batchId, amount }: Event<BatchExchange, "WithdrawRequest">,

--- a/src/streamed/state.ts
+++ b/src/streamed/state.ts
@@ -1,6 +1,8 @@
 import assert from "assert"
 import { EventData } from "web3-eth-contract"
+import { BatchExchange } from "../.."
 import { OrderbookOptions } from "."
+import { AnyEvent, Event } from "./events"
 
 /**
  * An ethereum address.
@@ -106,7 +108,7 @@ export class AuctionState {
 
   private readonly tokens: Map<TokenId, Address> = new Map();
   private readonly accounts: Map<Address, Account> = new Map();
-  private lastSolution?: { submitter: Address, burntFees: bigint };
+  private lastSolution?: Event<BatchExchange, "SolutionSubmission">;
 
   constructor(
     private readonly options: OrderbookOptions,
@@ -165,135 +167,275 @@ export class AuctionState {
    * number) are applied.
    *
    */
-  public applyEvents(events: EventData[]): void {
+  public applyEvents(events: AnyEvent<BatchExchange>[]): void {
     if (this.options.strict) {
       assertEventsAreAfterBlockAndOrdered(this.lastBlock, events)
     }
     this.lastBlock = events[events.length - 1]?.blockNumber ?? this.lastBlock
 
-    /* eslint-disable no-case-declarations */
     for (const ev of events) {
-      const data = ev.returnValues
       switch (ev.event) {
       case "Deposit":
-        this.updateBalance(
-          data.user,
-          data.token,
-          amount => amount + BigInt(data.amount),
-        )
+        this.applyDeposit(ev.returnValues)
         break
       case "OrderCancellation":
-        this.order(data.owner, parseInt(data.id)).validUntil = null
+        this.applyOrderCancellation(ev.returnValues)
         break
       case "OrderDeletion":
-        this.deleteOrder(data.owner, parseInt(data.id))
+        this.applyOrderDeletion(ev.returnValues)
         break
       case "OrderPlacement":
-        const orderId = this.addOrder(data.owner, {
-          buyToken: parseInt(data.buyToken),
-          sellToken: parseInt(data.sellToken),
-          validFrom: parseInt(data.validFrom),
-          validUntil: parseInt(data.validUntil),
-          priceNumerator: BigInt(data.priceNumerator),
-          priceDenominator: BigInt(data.priceDenominator),
-          remainingAmount: BigInt(data.priceDenominator),
-        })
-        if (this.options.strict) {
-          assert(
-            orderId == parseInt(data.index),
-            `user ${data.user} order ${data.index} added as the ${orderId}th order`,
-          )
-        }
+        this.applyOrderPlacement(ev.returnValues)
         break
       case "SolutionSubmission":
-        const submitter = data.submitter
-        const burntFees = BigInt(data.burntFees)
-        this.updateBalance(submitter, 0, amount => amount + burntFees)
-        this.lastSolution = { submitter, burntFees }
+        this.applySolutionSubmission(ev.returnValues)
+        this.lastSolution = ev.returnValues
         break
       case "TokenListing":
-        this.addToken(parseInt(data.id), data.token)
+        this.applyTokenListing(ev.returnValues)
         break
       case "Trade":
         this.lastSolution = undefined
-        this.updateBalance(
-          data.owner,
-          parseInt(data.sellToken),
-          amount => amount - BigInt(data.executedSellAmount),
-        )
-        this.updateOrderRemainingAmount(
-          data.owner,
-          parseInt(data.orderId),
-          amount => amount - BigInt(data.executedSellAmount),
-        )
-        this.updateBalance(
-          data.owner,
-          parseInt(data.buyToken),
-          amount => amount + BigInt(data.executedBuyAmount),
-        )
+        this.applyTrade(ev.returnValues)
         break
       case "TradeReversion":
         if (this.lastSolution !== undefined) {
-          const { submitter, burntFees } = this.lastSolution
-          this.updateBalance(submitter, 0, amount => amount - burntFees)
+          this.applySolutionReversion(this.lastSolution)
           this.lastSolution = undefined
         }
-        this.updateBalance(
-          data.owner,
-          parseInt(data.sellToken),
-          amount => amount + BigInt(data.executedSellAmount),
-        )
-        this.updateOrderRemainingAmount(
-          data.owner,
-          parseInt(data.orderId),
-          amount => amount + BigInt(data.executedSellAmount),
-        )
-        this.updateBalance(
-          data.owner,
-          parseInt(data.buyToken),
-          amount => amount - BigInt(data.executedBuyAmount),
-        )
+        this.applyTradeReversion(ev.returnValues)
         break
       case "WithdrawRequest":
-        this.setPendingWithdrawal(
-          data.user,
-          data.token,
-          parseInt(data.batchId),
-          BigInt(data.amount),
-        )
+        this.applyWithdrawRequest(ev.returnValues)
         break
       case "Withdraw":
-        const newBalance = this.updateBalance(
-          data.user,
-          data.token,
-          amount => amount - BigInt(data.amount),
-        )
-        if (this.options.strict) {
-          assert(
-            newBalance >= BigInt(0),
-            `overdrew user ${data.user} token ${data.token} balance`,
-          )
-        }
-        this.clearPendingWithdrawal(data.user, data.token)
+        this.applyWithdraw(ev.returnValues)
         break
       default:
         throw new UnhandledEventError(ev)
       }
     }
-    /* eslint-enable no-case-declarations */
+  }
 
+  /**
+   * Applies a deposit event to the auction state.
+   */
+  private applyDeposit(
+    { user, token, amount: depositAmount }: Event<BatchExchange, "Deposit">,
+  ) {
+    this.updateBalance(user, token, amount => amount + BigInt(depositAmount))
+  }
+
+  /**
+   * Applies an order cancellation event to the auction state.
+   */
+  private applyOrderCancellation({ owner, id }: Event<BatchExchange, "OrderCancellation">) {
+    // TODO(nlordell): We need to pre-fetch the batch ID based on the block
+    // number for this event to be able to accurately set this value.
+    this.order(owner, parseInt(id)).validUntil = null
+  }
+
+  /**
+   * Applies an order deletion event to the auction state.
+   */
+  private applyOrderDeletion({ owner, id }: Event<BatchExchange, "OrderDeletion">) {
+    const order = this.order(owner, parseInt(id))
+    order.buyToken = 0
+    order.sellToken = 0
+    order.validFrom = 0
+    order.validUntil = 0
+    order.priceNumerator = BigInt(0)
+    order.priceDenominator = BigInt(0)
+    order.remainingAmount = BigInt(0)
+  }
+
+  /**
+   * Applies an order placement event to the auction state.
+   *
+   * @throws
+   * In strict mode, throws if the order ID from the event does not match the
+   * expected order ID based on the number of previously placed orders.
+   */
+  private applyOrderPlacement(order: Event<BatchExchange, "OrderPlacement">) {
+    const userOrders = this.account(order.owner).orders
+    const orderId = userOrders.length
     if (this.options.strict) {
-      assertAccountsAreValid(this.lastBlock, this.accounts.entries())
+      assert(
+        orderId == parseInt(order.index),
+        `user ${order.owner} order ${order.index} added as the ${orderId}th order`,
+      )
+    }
+
+    userOrders.push({
+      buyToken: parseInt(order.buyToken),
+      sellToken: parseInt(order.sellToken),
+      validFrom: parseInt(order.validFrom),
+      validUntil: parseInt(order.validUntil),
+      priceNumerator: BigInt(order.priceNumerator),
+      priceDenominator: BigInt(order.priceDenominator),
+      remainingAmount: BigInt(order.priceDenominator),
+    })
+  }
+
+  /**
+   * Applies an emulated solution reversion event.
+   *
+   * @throws
+   * In strict mode, throws if the account balances are left in an invalid state
+   * while applying a solution. See `applySolutionSubmission` documentation for
+   * more details.
+   */
+  private applySolutionReversion(
+    { submitter, burntFees }: Event<BatchExchange, "SolutionSubmission">,
+  ) {
+    this.updateBalance(submitter, 0, amount => amount - BigInt(burntFees))
+    if (this.options.strict) {
+      assertAccountBalancesAreValid(this.lastBlock, this.accounts.entries())
     }
   }
 
   /**
-   * Adds a token to the account state.
+   * Applies a solution submission event to the auction state.
    *
-   * @throws If a token with the same ID has already been added.
+   * @throws
+   * In strict mode, throws if the account balances are left in an invalid state
+   * while applying a solution. This check has to be done after applying all
+   * trades, as a user balance can temporarily go below 0 when a solution is
+   * being applied.
    */
-  private addToken(id: TokenId, addr: Address): void {
-    this.tokens.set(id, addr)
+  private applySolutionSubmission(
+    { submitter, burntFees }: Event<BatchExchange, "SolutionSubmission">,
+  ) {
+    this.updateBalance(submitter, 0, amount => amount + BigInt(burntFees))
+    if (this.options.strict) {
+      assertAccountBalancesAreValid(this.lastBlock, this.accounts.entries())
+    }
+  }
+
+  /**
+   * Applies a token listing event and adds a token to the account state.
+   *
+   * @throws
+   * In strict mode, throws if the token has already been listed.
+   */
+  private applyTokenListing({ id, token }: Event<BatchExchange, "TokenListing">) {
+    const tokenId = parseInt(id)
+    if (this.options.strict) {
+      assert(
+        this.tokens.get(tokenId) === undefined,
+        `token ${tokenId} has already been listed`,
+      )
+    }
+
+    this.tokens.set(parseInt(id), token)
+  }
+
+  /**
+   * Applies a trade event to the auction state.
+   */
+  private applyTrade({
+    owner,
+    orderId,
+    sellToken,
+    buyToken,
+    executedSellAmount,
+    executedBuyAmount,
+  }: Event<BatchExchange, "Trade">) {
+    this.updateBalance(
+      owner,
+      parseInt(sellToken),
+      amount => amount - BigInt(executedSellAmount),
+    )
+    this.updateOrderRemainingAmount(
+      owner,
+      parseInt(orderId),
+      amount => amount - BigInt(executedSellAmount),
+    )
+    this.updateBalance(
+      owner,
+      parseInt(buyToken),
+      amount => amount + BigInt(executedBuyAmount),
+    )
+  }
+
+  /**
+   * Applies a trade reversion event to the auction state.
+   */
+  private applyTradeReversion({
+    owner,
+    orderId,
+    sellToken,
+    buyToken,
+    executedSellAmount,
+    executedBuyAmount,
+  }: Event<BatchExchange, "TradeReversion">) {
+    this.updateBalance(
+      owner,
+      parseInt(sellToken),
+      amount => amount + BigInt(executedSellAmount),
+    )
+    this.updateOrderRemainingAmount(
+      owner,
+      parseInt(orderId),
+      amount => amount + BigInt(executedSellAmount),
+    )
+    this.updateBalance(
+      owner,
+      parseInt(buyToken),
+      amount => amount - BigInt(executedBuyAmount),
+    )
+  }
+
+  /**
+   * Applies a withdraw event to the auction state.
+   *
+   * @throws
+   * In strict mode, throws if the withdrawing user's balance would be overdrawn
+   * as a result of this event.
+   */
+  private applyWithdraw(
+    { user, token, amount: withdrawAmount }: Event<BatchExchange, "Withdraw">,
+  ) {
+    const tokenAddr = this.tokenAddr(token)
+    const newBalance = this.updateBalance(
+      user, token, amount => amount - BigInt(withdrawAmount),
+    )
+
+    if (this.options.strict) {
+      assert(
+        newBalance >= BigInt(0),
+        `overdrew user ${user} token ${token} balance`,
+      )
+    }
+
+    this.account(user).pendingWithdrawals.delete(tokenAddr)
+  }
+
+  /**
+   * Applies a withdraw request event to the auction state.
+   *
+   * @throws
+   * In strict mode, throws if the withdraw request is placed in the over top of
+   * and existing unapplied request.
+   */
+  private applyWithdrawRequest(
+    { user, token, batchId, amount }: Event<BatchExchange, "WithdrawRequest">,
+  ) {
+    const tokenAddr = this.tokenAddr(token)
+    const batch = parseInt(batchId)
+
+    if (this.options.strict) {
+      const existingBatch = this.account(user).pendingWithdrawals.get(tokenAddr)?.batchId
+      assert(
+        existingBatch === undefined || existingBatch === batch,
+        `pending withdrawal for user ${user} modified from batch ${existingBatch} to ${batchId}`,
+      )
+    }
+
+    this.account(user).pendingWithdrawals.set(tokenAddr, {
+      batchId: batch,
+      amount: BigInt(amount),
+    })
   }
 
   /**
@@ -352,46 +494,6 @@ export class AuctionState {
   }
 
   /**
-   * Sets a pending withdrawal for a user for the specified token and amount.
-   */
-  private setPendingWithdrawal(
-    user: Address,
-    token: TokenId | Address,
-    batchId: number,
-    amount: bigint,
-  ): void {
-    const tokenAddr = this.tokenAddr(token)
-    if (this.options.strict) {
-      const existingBatch = this.account(user).pendingWithdrawals.get(tokenAddr)?.batchId
-      assert(
-        existingBatch === undefined || existingBatch === batchId,
-        `pending withdrawal for user ${user} modified from batch ${existingBatch} to ${batchId}`,
-      )
-    }
-    this.account(user).pendingWithdrawals.set(tokenAddr, { batchId, amount })
-  }
-
-  /**
-   * Clears a pending withdrawal.
-   */
-  private clearPendingWithdrawal(
-    user: Address,
-    token: TokenId | Address,
-  ): void {
-    const tokenAddr = this.tokenAddr(token)
-    this.account(user).pendingWithdrawals.delete(tokenAddr)
-  }
-
-  /**
-   * Adds a user order and returns the order ID of the newly created order.
-   */
-  private addOrder(user: Address, order: Order): number {
-    const userOrders = this.account(user).orders
-    userOrders.push(order)
-    return userOrders.length - 1
-  }
-
-  /**
    * Retrieves an existing user order by user address and order ID.
    *
    * @throws If the order does not exist.
@@ -419,23 +521,13 @@ export class AuctionState {
       order.priceDenominator !== UNLIMITED_ORDER_AMOUNT
     ) {
       order.remainingAmount = update(order.remainingAmount)
+      if (this.options.strict) {
+        assert(
+          order.remainingAmount >= BigInt(0),
+          `user ${user} order ${orderId} is negative`,
+        )
+      }
     }
-  }
-
-  /**
-   * Sets a user's order to all 0's.
-   *
-   * @throws If the order does not exist.
-   */
-  private deleteOrder(user: Address, orderId: number): void {
-    const order = this.order(user, orderId)
-    order.buyToken = 0
-    order.sellToken = 0
-    order.validFrom = 0
-    order.validUntil = 0
-    order.priceNumerator = BigInt(0)
-    order.priceDenominator = BigInt(0)
-    order.remainingAmount = BigInt(0)
   }
 }
 
@@ -470,26 +562,17 @@ function assertEventsAreAfterBlockAndOrdered(block: number, events: EventData[])
 }
 
 /**
- * Asserts that all accounts are valid by ensuring that all token balances and
- * order remaining amounts are positive
+ * Asserts that all account balances are positive.
  *
- * @throws If an account has an invalid amount.
+ * @throws If an account balance is negative.
  */
-function assertAccountsAreValid(blockNumber: number, accounts: Iterable<[Address, Account]>) {
-  for (const [user, { balances, orders }] of accounts) {
+function assertAccountBalancesAreValid(
+  blockNumber: number,
+  accounts: Iterable<[Address, Account]>,
+) {
+  for (const [user, { balances }] of accounts) {
     for (const [token, balance] of balances.entries()) {
-      assert(
-        balance >= BigInt(0),
-        `user ${user} token ${token} balance is negative at block ${blockNumber}`,
-      )
-    }
-
-    for (let id = 0; id < orders.length; id++) {
-      const order = orders[id]
-      assert(
-        order.remainingAmount >= BigInt(0),
-        `user ${user} order ${id} remaining amount is negative at block ${blockNumber}`,
-      )
+      assert(balance >= BigInt(0), `user ${user} token ${token} is negative`)
     }
   }
 }

--- a/src/streamed/state.ts
+++ b/src/streamed/state.ts
@@ -290,7 +290,7 @@ export class AuctionState {
   ) {
     this.updateBalance(submitter, 0, amount => amount - BigInt(burntFees))
     if (this.options.strict) {
-      assertAccountBalancesAreValid(this.lastBlock, this.accounts.entries())
+      assertAccountBalancesAreValid(this.accounts.entries())
     }
   }
 
@@ -308,7 +308,7 @@ export class AuctionState {
   ) {
     this.updateBalance(submitter, 0, amount => amount + BigInt(burntFees))
     if (this.options.strict) {
-      assertAccountBalancesAreValid(this.lastBlock, this.accounts.entries())
+      assertAccountBalancesAreValid(this.accounts.entries())
     }
   }
 
@@ -566,10 +566,7 @@ function assertEventsAreAfterBlockAndOrdered(block: number, events: EventData[])
  *
  * @throws If an account balance is negative.
  */
-function assertAccountBalancesAreValid(
-  blockNumber: number,
-  accounts: Iterable<[Address, Account]>,
-) {
+function assertAccountBalancesAreValid(accounts: Iterable<[Address, Account]>) {
   for (const [user, { balances }] of accounts) {
     for (const [token, balance] of balances.entries()) {
       assert(balance >= BigInt(0), `user ${user} token ${token} is negative`)

--- a/src/streamed/state.ts
+++ b/src/streamed/state.ts
@@ -333,56 +333,42 @@ export class AuctionState {
   /**
    * Applies a trade event to the auction state.
    */
-  private applyTrade({
-    owner,
-    orderId,
-    sellToken,
-    buyToken,
-    executedSellAmount,
-    executedBuyAmount,
-  }: Event<BatchExchange, "Trade">) {
+  private applyTrade(trade: Event<BatchExchange, "Trade">) {
     this.updateBalance(
-      owner,
-      parseInt(sellToken),
-      amount => amount - BigInt(executedSellAmount),
+      trade.owner,
+      parseInt(trade.sellToken),
+      amount => amount - BigInt(trade.executedSellAmount),
     )
     this.updateOrderRemainingAmount(
-      owner,
-      parseInt(orderId),
-      amount => amount - BigInt(executedSellAmount),
+      trade.owner,
+      parseInt(trade.orderId),
+      amount => amount - BigInt(trade.executedSellAmount),
     )
     this.updateBalance(
-      owner,
-      parseInt(buyToken),
-      amount => amount + BigInt(executedBuyAmount),
+      trade.owner,
+      parseInt(trade.buyToken),
+      amount => amount + BigInt(trade.executedBuyAmount),
     )
   }
 
   /**
    * Applies a trade reversion event to the auction state.
    */
-  private applyTradeReversion({
-    owner,
-    orderId,
-    sellToken,
-    buyToken,
-    executedSellAmount,
-    executedBuyAmount,
-  }: Event<BatchExchange, "TradeReversion">) {
+  private applyTradeReversion(trade: Event<BatchExchange, "TradeReversion">) {
     this.updateBalance(
-      owner,
-      parseInt(sellToken),
-      amount => amount + BigInt(executedSellAmount),
+      trade.owner,
+      parseInt(trade.sellToken),
+      amount => amount + BigInt(trade.executedSellAmount),
     )
     this.updateOrderRemainingAmount(
-      owner,
-      parseInt(orderId),
-      amount => amount + BigInt(executedSellAmount),
+      trade.owner,
+      parseInt(trade.orderId),
+      amount => amount + BigInt(trade.executedSellAmount),
     )
     this.updateBalance(
-      owner,
-      parseInt(buyToken),
-      amount => amount - BigInt(executedBuyAmount),
+      trade.owner,
+      parseInt(trade.buyToken),
+      amount => amount - BigInt(trade.executedBuyAmount),
     )
   }
 

--- a/src/streamed/state.ts
+++ b/src/streamed/state.ts
@@ -312,13 +312,14 @@ export class AuctionState {
    * Applies a token listing event and adds a token to the account state.
    *
    * @throws
-   * In strict mode, throws if the token has already been listed.
+   * In strict mode, throws either if the token has already been listed or if
+   * it was listed out of order.
    */
   private applyTokenListing({ id, token }: Event<BatchExchange, "TokenListing">) {
     if (this.options.strict) {
       assert(
         this.tokens.length === parseInt(id),
-        `token ${token} with ID ${id} added as the ${this.tokens.length} token`,
+        `token ${token} with ID ${id} added as token ${this.tokens.length}`,
       )
     }
 

--- a/test/models/streamed/state.spec.ts
+++ b/test/models/streamed/state.spec.ts
@@ -59,7 +59,7 @@ describe("Account State", () => {
       const state = auctionState()
       expect(() => state.applyEvents([
         event(2, "TokenListing", { id: "0", token: addr(1) }),
-        event(1, "TokenListing", { id: "0", token: addr(1) }),
+        event(1, "TokenListing", { id: "1", token: addr(1) }),
       ])).to.throw()
     })
   })
@@ -78,6 +78,13 @@ describe("Account State", () => {
       expect(() => state.applyEvents([
         event(1, "TokenListing", { id: "0", token: addr(0) }),
         event(1, "TokenListing", { id: "0", token: addr(0) }),
+      ])).to.throw()
+    })
+
+    it("Throws if a token is skipped", () => {
+      const state = auctionState()
+      expect(() => state.applyEvents([
+        event(1, "TokenListing", { id: "1", token: addr(0) }),
       ])).to.throw()
     })
   })

--- a/test/models/streamed/state.spec.ts
+++ b/test/models/streamed/state.spec.ts
@@ -64,6 +64,24 @@ describe("Account State", () => {
     })
   })
 
+  describe("TokenListing", () => {
+    it("Adds a new token", () => {
+      const state = auctionState()
+      state.applyEvents([
+        event(1, "TokenListing", { id: "0", token: addr(0) }),
+      ])
+      expect(state.toJSON().tokens[0]).to.equal(addr(0))
+    })
+
+    it("Throws if the same token is listed twice", () => {
+      const state = auctionState()
+      expect(() => state.applyEvents([
+        event(1, "TokenListing", { id: "0", token: addr(0) }),
+        event(1, "TokenListing", { id: "0", token: addr(0) }),
+      ])).to.throw()
+    })
+  })
+
   describe("OrderPlacement > OrderCancellation > OrderDeletion", () => {
     it("Adds a new user orders", () => {
       const state = auctionState()

--- a/test/models/streamed/state.spec.ts
+++ b/test/models/streamed/state.spec.ts
@@ -59,32 +59,7 @@ describe("Account State", () => {
       const state = auctionState()
       expect(() => state.applyEvents([
         event(2, "TokenListing", { id: "0", token: addr(1) }),
-        event(1, "TokenListing", { id: "1", token: addr(1) }),
-      ])).to.throw()
-    })
-  })
-
-  describe("TokenListing", () => {
-    it("Adds a new token", () => {
-      const state = auctionState()
-      state.applyEvents([
-        event(1, "TokenListing", { id: "0", token: addr(0) }),
-      ])
-      expect(state.toJSON().tokens[0]).to.equal(addr(0))
-    })
-
-    it("Throws if the same token is listed twice", () => {
-      const state = auctionState()
-      expect(() => state.applyEvents([
-        event(1, "TokenListing", { id: "0", token: addr(0) }),
-        event(2, "TokenListing", { id: "0", token: addr(0) }),
-      ])).to.throw()
-    })
-
-    it("Throws if a token is skipped", () => {
-      const state = auctionState()
-      expect(() => state.applyEvents([
-        event(1, "TokenListing", { id: "1", token: addr(0) }),
+        event(1, "TokenListing", { id: "0", token: addr(1) }),
       ])).to.throw()
     })
   })

--- a/test/models/streamed/state.spec.ts
+++ b/test/models/streamed/state.spec.ts
@@ -77,7 +77,7 @@ describe("Account State", () => {
       const state = auctionState()
       expect(() => state.applyEvents([
         event(1, "TokenListing", { id: "0", token: addr(0) }),
-        event(1, "TokenListing", { id: "0", token: addr(0) }),
+        event(2, "TokenListing", { id: "0", token: addr(0) }),
       ])).to.throw()
     })
 

--- a/test/models/streamed/state.spec.ts
+++ b/test/models/streamed/state.spec.ts
@@ -133,6 +133,24 @@ describe("Account State", () => {
       })
     })
 
+    it("Throws for mismatched order IDs", () => {
+      const state = auctionState()
+      expect(() => state.applyEvents([
+        event(1, "TokenListing", { id: "0", token: addr(0) }, 1),
+        event(1, "TokenListing", { id: "1", token: addr(1) }, 2),
+        event(1, "OrderPlacement", {
+          owner: addr(3),
+          index: "1",
+          buyToken: "0",
+          sellToken: "1",
+          validFrom: "2",
+          validUntil: "99999",
+          priceNumerator: "100000",
+          priceDenominator: "100000",
+        }, 3),
+      ])).to.throw()
+    })
+
     it("Throws for nonexistent order", () => {
       const state = auctionState()
       expect(() => state.applyEvents([
@@ -146,7 +164,7 @@ describe("Account State", () => {
   })
 
   describe("Deposit", () => {
-    it("Adds a user balance and updates it if already existing", () => {
+    it("Adds a user balance for a new user/token pair", () => {
       const state = auctionState()
       state.applyEvents([
         event(0, "Deposit", {
@@ -157,8 +175,17 @@ describe("Account State", () => {
         }),
       ])
       expect(state.toJSON().accounts[addr(1)].balances[addr(0)]).to.equal("100000")
+    })
 
+    it("Updates a balance for an existing user/token pair", () => {
+      const state = auctionState()
       state.applyEvents([
+        event(0, "Deposit", {
+          user: addr(1),
+          token: addr(0),
+          amount: "100000",
+          batchId: "1",
+        }),
         event(1, "Deposit", {
           user: addr(1),
           token: addr(0),


### PR DESCRIPTION
The refactor that was promised! This PR refactors `applyEvents` switch statement to be more "dumb" by forwarding each event to their individual functions.

This has the added benefit of using the `Event` types so that we have type safety on the event `returnValues` property.

### Test Plan

This PR is just a refactor so unit tests should verify that nothing broke.