### PR TITLE
[Easy] Remove strict withdraw request check

### DIFF
--- a/src/streamed/state.ts
+++ b/src/streamed/state.ts
@@ -282,11 +282,11 @@ export class AuctionState {
           }
           this.applyTradeReversion(ev.returnValues);
           break;
-        case "WithdrawRequest":
-          this.applyWithdrawRequest(ev.returnValues);
-          break;
         case "Withdraw":
           this.applyWithdraw(ev.returnValues);
+          break;
+        case "WithdrawRequest":
+          this.applyWithdrawRequest(ev.returnValues);
           break;
         default:
           throw new UnhandledEventError(ev);
@@ -510,14 +510,10 @@ export class AuctionState {
     const tokenAddr = this.tokenAddr(token);
     const batch = parseInt(batchId);
 
-    if (this.options.strict) {
-      const existingBatch = this.account(user).pendingWithdrawals.get(tokenAddr)
-        ?.batchId;
-      assert(
-        existingBatch === undefined || existingBatch === batch,
-        `pending withdrawal for user ${user} modified from batch ${existingBatch} to ${batchId}`,
-      );
-    }
+    // TODO(nlordell): Add a `strict` mode check that verifies that a valid
+    // withdraw request can't be made over an existing one. For this, however,
+    // we need the current batch number as a future withdraw request that has
+    // not yet matured can be overwritten by another withdraw request.
 
     this.account(user).pendingWithdrawals.set(tokenAddr, {
       batchId: batch,

--- a/test/models/streamed/index.spec.ts
+++ b/test/models/streamed/index.spec.ts
@@ -1,6 +1,5 @@
 /* eslint-disable no-console */
 
-import BN from "bn.js";
 import { assert } from "chai";
 import "mocha";
 import Web3 from "web3";
@@ -52,16 +51,18 @@ describe("Streamed Orderbook", () => {
       });
       const targetBlock = endBlock ?? (await orderbook.update());
 
-      const streamedOrders = orderbook.getOpenOrders().map((order) => ({
-        ...order,
-        sellTokenBalance: new BN(order.sellTokenBalance.toString()),
-        priceNumerator: new BN(order.priceNumerator.toString()),
-        priceDenominator: new BN(order.priceDenominator.toString()),
-        remainingAmount: new BN(order.remainingAmount.toString()),
-      }));
+      const streamedOrders = orderbook.getOpenOrders();
 
       console.debug("==> querying onchain orderbook...");
-      const queriedOrders = await getOpenOrders(viewer, 300, targetBlock);
+      const queriedOrders = (await getOpenOrders(viewer, 300, targetBlock)).map(
+        (order) => ({
+          ...order,
+          sellTokenBalance: BigInt(order.sellTokenBalance.toString()),
+          priceNumerator: BigInt(order.priceNumerator.toString()),
+          priceDenominator: BigInt(order.priceDenominator.toString()),
+          remainingAmount: BigInt(order.remainingAmount.toString()),
+        }),
+      );
 
       console.debug("==> comparing orderbooks...");
       function toDiffableOrders<T>(


### PR DESCRIPTION
This PR removes a strict withdraw request check that was making sure a previous withdraw request would not get overwritten. While this cannot happen for matured withdraw requests, it is possible for future withdraw requests that have not yet matured to be overwritten. Since the state currently does note get batch index information with events, we just remove the check for now and leave a TODO to add it back in later once we provide batch information with the events.

### Test Plan

```
ETHEREUM_NODE_URL=https://some.rinkeby.node yarn ts-streamed-orderbook
```

Note that the test was slightly modified. It looks like something might have changed in `BN` as it was producing numbers with extra leading 0's for some reason and causing the tests to fail on benign errors:
```
             "words": [
               46182994
               463411
               13477242
      +        0
      +        0
      +        0
      +        0
      +        0
      +        0
      +        0
      +        0
             ]
           }
           "user": "0x740a98f8f4fae0986fb3264fe4aacf94ac1ee96f"
           "validFrom": 5271160
```