### PR TITLE
Added order encoding methods

### DIFF
--- a/src/encoding.ts
+++ b/src/encoding.ts
@@ -8,7 +8,7 @@
 import BN from "bn.js";
 import assert from "assert";
 
-export interface Order<T = string> {
+export interface Order<T = BN> {
   user: string;
   sellTokenBalance: T;
   buyToken: number;
@@ -20,7 +20,7 @@ export interface Order<T = string> {
   remainingAmount: T;
 }
 
-export interface IndexedOrder<T> extends Order<T> {
+export interface IndexedOrder<T = BN> extends Order<T> {
   orderId: number;
 }
 
@@ -60,7 +60,7 @@ function decodeIndexedOrder(bytes: OrderBuffer): IndexedOrder<BN> {
 }
 
 function decodeOrdersInternal<T>(
-  bytes: string,
+  bytes: string | null,
   decodeFunction: (x: OrderBuffer) => T,
   width: number,
 ): T[] {
@@ -82,7 +82,7 @@ function decodeOrdersInternal<T>(
  * decode the result of `BatchExchange.getEncodedUserOrders` and
  * `BatchExchange.getEncodedOrders`.
  */
-export function decodeOrders(bytes: string): Order<BN>[] {
+export function decodeOrders(bytes: string | null): Order<BN>[] {
   return decodeOrdersInternal<Order<BN>>(bytes, decodeOrder, 112);
 }
 
@@ -91,6 +91,110 @@ export function decodeOrders(bytes: string): Order<BN>[] {
  * This can be used to decode the result of `BatchExchangeViewer.getOpenOrderBook` and
  * `BatchExchangeViewer.getFinalizedOrderBook`.
  */
-export function decodeIndexedOrders(bytes: string): IndexedOrder<BN>[] {
+export function decodeIndexedOrders(bytes: string | null): IndexedOrder<BN>[] {
   return decodeOrdersInternal<IndexedOrder<BN>>(bytes, decodeIndexedOrder, 114);
+}
+
+type EncodableInt = string | { toString(base: number): string };
+
+class OrderEncoder {
+  private index = 0;
+  private readonly view: DataView;
+  constructor(private readonly bytes: Uint8Array) {
+    this.view = new DataView(bytes.buffer);
+  }
+
+  private encodeHex(hex: string): void {
+    const len = hex.length / 2;
+    for (let i = 0; i < len; i++) {
+      this.bytes[i + this.index] = parseInt(hex.substr(i * 2, 2), 16);
+    }
+    this.index += len;
+  }
+
+  encodeAddr(addr: string): void {
+    assert(
+      addr.length === 42 && addr.substr(0, 2) === "0x",
+      `invalid Ethereum address '${addr}`,
+    );
+    this.encodeHex(addr.substr(2));
+  }
+
+  encodeInt(size: number, value: EncodableInt): void {
+    const hex =
+      typeof value === "string"
+        ? BigInt(value).toString(16)
+        : value.toString(16);
+
+    assert(hex.length < size * 2, `value ${value} overflows ${size} bits`);
+    this.encodeHex(hex.padStart(size / 4, "0"));
+  }
+
+  encodeNumber(size: 16 | 32, value: number): void {
+    let setter: keyof DataView;
+    switch (size) {
+      case 16:
+        setter = "setUint16";
+        break;
+      case 32:
+        setter = "setUint32";
+        break;
+    }
+    this.view[setter](this.index, value, false);
+    this.index += size / 8;
+  }
+
+  encodeOrder<T extends EncodableInt>(order: Order<T>): void {
+    this.encodeAddr(order.user);
+    this.encodeInt(256, order.sellTokenBalance);
+    this.encodeNumber(16, order.buyToken);
+    this.encodeNumber(16, order.sellToken);
+    this.encodeNumber(32, order.validFrom);
+    this.encodeNumber(32, order.validUntil);
+    this.encodeInt(128, order.priceNumerator);
+    this.encodeInt(128, order.priceDenominator);
+    this.encodeInt(128, order.remainingAmount);
+  }
+
+  encodeIndexedOrder<T extends EncodableInt>(order: IndexedOrder<T>): void {
+    this.encodeOrder(order);
+    this.encodeNumber(16, order.orderId);
+  }
+}
+
+function encodeOrdersInternal<T>(
+  orders: T[],
+  stride: number,
+  encode: (encoder: OrderEncoder, order: T) => void,
+): Uint8Array {
+  const bytes = new Uint8Array(orders.length * stride);
+  const encoder = new OrderEncoder(bytes);
+  for (const order of orders) {
+    encode(encoder, order);
+  }
+  return bytes;
+}
+
+/**
+ * Encodes an array of orders into a `Uint8Array` of bytes. This uses the same
+ * format as `BatchExchange.getEncodedOrders`.
+ */
+export function encodeOrders<T extends EncodableInt>(
+  orders: Order<T>[],
+): Uint8Array {
+  return encodeOrdersInternal(orders, 112, (encoder, order) =>
+    encoder.encodeOrder(order),
+  );
+}
+
+/**
+ * Encodes an array of indexed orders into a `Uint8Array` of bytes. This uses
+ * the same format as `BatchExchangeViewer.getFilteredOrderBook`.
+ */
+export function encodeIndexedOrders<T extends EncodableInt>(
+  orders: IndexedOrder<T>[],
+): Uint8Array {
+  return encodeOrdersInternal(orders, 114, (encoder, order) =>
+    encoder.encodeIndexedOrder(order),
+  );
 }

--- a/test/models/encoding.spec.ts
+++ b/test/models/encoding.spec.ts
@@ -1,0 +1,161 @@
+import {
+  decodeOrders,
+  decodeIndexedOrders,
+  encodeOrders,
+  encodeIndexedOrders,
+} from "../../src";
+import BN from "bn.js";
+import { expect } from "chai";
+import "mocha";
+
+function hex(bytes: Uint8Array): string {
+  return `0x${Array.prototype.map
+    .call(bytes, (byte) => byte.toString(16).padStart(2, "0"))
+    .join("")}`;
+}
+
+function json(obj: unknown): unknown {
+  return JSON.parse(JSON.stringify(obj));
+}
+
+describe("Encoding Orders", () => {
+  describe("decodeOrders", () => {
+    it("accepts empty bytes and null and as input", () => {
+      expect(decodeOrders("")).to.deep.equal([]);
+      expect(decodeOrders("0x")).to.deep.equal([]);
+      expect(decodeOrders(null)).to.deep.equal([]);
+    });
+  });
+
+  describe("encodeOrders", () => {
+    it("encodes orders that can be decoded into the same values", () => {
+      const orders = [
+        {
+          user: "0x000102030405060708090a0b0c0d0e0f10111213",
+          sellTokenBalance: new BN(1),
+          buyToken: 2,
+          sellToken: 3,
+          validFrom: 4,
+          validUntil: 5,
+          priceNumerator: new BN("1000000000000000000"),
+          priceDenominator: new BN("1000000000000000000"),
+          remainingAmount: new BN(42),
+        },
+        {
+          user: "0x131211100f0e0d0c0b0a09080706050403020100",
+          sellTokenBalance: new BN(1),
+          buyToken: 2,
+          sellToken: 3,
+          validFrom: 4,
+          validUntil: 5,
+          priceNumerator: new BN(1337),
+          priceDenominator: new BN(0x12345678),
+          remainingAmount: new BN(42),
+        },
+      ];
+      const encoded = encodeOrders(orders);
+      const decoded = decodeOrders(hex(encoded));
+      expect(json(decoded)).to.deep.equal(json(orders));
+    });
+
+    it("can encode orders with string integer format", () => {
+      const orders = [
+        {
+          user: "0x000102030405060708090a0b0c0d0e0f10111213",
+          sellTokenBalance: "1",
+          buyToken: 2,
+          sellToken: 3,
+          validFrom: 4,
+          validUntil: 5,
+          priceNumerator: "6",
+          priceDenominator: "7",
+          remainingAmount: "8",
+        },
+      ];
+      const encoded = encodeOrders(orders);
+      expect(hex(encoded)).to.equal(
+        "0x\
+         000102030405060708090a0b0c0d0e0f10111213\
+         0000000000000000000000000000000000000000000000000000000000000001\
+         0002\
+         0003\
+         00000004\
+         00000005\
+         00000000000000000000000000000006\
+         00000000000000000000000000000007\
+         00000000000000000000000000000008\
+        ".replace(
+          /\s/g,
+          "",
+        ),
+      );
+    });
+
+    it("can encode orders with bigint integer format", () => {
+      const orders = [
+        {
+          user: "0x000102030405060708090a0b0c0d0e0f10111213",
+          sellTokenBalance: BigInt(1),
+          buyToken: 2,
+          sellToken: 3,
+          validFrom: 4,
+          validUntil: 5,
+          priceNumerator: BigInt(6),
+          priceDenominator: BigInt(7),
+          remainingAmount: BigInt(8),
+        },
+      ];
+      const encoded = encodeOrders(orders);
+      expect(hex(encoded)).to.equal(
+        "0x\
+         000102030405060708090a0b0c0d0e0f10111213\
+         0000000000000000000000000000000000000000000000000000000000000001\
+         0002\
+         0003\
+         00000004\
+         00000005\
+         00000000000000000000000000000006\
+         00000000000000000000000000000007\
+         00000000000000000000000000000008\
+        ".replace(
+          /\s/g,
+          "",
+        ),
+      );
+    });
+  });
+
+  describe("encodeIndexedOrders", () => {
+    it("encodes indexed orders that can be decoded into the same values", () => {
+      const orders = [
+        {
+          user: "0x000102030405060708090a0b0c0d0e0f10111213",
+          sellTokenBalance: new BN(1),
+          buyToken: 2,
+          sellToken: 3,
+          validFrom: 4,
+          validUntil: 5,
+          priceNumerator: new BN("1000000000000000000"),
+          priceDenominator: new BN("1000000000000000000"),
+          remainingAmount: new BN(42),
+          orderId: 99,
+        },
+        {
+          user: "0x131211100f0e0d0c0b0a09080706050403020100",
+          sellTokenBalance: new BN(1),
+          buyToken: 2,
+          sellToken: 3,
+          validFrom: 4,
+          validUntil: 5,
+          priceNumerator: new BN(1337),
+          priceDenominator: new BN(0x12345678),
+          remainingAmount: new BN(42),
+          orderId: 7,
+        },
+      ];
+      const encoded = encodeIndexedOrders(orders);
+      const decoded = decodeIndexedOrders(hex(encoded));
+      expect(json(decoded)).to.deep.equal(json(orders));
+    });
+  });
+});


### PR DESCRIPTION
This PR implements order encoding in `dex-contracts`. This can be used in `dex-price-estimator` once released to an npm package.

### Test Plan

New unit tests.