### PR TITLE
[Easy] Use `import type` where appropriate

### DIFF
--- a/src/balance_reader.ts
+++ b/src/balance_reader.ts
@@ -1,6 +1,6 @@
 import BN from "bn.js";
-import Web3 from "web3";
-import { BatchExchangeInstance } from "../types/truffle-typings";
+import type Web3 from "web3";
+import type { BatchExchangeInstance } from "../types/truffle-typings";
 
 const WORD_DATA_LENGTH = 64;
 

--- a/src/onchain_reading.ts
+++ b/src/onchain_reading.ts
@@ -4,9 +4,8 @@ import {
   Order,
   IndexedOrder,
 } from "./encoding";
-import { BatchExchangeViewer } from "../build/types/BatchExchangeViewer";
-import { BatchExchange } from "../build/types/BatchExchange";
-import BN from "bn.js";
+import { BatchExchange, BatchExchangeViewer } from "./contracts";
+import type BN from "bn.js";
 
 /**
  * Returns an iterator yielding an item for each page of order in the orderbook that is currently being collected.

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -1,5 +1,5 @@
 import { Fraction, FractionJson } from "./fraction";
-import BN from "bn.js";
+import type BN from "bn.js";
 
 export class Offer {
   price: Fraction;

--- a/src/streamed/events.ts
+++ b/src/streamed/events.ts
@@ -1,5 +1,5 @@
-import { Contract, EventData } from "web3-eth-contract";
-import { ContractEvent } from "../../build/types/types";
+import type { Contract, EventData } from "web3-eth-contract";
+import type { ContractEvent } from "../../build/types/types";
 
 /**
  * Event data type specified by name.

--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -13,9 +13,9 @@
  * @packageDocumentation
  */
 
-import Web3 from "web3";
-import { BlockNumber, TransactionReceipt } from "web3-core";
-import { Contract } from "web3-eth-contract";
+import type Web3 from "web3";
+import type { BlockNumber, TransactionReceipt } from "web3-core";
+import type { Contract } from "web3-eth-contract";
 import {
   BatchExchange,
   BatchExchangeArtifact,

--- a/src/streamed/state.ts
+++ b/src/streamed/state.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import { EventData } from "web3-eth-contract";
+import type { EventData } from "web3-eth-contract";
 import { BatchExchange } from "../contracts";
 import { IndexedOrder } from "../encoding";
 import { OrderbookOptions } from ".";


### PR DESCRIPTION
This PR changes the code to use `import type` where appropriate. This makes it so the generated `.js` code doesn't `require(...)` the package. This is useful when using a package just for type definitions.

### Test Plan

CI - no code change. Note the compiler doesn't let you use `import type` if the imported piece is actually used.