### PR TITLE
[TypeScript] Added truffle assertions typings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@ coverage.json
 deploy/*
 node_modules/*
 build/
-types/
+
 package-lock.json
+yarn-error.log
 
 .idea/
 .vscode/

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "tsc:esm": "rimraf build/esm && tsc -m es6 -t esnext --outDir build/esm",
     "ts-check": "tsc --esModuleInterop --noEmit src/index.d.ts",
     "ts-contracts": "yarn ts-contracts:web3 && yarn ts-contracts:truffle",
-    "ts-contracts:truffle": "typechain --target trufflehotfix --outDir types/truffle-typings \"build/contracts/*.json\"",
+    "ts-contracts:truffle": "typechain --target trufflehotfix --outDir build/truffle-typings \"build/contracts/*.json\"",
     "ts-contracts:web3": "typechain --target web3-v1 --outDir build/types \"build/contracts/{BatchExchange,BatchExchangeViewer}.json\"",
     "ganache": "ganache-cli -h 0.0.0.0 --gasLimit 8e6 --deterministic"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,11 +43,7 @@
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    "typeRoots": [
-      "./node_modules/@types",
-      "./node_modules/@openeth",
-      "./types"
-    ],
+    // "typeRoots": [],
     //"allowSyntheticDefaultImports": true    /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
     "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */

--- a/types/truffle-assertions/index.d.ts
+++ b/types/truffle-assertions/index.d.ts
@@ -1,0 +1,56 @@
+/**
+ * Typings for `truffle-assertions` package.
+ */
+
+declare module "truffle-assertions" {
+  import "@openeth/truffle-typings"
+  import { TransactionReceipt } from "web3-core"
+
+  class InvalidTxResultError extends Error {}
+
+  const enum ErrorType {
+    REVERT = "revert",
+    INVALID_OPCODE = "invalid opcode",
+    OUT_OF_GAS = "out of gas",
+    INVALID_JUMP = "invalid JUMP",
+  }
+
+  interface TransactionResult {
+    tx: string;
+    receipt: TransactionReceipt;
+    logs: Truffle.TransactionLog[];
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  type FilterOrObject = ((data: any) => boolean) | any
+
+  interface TruffleAssert {
+    eventEmitted: (
+      result: TransactionResult,
+      eventType: string,
+      filterOrObject?: FilterOrObject,
+      message?: string,
+    ) => void;
+    eventNotEmitted: (
+      result: TransactionResult,
+      eventType: string,
+      filterOrObject?: FilterOrObject,
+      message?: string,
+    ) => void;
+    prettyPrintEmittedEvents: (result: TransactionResult, indentationSize: number) => void;
+    createTransactionResult: <T>(
+      contract: Truffle.Contract<T>,
+      transactionHash: string,
+    ) => TransactionResult;
+
+    passes: (asyncFn: Promise<{}>, message?: string) => void;
+    fails: (asyncFn: Promise<{}>, errorType: ErrorType, reason?: string, message?: string) => void;
+    reverts: (asyncFn: Promise<{}>, reason?: string, message?: string) => void;
+
+    ErrorType: ErrorType;
+    InvalidTxResultError: InvalidTxResultError;
+  }
+
+  const truffleAssert: TruffleAssert
+  export = truffleAssert
+}

--- a/types/truffle-typings/index.d.ts
+++ b/types/truffle-typings/index.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Include generated tuffle typings for tests.
+ */
+
+/// <reference types="../../build/truffle-typings/merge" />
+
+export * from "../../build/truffle-typings"


### PR DESCRIPTION
This PR includes changes that were a part of #736 and that require some special attention.

This PR moves the generated truffle typings to the `build/` directory, so we can use the `types/` directory for manually created type definitions.

Added typings for the `truffle-assertions` npm package for use in the truffle tests.

### Test Plan

CI!