### PR TITLE
Test multiply touched orders in a single trade

### DIFF
--- a/test/regression_tests.js
+++ b/test/regression_tests.js
@@ -98,17 +98,19 @@ contract("BatchExchange", async (accounts) => {
 
       const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
 
+      // Modifying owners so that last owner appears twice.
+      // That is, owners = [owner1, owner2, ... ownerN, ownerN]
+      solution.owners.push(solution.owners.slice(-1)[0])
+      // Modifying touched orders so that last orderID appears twice.
+      solution.touchedorderIds.push(solution.touchedorderIds.slice(-1)[0])
       // Replace the last element of the basic trade volume with two coppies of half of it.
       const lastVolume = solution.volumes.slice(-1)[0]
-      const ramifiedVolumes = solution.volumes.slice(-1).concat([lastVolume.divn(2), lastVolume.divn(2)])
+      const ramifiedVolumes = solution.volumes.slice(0, -1).concat([lastVolume.divn(2), lastVolume.divn(2)])
 
       const ramifiedSolution = {
         objectiveValue: solution.objectiveValue,
-        // Modifying owners so that last owner appears twice.
-        // That is, owners = [owner1, owner2, ... ownerN, ownerN]
-        owners: solution.owners.push(solution.owners.slice(-1)[0]),
-        // Modifying touched orders so that last orderID appears twice.
-        touchedorderIds: solution.touchedorderIds.push(solution.owners.slice(-1)[0]),
+        owners: solution.owners,
+        touchedorderIds: solution.touchedorderIds,
         volumes: ramifiedVolumes,
         prices: solution.prices,
         tokenIdsForPrice: solution.tokenIdsForPrice,

--- a/test/regression_tests.js
+++ b/test/regression_tests.js
@@ -98,8 +98,6 @@ contract("BatchExchange", async (accounts) => {
 
       const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
 
-      solution.owners.push(solution.owners.slice(-1)[0])
-
       // Replace the last element of the basic trade volume with two coppies of half of it.
       const lastVolume = solution.volumes.slice(-1)[0]
       const ramifiedVolumes = solution.volumes.slice(-1).concat([lastVolume.divn(2), lastVolume.divn(2)])

--- a/test/regression_tests.js
+++ b/test/regression_tests.js
@@ -6,7 +6,7 @@ const IterableAppendOnlySet = artifacts.require("IterableAppendOnlySet")
 const BN = require("bn.js")
 const truffleAssert = require("truffle-assertions")
 
-const { closeAuction } = require("../scripts/utilities.js")
+const { closeAuction } = require("../scripts/utilities")
 
 const { solutionSubmissionParams, basicTrade, utilityOverflow } = require("../build/common/test/resources/examples")
 const { makeDeposits, placeOrders, setupGenericStableX } = require("./stablex_utils")
@@ -86,6 +86,47 @@ contract("BatchExchange", async (accounts) => {
         ),
         "Amount exceeds user's balance"
       )
+    })
+    it("[Ramified Basic Trade] Touches one order twice in the same solution.", async () => {
+      const batchExchange = await setupGenericStableX()
+
+      // Make deposits, place orders and close auction[aka runAuctionScenario(basicTrade)]
+      await makeDeposits(batchExchange, accounts, basicTrade.deposits)
+      const batchId = (await batchExchange.getCurrentBatchId.call()).toNumber()
+      const orderIds = await placeOrders(batchExchange, accounts, basicTrade.orders, batchId + 1)
+      await closeAuction(batchExchange)
+
+      const solution = solutionSubmissionParams(basicTrade.solutions[0], accounts, orderIds)
+
+      solution.owners.push(solution.owners.slice(-1)[0])
+
+      // Replace the last element of the basic trade volume with two coppies of half of it.
+      const lastVolume = solution.volumes.slice(-1)[0]
+      const ramifiedVolumes = solution.volumes.slice(-1).concat([lastVolume.divn(2), lastVolume.divn(2)])
+
+      const ramifiedSolution = {
+        objectiveValue: solution.objectiveValue,
+        // Modifying owners so that last owner appears twice.
+        // That is, owners = [owner1, owner2, ... ownerN, ownerN]
+        owners: solution.owners.push(solution.owners.slice(-1)[0]),
+        // Modifying touched orders so that last orderID appears twice.
+        touchedorderIds: solution.touchedorderIds.push(solution.owners.slice(-1)[0]),
+        volumes: ramifiedVolumes,
+        prices: solution.prices,
+        tokenIdsForPrice: solution.tokenIdsForPrice,
+      }
+      const objectiveValue = await batchExchange.submitSolution.call(
+        batchId,
+        ramifiedSolution.objectiveValue,
+        ramifiedSolution.owners,
+        ramifiedSolution.touchedorderIds,
+        ramifiedSolution.volumes,
+        ramifiedSolution.prices,
+        ramifiedSolution.tokenIdsForPrice,
+        { from: solver }
+      )
+      // Assertion that previous transaction passed.
+      assert(objectiveValue > 0, "the computed objective value is greater than 0")
     })
   })
 })


### PR DESCRIPTION
As we have recently learned, it is possible to "touch" the same order twice in a single solutions submission. This is elaborated on in the related issue:

Closes #777

Tagging @alfetopito and @anxolin who brought this up. I think this new discovery may also make it difficult to query for "finalized trades"

_Solutions with non-trivial touched order ramification index_

Test Plan: Unit tests.