### PR TITLE
[Trivial] Bump to v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.2.15",
+  "version": "0.3.0",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "src/index.js",
   "module": "build/esm/index.js",


### PR DESCRIPTION
This PR bumps the dex-contracts to v0.3.0 so that the new event based orderbook can be used in the price estimator.

Note that this it contains breaking changes in the exported code, notably:
```
export interface Order { ... }
export interface OrderBN { ... }
export const BatchExchange = ...
export const BatchExchangeViewer = ...
```

Is now:
```
export interface Order<string> { ... }
export interface Order<BN> { ... }
export const BatchExchangeArtifact = ...
export const BatchExchangeViewerArtifact = ...
```