### PR TITLE
[JS->TS] Migrating encoding.js

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -25,15 +25,17 @@ export interface IndexedOrder<T> extends Order<T> {
 }
 
 class OrderBuffer {
-  index = 2; // skip '0x'
-  constructor(public bytes: string) {}
+  private index = 2; // skip '0x'
+  constructor(private readonly bytes: string) {}
 
-  readBytes = (size: number) =>
+  readBytes = (size: number): string =>
     this.bytes.slice(this.index, (this.index += size * 2));
 
-  decodeAddr = () => `0x${this.readBytes(20)}`;
+  decodeAddr = (): string => `0x${this.readBytes(20)}`;
   decodeInt = (size: number): BN => new BN(this.readBytes(size / 8), 16);
-  decodeNumber = (size: number) => parseInt(this.readBytes(size / 8), 16);
+  decodeNumber = (size: number): number =>
+    parseInt(this.readBytes(size / 8), 16);
+  hasMoreBytes = (): boolean => this.index < this.bytes.length;
 }
 
 function decodeOrder(bytes: OrderBuffer): Order<BN> {
@@ -69,7 +71,7 @@ function decodeOrdersInternal<T>(
 
   const buffer = new OrderBuffer(bytes);
   const result = [];
-  while (buffer.index < buffer.bytes.length) {
+  while (buffer.hasMoreBytes()) {
     result.push(decodeFunction(buffer));
   }
   return result;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -77,9 +77,6 @@ export interface ContractArtifact {
 export declare const BatchExchangeArtifact: ContractArtifact;
 export declare const BatchExchangeViewerArtifact: ContractArtifact;
 
-export declare function decodeOrders(bytes: string): Order<string>[];
-export declare function decodeOrdersBN(bytes: string): Order<BN>[];
-
 export declare function getOpenOrdersPaginated(
   contract: BatchExchangeViewer,
   pageSize: number,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,10 +1,12 @@
 import BN from "bn.js";
 import { BatchExchangeViewer } from "../build/types/BatchExchangeViewer";
+import { IndexedOrder, Order } from "./encoding";
 
 export { BatchExchange } from "../build/types/BatchExchange";
 export { BatchExchangeViewer } from "../build/types/BatchExchangeViewer";
 export * from "./orderbook";
 export * from "./fraction";
+export * from "./encoding";
 
 export interface ContractAbiEntry {
   type: string;
@@ -74,22 +76,6 @@ export interface ContractArtifact {
 
 export declare const BatchExchangeArtifact: ContractArtifact;
 export declare const BatchExchangeViewerArtifact: ContractArtifact;
-
-export interface Order<T = string> {
-  user: string;
-  sellTokenBalance: T;
-  buyToken: number;
-  sellToken: number;
-  validFrom: number;
-  validUntil: number;
-  priceNumerator: T;
-  priceDenominator: T;
-  remainingAmount: T;
-}
-
-export interface IndexedOrder<T> extends Order<T> {
-  orderId: number;
-}
 
 export declare function decodeOrders(bytes: string): Order<string>[];
 export declare function decodeOrdersBN(bytes: string): Order<BN>[];

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,6 @@ module.exports = {
   BatchExchangeViewerArtifact: require("../build/contracts/BatchExchangeViewer.json"),
   ...require("../build/common/src/fraction.js"),
   ...require("../build/common/src/orderbook.js"),
-  ...require("./encoding.js"),
   ...require("./onchain_reading.js"),
   ...require("../build/common/src/balance_reader.js"),
 }

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ module.exports = {
   BatchExchangeViewerArtifact: require("../build/contracts/BatchExchangeViewer.json"),
   ...require("../build/common/src/fraction.js"),
   ...require("../build/common/src/orderbook.js"),
+  ...require("../build/common/src/encoding.js"),
   ...require("./onchain_reading.js"),
   ...require("../build/common/src/balance_reader.js"),
 }

--- a/src/onchain_reading.js
+++ b/src/onchain_reading.js
@@ -1,4 +1,4 @@
-const { decodeOrdersBN, decodeIndexedOrdersBN } = require("./encoding")
+const { decodeOrders, decodeIndexedOrders } = require("../build/common/src/encoding")
 
 /**
  * Returns an iterator yielding an item for each page of order in the orderbook that is currently being collected.
@@ -15,7 +15,7 @@ const getOpenOrdersPaginated = async function* (contract, pageSize, blockNumber)
     const page = await contract.methods
       .getOpenOrderBookPaginated([], nextPageUser, nextPageUserOffset, pageSize)
       .call({}, blockNumber)
-    const elements = decodeIndexedOrdersBN(page.elements)
+    const elements = decodeIndexedOrders(page.elements)
     yield elements
 
     //Update page info
@@ -51,7 +51,7 @@ const getOrdersPaginated = async (contract, pageSize, blockNumber) => {
   let currentOffSet = 0
   let lastPageSize = pageSize
   while (lastPageSize == pageSize) {
-    const page = decodeOrdersBN(
+    const page = decodeOrders(
       await contract.methods.getEncodedUsersPaginated(currentUser, currentOffSet, pageSize).call({}, blockNumber)
     )
     orders = orders.concat(page)

--- a/test/batch_exchange.js
+++ b/test/batch_exchange.js
@@ -10,7 +10,7 @@ const truffleAssert = require("truffle-assertions")
 const { waitForNSeconds, sendTxAndGetReturnValue } = require("../build/common/test/utilities")
 
 const { closeAuction } = require("../scripts/utilities.js")
-const { decodeOrdersBN } = require("../src/encoding")
+const { decodeOrders } = require("../build/common/src/encoding")
 
 const { toETH, getExecutedSellAmount, ERROR_EPSILON, feeAdded, feeSubtracted } = require("../build/common/test/resources/math")
 const {
@@ -1791,7 +1791,7 @@ contract("BatchExchange", async (accounts) => {
       }
 
       // get 2nd order with getEncodedUserOrdersPaginated(user_1, 1, 1)
-      const auctionElements = decodeOrdersBN(await batchExchange.getEncodedUserOrdersPaginated(user_1, 1, 1))
+      const auctionElements = decodeOrders(await batchExchange.getEncodedUserOrdersPaginated(user_1, 1, 1))
       assert.equal(auctionElements[0].priceNumerator, 1)
     })
   })
@@ -1856,7 +1856,7 @@ contract("BatchExchange", async (accounts) => {
       await waitForNSeconds(BATCH_TIME)
       await batchExchange.cancelOrders([0])
 
-      const auctionElements = decodeOrdersBN(await batchExchange.getEncodedUserOrders(user_1))
+      const auctionElements = decodeOrders(await batchExchange.getEncodedUserOrders(user_1))
       assert.equal(JSON.stringify(auctionElements), JSON.stringify([cancelledOrderInfo, freedOrderInfo, validOrderInfo]))
     })
   })
@@ -1894,7 +1894,7 @@ contract("BatchExchange", async (accounts) => {
       await batchExchange.placeOrder(1, 0, batchId, 20, 10, { from: user_1 })
       await batchExchange.placeOrder(0, 1, batchId, 500, 400, { from: user_2 })
 
-      const auctionElements = decodeOrdersBN(await batchExchange.getEncodedOrders())
+      const auctionElements = decodeOrders(await batchExchange.getEncodedOrders())
       assert.equal(JSON.stringify(auctionElements), JSON.stringify(orderInfo))
     })
     it("credits balance when it's valid", async () => {
@@ -1908,12 +1908,12 @@ contract("BatchExchange", async (accounts) => {
       await batchExchange.deposit(erc20_2, 20, { from: user_1 })
       await batchExchange.placeOrder(1, 2, batchId, 20, 10, { from: user_1 })
 
-      let auctionElements = decodeOrdersBN(await batchExchange.getEncodedOrders())
+      let auctionElements = decodeOrders(await batchExchange.getEncodedOrders())
       assert.equal(auctionElements[0].sellTokenBalance, 0)
 
       await waitForNSeconds(BATCH_TIME)
 
-      auctionElements = decodeOrdersBN(await batchExchange.getEncodedOrders())
+      auctionElements = decodeOrders(await batchExchange.getEncodedOrders())
       assert.equal(auctionElements[0].sellTokenBalance, 20)
     })
     it("includes freed orders with empty fields", async () => {
@@ -1922,7 +1922,7 @@ contract("BatchExchange", async (accounts) => {
       const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
       await batchExchange.placeOrder(1, 0, batchId + 10, 20, 10)
 
-      let auctionElements = decodeOrdersBN(await batchExchange.getEncodedOrders())
+      let auctionElements = decodeOrders(await batchExchange.getEncodedOrders())
       assert.equal(auctionElements.length, 1)
       assert.equal(auctionElements[0].validFrom, batchId)
 
@@ -1930,14 +1930,14 @@ contract("BatchExchange", async (accounts) => {
       await batchExchange.cancelOrders([0])
 
       // Cancellation is active but not yet freed
-      auctionElements = decodeOrdersBN(await batchExchange.getEncodedOrders())
+      auctionElements = decodeOrders(await batchExchange.getEncodedOrders())
       assert.equal(auctionElements.length, 1)
       assert.equal(auctionElements[0].validFrom, batchId)
 
       await closeAuction(batchExchange)
       await batchExchange.cancelOrders([0])
 
-      auctionElements = decodeOrdersBN(await batchExchange.getEncodedOrders())
+      auctionElements = decodeOrders(await batchExchange.getEncodedOrders())
       assert.equal(auctionElements.length, 1)
       assert.equal(auctionElements[0].validFrom, 0)
     })
@@ -1960,7 +1960,7 @@ contract("BatchExchange", async (accounts) => {
       await batchExchange.placeOrder(1, 2, batchId + 10, 100, 100, { from: user_1 })
       await batchExchange.placeOrder(0, 1, batchId + 10, 100, 100, { from: user_2 })
 
-      const firstPage = decodeOrdersBN(await batchExchange.getEncodedUsersPaginated(zero_address, 0, 1))
+      const firstPage = decodeOrders(await batchExchange.getEncodedUsersPaginated(zero_address, 0, 1))
       assert.equal(
         JSON.stringify(firstPage),
         JSON.stringify([
@@ -1978,7 +1978,7 @@ contract("BatchExchange", async (accounts) => {
         ])
       )
 
-      const secondPage = decodeOrdersBN(await batchExchange.getEncodedUsersPaginated(user_1, 1, 1))
+      const secondPage = decodeOrders(await batchExchange.getEncodedUsersPaginated(user_1, 1, 1))
       assert.equal(
         JSON.stringify(secondPage),
         JSON.stringify([
@@ -1996,7 +1996,7 @@ contract("BatchExchange", async (accounts) => {
         ])
       )
 
-      const thirdPage = decodeOrdersBN(await batchExchange.getEncodedUsersPaginated(user_1, 2, 1))
+      const thirdPage = decodeOrders(await batchExchange.getEncodedUsersPaginated(user_1, 2, 1))
       assert.equal(
         JSON.stringify(thirdPage),
         JSON.stringify([
@@ -2024,7 +2024,7 @@ contract("BatchExchange", async (accounts) => {
       await batchExchange.placeOrder(1, 2, batchId + 10, 100, 100, { from: user_1 })
       await batchExchange.placeOrder(0, 1, batchId + 10, 100, 100, { from: user_2 })
 
-      const page = decodeOrdersBN(await batchExchange.getEncodedUsersPaginated(user_1, 1, 2))
+      const page = decodeOrders(await batchExchange.getEncodedUsersPaginated(user_1, 1, 2))
       assert.equal(page[0].user, user_1.toLowerCase())
       assert.equal(page[1].user, user_2.toLowerCase())
     })
@@ -2035,7 +2035,7 @@ contract("BatchExchange", async (accounts) => {
       await batchExchange.placeOrder(1, 2, batchId + 10, 100, 100, { from: user_2 })
       await batchExchange.placeOrder(0, 1, batchId + 10, 100, 100, { from: user_3 })
 
-      const page = decodeOrdersBN(await batchExchange.getEncodedUsersPaginated(zero_address, 0, 5))
+      const page = decodeOrders(await batchExchange.getEncodedUsersPaginated(zero_address, 0, 5))
       assert.equal(page.length, 3)
       assert.equal(page[0].user, user_1.toLowerCase())
       assert.equal(page[1].user, user_2.toLowerCase())

--- a/test/batch_exchange_viewer.js
+++ b/test/batch_exchange_viewer.js
@@ -5,7 +5,7 @@ const MockContract = artifacts.require("MockContract")
 const BN = require("bn.js")
 const truffleAssert = require("truffle-assertions")
 
-const { decodeOrdersBN, decodeIndexedOrdersBN } = require("../src/encoding")
+const { decodeOrders, decodeIndexedOrders } = require("../build/common/src/encoding")
 const { closeAuction } = require("../scripts/utilities.js")
 const { setupGenericStableX } = require("./stablex_utils")
 
@@ -38,7 +38,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       await batchExchange.requestWithdraw(token_2.address, 50)
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
-      const result = decodeIndexedOrdersBN(await viewer.getOpenOrderBook([]))
+      const result = decodeIndexedOrders(await viewer.getOpenOrderBook([]))
       assert.equal(result[0].sellTokenBalance.toNumber(), 50)
     })
     it("does not count already matured deposits twice", async () => {
@@ -53,7 +53,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       await closeAuction(batchExchange)
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
-      const result = decodeIndexedOrdersBN(await viewer.getOpenOrderBook([]))
+      const result = decodeIndexedOrders(await viewer.getOpenOrderBook([]))
       assert.equal(result[0].sellTokenBalance.toNumber(), 50)
     })
     it("can be queried without pagination", async () => {
@@ -76,7 +76,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       )
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
-      const result = decodeIndexedOrdersBN(await viewer.getOpenOrderBook([]))
+      const result = decodeIndexedOrders(await viewer.getOpenOrderBook([]))
       assert.equal(result.filter((e) => e.validFrom == batchId).length, 10)
     })
     it("can be queried with pagination", async () => {
@@ -100,7 +100,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
       const result = await viewer.getOpenOrderBookPaginated([], zero_address, 0, 5)
-      assert.equal(decodeIndexedOrdersBN(result.elements).filter((e) => e.validFrom == batchId).length, 5)
+      assert.equal(decodeIndexedOrders(result.elements).filter((e) => e.validFrom == batchId).length, 5)
       assert.equal(result.nextPageUser, accounts[0])
       assert.equal(result.nextPageUserOffset, 15)
     })
@@ -123,7 +123,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
         Array(5).fill(0) //sellAmounts
       )
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
-      const result = decodeIndexedOrdersBN(await viewer.getOpenOrderBook([token_1.address, token_2.address]))
+      const result = decodeIndexedOrders(await viewer.getOpenOrderBook([token_1.address, token_2.address]))
       assert.deepEqual(
         result.map((e) => e.orderId),
         [3, 4, 5, 6, 7]
@@ -143,7 +143,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       await batchExchange.requestWithdraw(token_2.address, 50)
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
-      const result = decodeIndexedOrdersBN(await viewer.getFinalizedOrderBook([]))
+      const result = decodeIndexedOrders(await viewer.getFinalizedOrderBook([]))
       assert.equal(result[0].sellTokenBalance.toNumber(), 0)
     })
     it("can be queried without pagination", async () => {
@@ -169,7 +169,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       await closeAuction(batchExchange)
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
-      const result = decodeIndexedOrdersBN(await viewer.getFinalizedOrderBook([]))
+      const result = decodeIndexedOrders(await viewer.getFinalizedOrderBook([]))
       assert.equal(result.filter((e) => e.validFrom == batchId).length, 10)
     })
     it("can be queried with pagination", async () => {
@@ -196,7 +196,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
       const result = await viewer.getFinalizedOrderBookPaginated([], zero_address, 0, 5)
-      assert.equal(decodeIndexedOrdersBN(result.elements).filter((e) => e.validFrom == batchId).length, 5)
+      assert.equal(decodeIndexedOrders(result.elements).filter((e) => e.validFrom == batchId).length, 5)
       assert.equal(result.nextPageUser, accounts[0])
       assert.equal(result.nextPageUserOffset, 15)
     })
@@ -223,7 +223,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       await closeAuction(batchExchange)
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
-      const result = decodeIndexedOrdersBN(await viewer.getFinalizedOrderBook([token_1.address, token_2.address]))
+      const result = decodeIndexedOrders(await viewer.getFinalizedOrderBook([token_1.address, token_2.address]))
       assert.deepEqual(
         result.map((e) => e.orderId),
         [3, 4, 5, 6, 7]
@@ -255,7 +255,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       // We are querying two subpages which contain 6 elements in total, but due to our
       // page size constraint only return 5. Thus we should have a nextPage.
       const result = await viewer.getFilteredOrdersPaginated([batchId, batchId, batchId], [1, 2], zero_address, 0, 5)
-      assert.equal(decodeIndexedOrdersBN(result.elements).length, 5)
+      assert.equal(decodeIndexedOrders(result.elements).length, 5)
       assert.equal(result.hasNextPage, true)
     }),
 
@@ -278,7 +278,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       // would return 3 orders (the third one having duplicate data of first two
       // orders).
       const result = await viewer.getFilteredOrdersPaginated([batchId, nextBatchId, nextBatchId], [0, 1], zero_address, 0, 3)
-      const orders = decodeIndexedOrdersBN(result.elements)
+      const orders = decodeIndexedOrders(result.elements)
       assert.equal(orders.length, 2, `unexpected third order ${JSON.stringify(orders[2])}`)
     }),
   ])
@@ -300,7 +300,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       await batchExchange.placeOrder(1, 2, batchId + 10, 100, 100, { from: user_1 })
       await batchExchange.placeOrder(0, 1, batchId + 10, 100, 100, { from: user_2 })
 
-      const firstPage = decodeOrdersBN(await viewer.getEncodedOrdersPaginated(zero_address, 0, 1))
+      const firstPage = decodeOrders(await viewer.getEncodedOrdersPaginated(zero_address, 0, 1))
       assert.equal(
         JSON.stringify(firstPage),
         JSON.stringify([
@@ -318,7 +318,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
         ])
       )
 
-      const secondPage = decodeOrdersBN(await viewer.getEncodedOrdersPaginated(user_1, 1, 1))
+      const secondPage = decodeOrders(await viewer.getEncodedOrdersPaginated(user_1, 1, 1))
       assert.equal(
         JSON.stringify(secondPage),
         JSON.stringify([
@@ -336,7 +336,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
         ])
       )
 
-      const thirdPage = decodeOrdersBN(await viewer.getEncodedOrdersPaginated(user_1, 2, 1))
+      const thirdPage = decodeOrders(await viewer.getEncodedOrdersPaginated(user_1, 2, 1))
       assert.equal(
         JSON.stringify(thirdPage),
         JSON.stringify([
@@ -366,7 +366,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       await batchExchange.placeOrder(1, 2, batchId + 10, 100, 100, { from: user_1 })
       await batchExchange.placeOrder(0, 1, batchId + 10, 100, 100, { from: user_2 })
 
-      const page = decodeOrdersBN(await viewer.getEncodedOrdersPaginated(user_1, 1, 2))
+      const page = decodeOrders(await viewer.getEncodedOrdersPaginated(user_1, 1, 2))
       assert.equal(page[0].user, user_1.toLowerCase())
       assert.equal(page[1].user, user_2.toLowerCase())
     })
@@ -379,7 +379,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
       await batchExchange.placeOrder(1, 2, batchId + 10, 100, 100, { from: user_2 })
       await batchExchange.placeOrder(0, 1, batchId + 10, 100, 100, { from: user_3 })
 
-      const page = decodeOrdersBN(await viewer.getEncodedOrdersPaginated(zero_address, 0, 5))
+      const page = decodeOrders(await viewer.getEncodedOrdersPaginated(zero_address, 0, 5))
       assert.equal(page.length, 3)
       assert.equal(page[0].user, user_1.toLowerCase())
       assert.equal(page[1].user, user_2.toLowerCase())
@@ -399,7 +399,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
       await truffleAssert.reverts(viewer.getEncodedOrdersPaginatedWithTokenFilter([], zero_address, 0, 10))
-      const result = decodeOrdersBN(await viewer.getEncodedOrdersPaginatedWithTokenFilter([0, 2], zero_address, 0, 10))
+      const result = decodeOrders(await viewer.getEncodedOrdersPaginatedWithTokenFilter([0, 2], zero_address, 0, 10))
       // Filtered orders still show up as 0s to preserve order indices
       assert.equal(result.length, 1)
       assert.equal(result[0].validFrom, 0)
@@ -413,7 +413,7 @@ contract("BatchExchangeViewer [ @skip-on-coverage ]", (accounts) => {
 
       const viewer = await BatchExchangeViewer.new(batchExchange.address)
       const result = await viewer.getFilteredOrdersPaginated([batchId, batchId, batchId], [1, 2], accounts[0], 0, 1)
-      assert.equal(decodeIndexedOrdersBN(result.elements).length, 1)
+      assert.equal(decodeIndexedOrders(result.elements).length, 1)
     })
   })
 })


### PR DESCRIPTION
Part of #330 

This PR migrates encoding.js to typescript and updates its usasges in the js tests/scripts to use the new compiled target file.

On the way I removed the decodeOrder<string> methods as they were not used.


### Test Plan

CI