### PR TITLE
[Linting] Add tsdoc plugin to lint doc comments.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,9 +17,10 @@ module.exports = {
     ecmaVersion: 2020,
     sourceType: "module",
   },
-  plugins: ["@typescript-eslint", "prettier"],
+  plugins: ["@typescript-eslint", "prettier", "tsdoc"],
   rules: {
     "no-console": "error",
+    "tsdoc/syntax": "error",
 
     "@typescript-eslint/camelcase": "off",
     "@typescript-eslint/no-use-before-define": "off",
@@ -34,6 +35,7 @@ module.exports = {
     {
       files: ["*.js"],
       rules: {
+        "tsdoc/syntax": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/no-var-requires": "off",
       },

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-no-only-tests": "^2.4.0",
     "eslint-plugin-prettier": "^3.1.3",
+    "eslint-plugin-tsdoc": "^0.2.4",
     "eth-gas-reporter": "^0.2.17",
     "ganache-cli": "^6.9.1",
     "husky": "^4.2.5",

--- a/src/balance_reader.ts
+++ b/src/balance_reader.ts
@@ -8,11 +8,11 @@ const WORD_DATA_LENGTH = 64;
  * Retrieves user's token balance as stored in the "balance" entry of the private exchange mapping balanceStates
  * Value is directly read from storage relying on Solidity's layout of storage variables
  * See https://solidity.readthedocs.io/en/develop/internals/layout_in_storage.html
- * @param userAddress address of the user
- * @param tokenAddress address of the token
- * @param batchExchangeAddress address of the batch exchange
- * @param web3Provider provider of Ethereum JavaScript API
- * @return balance of the token for the given user as stored in balanceStates[userAddress][tokenAddress].balance
+ * @param userAddress - address of the user
+ * @param tokenAddress - address of the token
+ * @param batchExchangeAddress - address of the batch exchange
+ * @param web3Provider - provider of Ethereum JavaScript API
+ * @returns balance of the token for the given user as stored in balanceStates[userAddress][tokenAddress].balance
  */
 export async function getBalanceState(
   userAddress: string,
@@ -63,11 +63,11 @@ export async function getBalanceState(
  * Computes amount of a token that a user can immediately withdraw from the exchange
  * It not only checks whether a withdrawal is pending, but also considers the balance available to the user,
  * pending deposits, and whether there were recent trades that would make withdrawing fail.
- * @param userAddress address of the user
- * @param tokenAddress address of the token
- * @param batchExchange object representing the batch exchange smart contract
- * @param web3Provider provider of Ethereum JavaScript API
- * @return amount of token that the user would receive by calling batchExchange.withdraw
+ * @param userAddress - address of the user
+ * @param tokenAddress - address of the token
+ * @param batchExchange - object representing the batch exchange smart contract
+ * @param web3Provider - provider of Ethereum JavaScript API
+ * @returns amount of token that the user would receive by calling batchExchange.withdraw
  */
 export async function getWithdrawableAmount(
   userAddress: string,

--- a/src/fraction.ts
+++ b/src/fraction.ts
@@ -107,8 +107,8 @@ export class Fraction {
   /**
    * Represents a Javascript number as a pair numerator/denominator without precision loss
    * by retrieving mantissa, exponent, and sign from its bit representation
-   * @param number The Javascript number to be represented
-   * @return a BigInt array with two elements: numerator and denominator
+   * @param number - The Javascript number to be represented
+   * @returns a BigInt array with two elements: numerator and denominator
    */
   private static numberToNumAndDen(number: number): [bigint, bigint] {
     const view = new DataView(new ArrayBuffer(8));

--- a/src/onchain_reading.ts
+++ b/src/onchain_reading.ts
@@ -9,9 +9,9 @@ import type BN from "bn.js";
 
 /**
  * Returns an iterator yielding an item for each page of order in the orderbook that is currently being collected.
- * @param contract to query from
- * @param pageSize the number of items to fetch per page
- * @param blockNumber the block number to execute the query at, defaults to "latest" if omitted
+ * @param contract - to query from
+ * @param pageSize - the number of items to fetch per page
+ * @param blockNumber - the block number to execute the query at, defaults to "latest" if omitted
  */
 export async function* getOpenOrdersPaginated(
   contract: BatchExchangeViewer,
@@ -43,9 +43,9 @@ export async function* getOpenOrdersPaginated(
 
 /**
  * Returns open orders in the orderbook.
- * @param contract to query from
- * @param pageSize the number of items to fetch per page
- * @param blockNumber the block number to execute the query at, defaults to "latest" if omitted
+ * @param contract - to query from
+ * @param pageSize - the number of items to fetch per page
+ * @param blockNumber - the block number to execute the query at, defaults to "latest" if omitted
  */
 export async function getOpenOrders(
   contract: BatchExchangeViewer,
@@ -65,9 +65,9 @@ export async function getOpenOrders(
 
 /**
  * Returns all orders in the orderbook.
- * @param contract to query from
- * @param pageSize the number of items to fetch per page
- * @param blockNumber the block number to execute the query at, defaults to "latest" if omitted
+ * @param contract - to query from
+ * @param pageSize - the number of items to fetch per page
+ * @param blockNumber - the block number to execute the query at, defaults to "latest" if omitted
  */
 export async function getOrdersPaginated(
   contract: BatchExchange,

--- a/src/orderbook.ts
+++ b/src/orderbook.ts
@@ -125,7 +125,7 @@ export class Orderbook {
 
   /**
    * In-place adds the given orderbook to the current one, combining all bids and asks at the same price point
-   * @param orderbook the orderbook to be added to this one
+   * @param orderbook - the orderbook to be added to this one
    */
   add(orderbook: Orderbook): void {
     if (orderbook.pair() != this.pair()) {
@@ -142,8 +142,8 @@ export class Orderbook {
   }
 
   /**
-   * @param amount the amount of base tokens to be sold
-   * @return the price for which there are enough bids to fill the specified amount or undefined if there is not enough liquidity
+   * @param amount - the amount of base tokens to be sold
+   * @returns the price for which there are enough bids to fill the specified amount or undefined if there is not enough liquidity
    */
   priceToSellBaseToken(amount: number | BN): Fraction | undefined {
     const bids = Array.from(this.bids.values());
@@ -154,8 +154,8 @@ export class Orderbook {
   }
 
   /**
-   * @param amount the amount of base tokens to be bought
-   * @return the price for which there are enough asks to fill the specified amount or undefined if there is not enough liquidity
+   * @param amount - the amount of base tokens to be bought
+   * @returns the price for which there are enough asks to fill the specified amount or undefined if there is not enough liquidity
    */
   priceToBuyBaseToken(amount: number | BN): Fraction | undefined {
     const asks = Array.from(this.asks.values());
@@ -167,7 +167,7 @@ export class Orderbook {
 
   /**
    * Removes any overlapping bid/asks which could be matched in the current orderbook
-   * @return A new instance of the orderbook with no more overlapping orders.
+   * @returns A new instance of the orderbook with no more overlapping orders.
    */
   reduced(): Orderbook {
     const result = new Orderbook(this.baseToken, this.quoteToken);
@@ -220,7 +220,7 @@ export class Orderbook {
   /**
    * Computes the transitive closure of this orderbook (e.g. ETH/DAI) with another one (e.g. DAI/USDC).
    * Throws if the orderbooks cannot be combined (baseToken is not equal to quoteToken)
-   * @param orderbook The orderbook for which the transitive closure will be computed
+   * @param orderbook - The orderbook for which the transitive closure will be computed
    * @returns A new instance of an orderbook representing the resulting closure.
    */
   transitiveClosure(orderbook: Orderbook): Orderbook {
@@ -324,10 +324,10 @@ export interface OrderbookJson {
 /**
  * Given a list of direct orderbooks this method returns the transitive orderbook
  * between two tokens by computing the transitive closure via a certain number of "hops".
- * @param direct_orderbooks the map direct (non-transitive) orderbooks between tokens
- * @param base the base token for which the transitive orderbook should be computed
- * @param quote the quote token for which the transitive orderbook should be computed
- * @param hops the number of intermediate tokens that should be considered when computing the transitive orderbook
+ * @param direct_orderbooks - the map direct (non-transitive) orderbooks between tokens
+ * @param base - the base token for which the transitive orderbook should be computed
+ * @param quote - the quote token for which the transitive orderbook should be computed
+ * @param hops - the number of intermediate tokens that should be considered when computing the transitive orderbook
  */
 export function transitiveOrderbook(
   direct_orderbooks: Map<string, Orderbook>,

--- a/test/resources/array-shims.ts
+++ b/test/resources/array-shims.ts
@@ -1,10 +1,10 @@
 /**
  * A shim for the `flat()` method that creates a new array with all sub-array
  * elements concatenated into it recursively up to the specified depth
- * @param arr The array.
- * @param depth The depth level specifying how deep a nested array
- *                           struction should be flattened. Defaults to 1.
- * @return {[]} A new array with the sub-array elements concatenated to it.
+ * @param arr - The array.
+ * @param depth - The depth level specifying how deep a nested array
+ *                struction should be flattened. Defaults to 1.
+ * @returns A new array with the sub-array elements concatenated to it.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function flat(arr: any[], depth = 1): any[] {
@@ -21,8 +21,8 @@ export function flat(arr: any[], depth = 1): any[] {
 
 /**
  * Deduplicates an array's element. Note that order is not preserved.
- * @param arr The array.
- * @return A new array containing only unique elements.
+ * @param arr - The array.
+ * @returns A new array containing only unique elements.
  */
 export function dedupe<T>(arr: T[]): T[] {
   return Array.from(new Set(arr));

--- a/test/resources/examples/generate.ts
+++ b/test/resources/examples/generate.ts
@@ -18,10 +18,10 @@ import {
 /**
  * Generates a test case to be used for unit and e2e testing with the contract
  * with computed solution values and objective values.
- * @param input The input to the test case
- * @param debug Print debug information in case of
- * @param strict Throw when solution is determined to be invalid
- * @return The test case
+ * @param input - The input to the test case
+ * @param debug - Print debug information in case of
+ * @param strict - Throw when solution is determined to be invalid
+ * @returns The test case
  */
 export function generateTestCase(
   input: TestCaseInput,
@@ -110,9 +110,9 @@ export function generateTestCase(
 
 /**
  * Prints debug information for a test case.
- * @param testCase The test case
- * @param [orderIds] The optional order indices for display, defaults to [0...]
- * @param [accounts] The optional accounts for display, defaults to [1...]
+ * @param testCase - The test case
+ * @param orderIds - The optional order indices for display, defaults to [0...]
+ * @param accounts - The optional accounts for display, defaults to [1...]
  */
 export function debugTestCase(
   testCase: TestCase,
@@ -211,10 +211,10 @@ export function debugTestCase(
 /**
  * Generates `submitSolution` parameters for a given computed solution. Note
  * that thifrom  order indices as they are not known until runtime
- * @param solution The computed solution
- * @param accounts The order indices as they are on the contract
- * @param orderIds The order indices as they are on the contract
- * @return The parameters to submit the solution
+ * @param solution - The computed solution
+ * @param accounts - The order indices as they are on the contract
+ * @param orderIds - The order indices as they are on the contract
+ * @returns The parameters to submit the solution
  */
 export function solutionSubmissionParams(
   solution: ComputedSolution,
@@ -239,7 +239,7 @@ export function solutionSubmissionParams(
 
 /**
  * Prints debug information for an objective value compuation.
- * @param testCase The test case
+ * @param testCase - The test case
  */
 export function debugObjectiveValueComputation(
   objectiveValue: ObjectiveValueComputation,

--- a/test/resources/math.ts
+++ b/test/resources/math.ts
@@ -5,8 +5,8 @@ import { Order, Solution, ObjectiveValueComputation } from "./examples/model";
 
 /**
  * Converts the amount value to `ether` unit.
- * @param value The amount to convert
- * @return The value in `ether` as a bignum
+ * @param value - - The amount to convert
+ * @returns The value in `ether` as a bignum
  */
 export function toETH(value: number): BN {
   const GWEI = 1000000000;
@@ -25,9 +25,9 @@ const FEE_DENOMINATOR_MINUS_ONE = FEE_DENOMINATOR.sub(new BN(1));
 
 /**
  * Removes fees to the specified value `n` times.
- * @param x The value to apply the fee to
- * @param n The number of times to apply the fee, must be greater than 0
- * @return The value minus fees
+ * @param x - - The value to apply the fee to
+ * @param n - - The number of times to apply the fee, must be greater than 0
+ * @returns The value minus fees
  */
 export function feeSubtracted(x: BN, n = 1): BN {
   const result = x.mul(FEE_DENOMINATOR_MINUS_ONE).div(FEE_DENOMINATOR);
@@ -36,8 +36,8 @@ export function feeSubtracted(x: BN, n = 1): BN {
 
 /**
  * Adds fees to the specified.
- * @param x The value to apply the fee to
- * @return The value plus fees
+ * @param x - The value to apply the fee to
+ * @returns The value plus fees
  */
 export function feeAdded(x: BN): BN {
   return x.mul(FEE_DENOMINATOR).div(FEE_DENOMINATOR_MINUS_ONE);
@@ -46,17 +46,16 @@ export function feeAdded(x: BN): BN {
 /**
  * The error epsilon required for buy/sell amounts to account for rounding
  * errors.
- * @type {BN}
  */
 export const ERROR_EPSILON = new BN(999000);
 
 /**
  * Calculates the executed buy amout given a buy volume and the settled buy and
  * sell prices.
- * @param executedBuyAmount The executed buy amount
- * @param buyTokenPrice The buy token price
- * @param sellTokenPrice The sell token price
- * @return The value plus fees
+ * @param executedBuyAmount - The executed buy amount
+ * @param buyTokenPrice - The buy token price
+ * @param sellTokenPrice - The sell token price
+ * @returns The value plus fees
  */
 export function getExecutedSellAmount(
   executedBuyAmount: BN,
@@ -73,10 +72,10 @@ export function getExecutedSellAmount(
 /**
  * Calculates the utility of an order given an executed buy amount and settled
  * solution prices.
- * @param order The order
- * @param executedBuyAmount The executed buy amount
- * @param prices The prices
- * @return The order's utility
+ * @param order - The order
+ * @param executedBuyAmount - The executed buy amount
+ * @param prices - The prices
+ * @returns The order's utility
  */
 export function orderUtility(
   order: Order,
@@ -111,10 +110,10 @@ export function orderUtility(
 /**
  * Calculates the disregarded utility of an order given an executed buy amount
  * and settled solution prices.
- * @param order The order
- * @param executedBuyAmount The executed buy amount
- * @param prices The prices
- * @return The order's disregarded utility
+ * @param order - The order
+ * @param executedBuyAmount - The executed buy amount
+ * @param prices - The prices
+ * @returns The order's disregarded utility
  */
 export function orderDisregardedUtility(
   order: Order,
@@ -153,9 +152,9 @@ export function orderDisregardedUtility(
 /**
  * Calculates the total objective value for the specified solution given the
  * order book.
- * @param orders The orders
- * @param solution The solution
- * @return The solution's objective value
+ * @param orders - The orders
+ * @param solution - The solution
+ * @returns The solution's objective value
  */
 export function solutionObjectiveValue(
   orders: Order[],
@@ -167,10 +166,10 @@ export function solutionObjectiveValue(
 /**
  * Calculates the solutions objective value returning a computation object with
  * all the intermediate values - useful for debugging.
- * @param orders The orders
- * @param solution The solution
- * @param strict Throw when solution is determined to be invalid
- * @return The solution's objective value computation object
+ * @param orders - The orders
+ * @param solution - The solution
+ * @param strict - Throw when solution is determined to be invalid
+ * @returns The solution's objective value computation object
  */
 export function solutionObjectiveValueComputation(
   orders: Order[],

--- a/test/utilities.ts
+++ b/test/utilities.ts
@@ -29,8 +29,8 @@ const send = function <T>(
 // Wait for n blocks to pass
 /**
  * Wait for n (evm) seconds to pass
- * @param seconds: time to wait
- * @param web3Provider: potentially different in contract tests and system end-to-end testing.
+ * @param seconds - time to wait
+ * @param web3Provider - potentially different in contract tests and system end-to-end testing.
  */
 export async function waitForNSeconds(
   seconds: number,
@@ -65,15 +65,16 @@ export async function sendTxAndGetReturnValue(
  * Finalizes user's pending deposits by updating user's balances for all input tokens.
  * It assumes no withdrawals have been requested.
  * State of the contract after the execution of this function for tokenAddress:
- * balanceState[userAddress][tokenAddress] =
- * {
+ * ```
+ * balanceState[userAddress][tokenAddress] = {
  *   balance: pendingDepositAmount,
  *   pendingDeposits: null,
  *   pendingWithdraws: null,
  * }
- * @param userAddress address of the user who deposited
- * @param epochTokenLocker instance of the epoch token locker to which the user deposited
- * @param tokenAddresses list of token addresses for which a deposit is pending
+ * ```
+ * @param userAddress - address of the user who deposited
+ * @param epochTokenLocker - instance of the epoch token locker to which the user deposited
+ * @param tokenAddresses - list of token addresses for which a deposit is pending
  */
 export async function applyBalances(
   userAddress: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -172,6 +172,21 @@
   dependencies:
     "@truffle/hdwallet-provider" "^1.0.27"
 
+"@microsoft/tsdoc-config@0.13.3":
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc-config/-/tsdoc-config-0.13.3.tgz#c35ab50289f5a5ca44338d10baa2f8526ca9b061"
+  integrity sha512-6v2JUsfQIr2KStZgRusIuJmNvXX/xZMkzXA9YKY99hpj7uuAeAsHeKTe07D8t7hKlz79qCZMmg6ptJ55dYP9Xg==
+  dependencies:
+    "@microsoft/tsdoc" "0.12.19"
+    ajv "~6.10.2"
+    jju "~1.4.0"
+    resolve "~1.12.0"
+
+"@microsoft/tsdoc@0.12.19":
+  version "0.12.19"
+  resolved "https://registry.yarnpkg.com/@microsoft/tsdoc/-/tsdoc-0.12.19.tgz#2173ccb92469aaf62031fa9499d21b16d07f9b57"
+  integrity sha512-IpgPxHrNxZiMNUSXqR1l/gePKPkfAmIKoDRP9hp7OwjU29ZR8WCJsOJ8iBKgw0Qk+pFwR+8Y1cy8ImLY6e9m4A==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"
@@ -667,6 +682,16 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5, ajv@^6.6.1, ajv@^6.9.1:
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
   dependencies:
     fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@~6.10.2:
+  version "6.10.2"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.10.2.tgz#d3cea04d6b017b2894ad69040fec8b623eb4bd52"
+  integrity sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==
+  dependencies:
+    fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
@@ -3025,6 +3050,14 @@ eslint-plugin-prettier@^3.1.3:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-tsdoc@^0.2.4:
+  version "0.2.4"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-tsdoc/-/eslint-plugin-tsdoc-0.2.4.tgz#b4e554838b9d0b09acd0955b6d9a0dd00978dc93"
+  integrity sha512-iUHb4SkithNERIfrHGWAdsR0cjHplF9F9Mop4cnDSplAw/0oKyPb9eDjcqwFfO4E2pz+JLv24TzgM7gFAGqO9A==
+  dependencies:
+    "@microsoft/tsdoc" "0.12.19"
+    "@microsoft/tsdoc-config" "0.13.3"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -3787,6 +3820,11 @@ fast-deep-equal@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
   integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
+
+fast-deep-equal@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
+  integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
 fast-deep-equal@^3.1.1:
   version "3.1.1"
@@ -5168,6 +5206,11 @@ isurl@^1.0.0-alpha5:
   dependencies:
     has-to-string-tag-x "^1.2.0"
     is-object "^1.0.1"
+
+jju@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/jju/-/jju-1.4.0.tgz#a3abe2718af241a2b2904f84a625970f389ae32a"
+  integrity sha1-o6vicYryQaKykE+EpiWXDzia4yo=
 
 js-sha3@0.5.7, js-sha3@^0.5.7:
   version "0.5.7"
@@ -7160,6 +7203,13 @@ resolve@^1.1.6, resolve@^1.10.0, resolve@^1.8.1:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@~1.12.0:
+  version "1.12.3"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.3.tgz#96d5253df8005ce19795c14338f2a013c38a8c15"
+  integrity sha512-hF6+hAPlxjqHWrw4p1rF3Wztbgxd4AjA5VlUzY5zcTb4J8D3JK4/1RjU48pHz2PJWzGVsLB1VWZkvJzhK2CCOA==
   dependencies:
     path-parse "^1.0.6"
 


### PR DESCRIPTION
This PR adds `eslint-plugin-tsdoc` to enable linting on doc comments to ensure they are correctly formatted as per the [tsdoc standard](https://github.com/Microsoft/tsdoc).

### Test Plan

Only comments were changed, make sure the linting succeeds in CI.