### PR TITLE
[Easy] Remove minimist dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "eth-gas-reporter": "^0.2.17",
     "ganache-cli": "^6.9.1",
     "husky": "^4.2.5",
-    "minimist": "^1.2.5",
     "mocha": "^7.1.1",
     "node-fetch": "^2.6.0",
     "prettier": "^2.0.5",

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,5 +1,16 @@
 const truffleConfig = require("@gnosis.pm/util-contracts/src/util/truffleConfig")
-const minimist = require("minimist")
+const argv = require("yargs")
+  .option("gas", {
+    alias: "g",
+    type: "boolean",
+    describe: "Enable gas reporter",
+  })
+  .option("grep", {
+    type: "string",
+    describe: "Mocha test filter pattern",
+  })
+  .help(false)
+  .version(false).argv
 
 const DEFAULT_GAS_PRICE_GWEI = 25
 const DEFAULT_GAS_LIMIT = 8e6
@@ -34,8 +45,7 @@ const urlDevelopment = process.env.GANACHE_HOST || "localhost"
 // network key
 const infuraKey = process.env.INFURA_KEY || "9408f47dedf04716a03ef994182cf150"
 
-const { gas: gasLog } = minimist(process.argv.slice(2), { alias: { gas: "g" } })
-const { grep: grep } = minimist(process.argv.slice(2))
+const { gas: gasLog, grep } = argv
 
 module.exports = {
   ...truffleConfig({


### PR DESCRIPTION
We were using `minimist` in only one place for parsing command line arguments and `yargs` everywhere else. This PR removes the minimist dependency and replaces its single use with `yargs` cause pirates are cool.

Closes #715

### Test Plan

Run:
```
npx truffle test --gas --grep @skip-on-coverage
```

And see only `@skip-on-coverage` tests being run and an `eth-gas-reporter` summary at the end.