### PR TITLE
[Events Orderbook] Implement querying the orderbook at the latest block

### DIFF
--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -260,7 +260,10 @@ export class StreamedOrderbook {
     const BATCH_DURATION = 300
 
     const block = await this.web3.eth.getBlock(blockNumber)
-    const batch = Math.floor(Number(block.timestamp) / BATCH_DURATION)
+    // NOTE: Pending or future blocks return null when queried, so approximate
+    // with system time
+    const timestamp = block?.timestamp ?? Date.now()
+    const batch = Math.floor(Number(timestamp) / BATCH_DURATION)
 
     return batch
   }

--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -205,7 +205,8 @@ export class StreamedOrderbook {
       return latestBlock
     }
 
-    const confirmedEventCount = events.findIndex(ev => ev.blockNumber > confirmedBlock)
+    const firstLatestEvent = events.findIndex(ev => ev.blockNumber > confirmedBlock)
+    const confirmedEventCount = firstLatestEvent !== -1 ? firstLatestEvent : events.length
     const confirmedEvents = events.slice(0, confirmedEventCount)
     const latestEvents = events.slice(confirmedEventCount)
 

--- a/src/streamed/state.ts
+++ b/src/streamed/state.ts
@@ -115,6 +115,26 @@ export class AuctionState {
   ) {}
 
   /**
+   * Creates a copy of the auction state that can apply events independently
+   * without modifying the original state.
+   */
+  public copy(): AuctionState {
+    const clone = new AuctionState(this.options)
+    clone.lastBlock = this.lastBlock
+    clone.tokens.push(...this.tokens)
+    for (const [user, account] of this.accounts.entries()) {
+      clone.accounts.set(user, {
+        balances: new Map(account.balances),
+        pendingWithdrawals: new Map(account.pendingWithdrawals),
+        orders: account.orders.map(order => ({ ...order })),
+      })
+    }
+    clone.lastSolution = this.lastSolution
+
+    return clone
+  }
+
+  /**
    * Create an object representation of the current account state for JSON
    * serialization.
    */

--- a/test/models/streamed/index.spec.ts
+++ b/test/models/streamed/index.spec.ts
@@ -28,15 +28,17 @@ describe("Streamed Orderbook", () => {
         "ETHEREUM_NODE_URL or INFURA_PROJECT_ID environment variable is required",
       )
       const url = ETHEREUM_NODE_URL || `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`
+      const endBlock = ORDERBOOK_END_BLOCK ?
+        parseInt(ORDERBOOK_END_BLOCK) :
+        undefined
+
       const web3 = new Web3(url)
       const [viewer] = await deployment<BatchExchangeViewer>(web3, BatchExchangeViewerArtifact)
 
-      const endBlock = ORDERBOOK_END_BLOCK ?
-        parseInt(ORDERBOOK_END_BLOCK) :
-        await web3.eth.getBlockNumber()
-
       console.debug("==> building streamed orderbook...")
       const orderbook = await StreamedOrderbook.init(web3, { endBlock, strict: true })
+      const targetBlock = endBlock ?? await orderbook.update()
+
       const streamedOrders = orderbook.getOpenOrders().map(order => ({
         ...order,
         sellTokenBalance: new BN(order.sellTokenBalance.toString()),
@@ -46,7 +48,7 @@ describe("Streamed Orderbook", () => {
       }))
 
       console.debug("==> querying onchain orderbook...")
-      const queriedOrders = await getOpenOrders(viewer, 300, endBlock)
+      const queriedOrders = await getOpenOrders(viewer, 300, targetBlock)
 
       console.debug("==> comparing orderbooks...")
       function toDiffableOrders<T>(orders: IndexedOrder<T>[]): Record<string, IndexedOrder<T>> {

--- a/test/models/streamed/index.spec.ts
+++ b/test/models/streamed/index.spec.ts
@@ -28,9 +28,7 @@ describe("Streamed Orderbook", () => {
         "ETHEREUM_NODE_URL or INFURA_PROJECT_ID environment variable is required",
       )
       const url = ETHEREUM_NODE_URL || `https://mainnet.infura.io/v3/${INFURA_PROJECT_ID}`
-      const endBlock = ORDERBOOK_END_BLOCK ?
-        parseInt(ORDERBOOK_END_BLOCK) :
-        undefined
+      const endBlock = ORDERBOOK_END_BLOCK ? parseInt(ORDERBOOK_END_BLOCK) : undefined
 
       const web3 = new Web3(url)
       const [viewer] = await deployment<BatchExchangeViewer>(web3, BatchExchangeViewerArtifact)

--- a/test/models/streamed/state.spec.ts
+++ b/test/models/streamed/state.spec.ts
@@ -531,4 +531,100 @@ describe("Account State", () => {
       ])).to.throw()
     })
   })
+
+  describe("copy", () => {
+    it("Does not modify the orginal state.", () => {
+      const state = auctionState()
+      state.applyEvents([
+        event(1, "TokenListing", { id: "0", token: addr(0) }),
+        event(2, "Deposit", {
+          user: addr(0),
+          token: addr(0),
+          amount: "100000",
+          batchId: "1",
+        }),
+        event(3, "OrderPlacement", {
+          owner: addr(0),
+          index: "0",
+          buyToken: "0",
+          sellToken: "0",
+          validFrom: "0",
+          validUntil: "9999",
+          priceNumerator: "100000",
+          priceDenominator: "100000",
+        }),
+        event(4, "SolutionSubmission", {
+          submitter: addr(0),
+          burntFees: "10000",
+          utility: "unused",
+          disregardedUtility: "unused",
+          lastAuctionBurntFees: "unsued",
+          prices: ["unsued"],
+          tokenIdsForPrice: ["unsued"],
+        }),
+        event(5, "WithdrawRequest", {
+          user: addr(0),
+          token: addr(0),
+          amount: "100000",
+          batchId: "1",
+        }),
+      ])
+      const original = state.toJSON()
+
+      const copy = state.copy()
+      copy.applyEvents([
+        // add a new token
+        event(10, "TokenListing", { id: "1", token: addr(1) }),
+        // add new balance
+        event(11, "Deposit", {
+          user: addr(0),
+          token: addr(0),
+          amount: "100000",
+          batchId: "1",
+        }),
+        // modify existing balance, clear existing pending withdrawal
+        event(12, "Withdraw", {
+          user: addr(0),
+          token: addr(0),
+          amount: "100000",
+        }),
+        // add new pending withdrawal
+        event(13, "WithdrawRequest", {
+          user: addr(0),
+          token: addr(0),
+          amount: "1000000",
+          batchId: "42",
+        }),
+        // modify existing order
+        event(14, "OrderCancellation", {
+          owner: addr(0),
+          id: "0",
+        }),
+        // add new order
+        event(15, "OrderPlacement", {
+          owner: addr(0),
+          index: "1",
+          buyToken: "0",
+          sellToken: "0",
+          validFrom: "0",
+          validUntil: "9999",
+          priceNumerator: "100000",
+          priceDenominator: "100000",
+        }),
+        // modify last solution, add new user
+        event(16, "SolutionSubmission", {
+          submitter: addr(1),
+          burntFees: "10000",
+          utility: "unused",
+          disregardedUtility: "unused",
+          lastAuctionBurntFees: "unsued",
+          prices: ["unsued"],
+          tokenIdsForPrice: ["unsued"],
+        }),
+      ])
+      const after = state.toJSON()
+
+      expect(original).to.deep.equal(after)
+    })
+  })
 })


### PR DESCRIPTION
This PR implements querying the latest open orderbook.

This is implemented by keeping a separate "confirmed" auction state, built from events that are part of confirmed blocks, and not subject to reorgs, and a "latest" auction state that is built by cloning the "confirmed" state and applying events in between the confirmed block and the latest block.

The "latest" state is implemented to be discardable and rebuilt on every update so that it is not prone to errors stemming from reorgs, nor does complex logic for rolling back events need to be implemented. Unfortunately, the current implementation is slightly inefficient. I created #734 as an issue to capture a potential solution to the problem.

This closes #719 

### Test Plan

Run the e2e test to ensure the event based orderbook on the latest block matches the onchain queried orderbook:
```
$ yarn test-streamed-orderbook

  Streamed Orderbook
    init
==> building streamed orderbook...
==> querying onchain orderbook...
==> comparing orderbooks...
      ✓ should successfully apply all events and match on-chain orderbook (287940ms)


  1 passing (5m)
```
