### PR TITLE
[Trivial] Remove debug code that snuck in

### DIFF
--- a/test/models/streamed/index.spec.ts
+++ b/test/models/streamed/index.spec.ts
@@ -68,7 +68,7 @@ describe("Streamed Orderbook", () => {
       function toDiffableOrders<T>(
         orders: IndexedOrder<T>[],
       ): Record<string, IndexedOrder<T>> {
-        return orders.slice(0, 10).reduce((obj, order) => {
+        return orders.reduce((obj, order) => {
           const user = order.user.toLowerCase();
           obj[`${user}-${order.orderId}`] = { ...order, user };
           return obj;


### PR DESCRIPTION
This PR removes some debug code that snuck in but shouldn't be there: the streamed orderbook test was effectively only comparing the first 10 orders :see_no_evil: 

### Test Plan

The streamed orderbook test should still succeed!
```
yarn test-streamed-orderbook
```