### PR TITLE
[EventOrderbook] Allow updating until a certain target block

### DIFF
--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -176,6 +176,7 @@ export class StreamedOrderbook {
    * Apply new confirmed events to the account state and store the remaining
    * events that are subject to reorgs into the `pendingEvents` array.
    *
+   * @param toBlock optional block number until which to fetch events
    * @returns The block number up until which the streamed orderbook is up to
    * date
    *
@@ -187,12 +188,14 @@ export class StreamedOrderbook {
    * then the streamed orderbook becomes invalid and can no longer apply new
    * events as the actual auction state is unknown.
    */
-  public async update(): Promise<number> {
+  public async update(toBlock?: number): Promise<number> {
     this.throwOnInvalidState();
 
     const fromBlock = this.confirmedState.nextBlock;
-    this.options.debug(`fetching new events from ${fromBlock}-latest`);
-    const events = await this.getPastEvents({ fromBlock });
+    this.options.debug(
+      `fetching new events from ${fromBlock}-${toBlock ?? "latest"}`,
+    );
+    const events = await this.getPastEvents({ fromBlock, toBlock });
 
     // NOTE: If the web3 instance is connected to nodes behind a load balancer,
     // it is possible that the events were queried on a node that includes an
@@ -205,9 +208,9 @@ export class StreamedOrderbook {
     );
     const confirmedBlock = latestBlock - this.options.blockConfirmations;
 
-    this.batch = await this.getBatchId(latestBlock);
+    this.batch = await this.getBatchId(toBlock ?? latestBlock);
     if (events.length === 0) {
-      return latestBlock;
+      return toBlock ?? latestBlock;
     }
 
     const firstLatestEvent = events.findIndex(
@@ -231,7 +234,9 @@ export class StreamedOrderbook {
 
     this.latestState = undefined;
     this.options.debug(
-      `reapplying ${latestEvents.length} latest events until block ${latestBlock}`,
+      `reapplying ${latestEvents.length} latest events until block ${
+        toBlock ?? latestBlock
+      }`,
     );
     if (latestEvents.length > 0) {
       // NOTE: Errors applying latest state are not considered fatal as we can
@@ -244,7 +249,7 @@ export class StreamedOrderbook {
       this.latestState = newLatestState;
     }
 
-    return latestBlock;
+    return toBlock ?? latestBlock;
   }
 
   /**

--- a/src/streamed/index.ts
+++ b/src/streamed/index.ts
@@ -176,7 +176,7 @@ export class StreamedOrderbook {
    * Apply new confirmed events to the account state and store the remaining
    * events that are subject to reorgs into the `pendingEvents` array.
    *
-   * @param toBlock optional block number until which to fetch events, capped at latest block number.
+   * @param toBlock - Optional block number until which to fetch events, capped at latest block number.
    * @returns The block number up until which the streamed orderbook is up to
    * date
    *

--- a/test/models/streamed/index.spec.ts
+++ b/test/models/streamed/index.spec.ts
@@ -49,8 +49,7 @@ describe("Streamed Orderbook", () => {
         endBlock,
         strict: true,
       });
-      const targetBlock = endBlock ?? (await orderbook.update());
-
+      const targetBlock = await orderbook.update(endBlock);
       const streamedOrders = orderbook.getOpenOrders();
 
       console.debug("==> querying onchain orderbook...");


### PR DESCRIPTION
In order to redo the price estimation at a certain target block in an efficient manner, it's important to be able to incrementally update the targetBlock for which the state is computed.

This way we can efficiently recreate the state for a list of orders sorted by blockNumber that they were placed.

This is achieved by giving the update method an optional toBlock argument.

### Test Plan

`ORDERBOOK_END_BLOCK=6481100; yarn test-streamed-orderbook`