### PR TITLE
[Events Orderbook] Implement orderbook update function

### DIFF
--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -189,7 +189,7 @@ export class StreamedOrderbook {
     const pendingEvents = events
 
     if (confirmedEvents.length > 0) {
-      this.options.logger?.debug(`applying ${confirmedEvents.length} confirmed events`)
+      this.options.logger?.debug(`applying ${confirmedEvents.length} confirmed events until block ${confirmedBlock}`)
       try {
         this.state.applyEvents(confirmedEvents)
       } catch (err) {

--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -240,7 +240,7 @@ export class StreamedOrderbook {
             this.scheduleUpdate()
           }
         } catch (err) {
-          this.options.logger?.error(`error applying new events: ${err}`)
+          this.options.logger?.error(`error applying new events up to block ${this.state.nextBlock - 1}: ${err}`)
           this.updateError = err
         }
       },

--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -163,8 +163,8 @@ export class StreamedOrderbook {
    * events with multiple queries to retrieve each block page at a time.
    */
   private async applyPastEvents(): Promise<void> {
-    const endBlock = this.options.endBlock ||
-      await this.web3.eth.getBlockNumber()
+    const endBlock = this.options.endBlock ??
+      (await this.web3.eth.getBlockNumber() - this.options.blockConfirmations)
 
     for (
       let fromBlock = this.startBlock;

--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -183,7 +183,7 @@ export class StreamedOrderbook {
 
     const latestBlock = await this.web3.eth.getBlockNumber()
     const confirmedBlock = latestBlock - this.options.blockConfirmations
-    const confirmedEventCount = events.findIndex(ev => ev.blockNumber <= confirmedBlock)
+    const confirmedEventCount = events.findIndex(ev => ev.blockNumber > confirmedBlock)
 
     const confirmedEvents = events.splice(0, confirmedEventCount)
     const pendingEvents = events

--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -179,7 +179,7 @@ export class StreamedOrderbook {
 
     const fromBlock = this.state.nextBlock
     this.options.logger?.debug(`fetching new events from ${fromBlock}-latest`)
-    const events = await this.contract.getPastEvents("allEvents", { fromBlock })
+    const events = await this.contract.getPastEvents("allEvents", { fromBlock, toBlock: "latest" })
 
     const latestBlock = await this.web3.eth.getBlockNumber()
     const confirmedBlock = latestBlock - this.options.blockConfirmations


### PR DESCRIPTION
Implements a method that can be called to update the orderbook with the latest confirmed events.

This PR is an alternative to #724 where the update polling would be implemented by the caller instead.

Closes #718 

### Test Plan

Run the e2e test and see new confirmed events being applied:
```
fetching page 10000147-10006346
applying 1105 past events
fetching new events from 10006342-latest
applying 2 confirmed events until block 10006358
```