### PR TITLE
use JS assert and bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "build/common/src/index.js",
   "types": "build/common/src/index.d.ts",

--- a/src/amounts.ts
+++ b/src/amounts.ts
@@ -1,5 +1,5 @@
 import BN from "bn.js";
-import { assert } from "chai";
+import assert from "assert";
 import { Fraction } from "./fraction";
 
 const MAX128 = new BN(2).pow(new BN(128)).subn(1);
@@ -19,14 +19,8 @@ export function getUnitPrice(
   sellTokenDecimals: number,
   buyTokenDecimals: number,
 ): Fraction {
-  assert.isTrue(
-    sellTokenDecimals >= 0,
-    "sell token decimals must be non-negative",
-  );
-  assert.isTrue(
-    buyTokenDecimals >= 0,
-    "buy token decimals must be non-negative",
-  );
+  assert(sellTokenDecimals >= 0, "sell token decimals must be non-negative");
+  assert(buyTokenDecimals >= 0, "buy token decimals must be non-negative");
 
   return Fraction.fromNumber(price).mul(
     new Fraction(
@@ -83,7 +77,7 @@ export function getUnlimitedOrderAmounts(
       buyTokenDecimals,
       sellTokenDecimals,
     );
-    assert.isTrue(
+    assert(
       buyAmount.gte(sellAmount),
       "Error: unable to create unlimited order",
     );

--- a/test/models/amounts.spec.ts
+++ b/test/models/amounts.spec.ts
@@ -5,7 +5,7 @@ import {
 } from "../../src/amounts";
 import { Fraction } from "../../src/fraction";
 import BN from "bn.js";
-import { assert } from "chai";
+import assert from "assert";
 import "mocha";
 
 const MAX128 = new BN(2).pow(new BN(128)).subn(1);
@@ -109,7 +109,7 @@ describe("Amounts", () => {
         );
 
         // Either the resulting fractions are identicall, or results are "essentiallyEqual"
-        assert.isTrue(
+        assert(
           essentiallyEqual(unitPrice, expected),
           `${unitPrice.toNumber()} != ${expected.toNumber()}`,
         );
@@ -171,7 +171,7 @@ describe("Amounts", () => {
           sellTokenDecimals,
           buyTokenDecimals,
         );
-        assert.isTrue(essentiallyEqual(output, expected));
+        assert(essentiallyEqual(output, expected));
       });
     }
   });
@@ -241,8 +241,8 @@ describe("Amounts", () => {
           sellTokenDecimals,
           buyTokenDecimals,
         );
-        assert.isTrue(essentiallyEqual(quote, expectedQuoteAmount));
-        assert.isTrue(essentiallyEqual(base, expectedbaseAmount));
+        assert(essentiallyEqual(quote, expectedQuoteAmount));
+        assert(essentiallyEqual(base, expectedbaseAmount));
       });
     }
   });

--- a/test/models/amounts.spec.ts
+++ b/test/models/amounts.spec.ts
@@ -5,7 +5,7 @@ import {
 } from "../../src/amounts";
 import { Fraction } from "../../src/fraction";
 import BN from "bn.js";
-import assert from "assert";
+import { assert } from "chai";
 import "mocha";
 
 const MAX128 = new BN(2).pow(new BN(128)).subn(1);
@@ -109,7 +109,7 @@ describe("Amounts", () => {
         );
 
         // Either the resulting fractions are identicall, or results are "essentiallyEqual"
-        assert(
+        assert.isTrue(
           essentiallyEqual(unitPrice, expected),
           `${unitPrice.toNumber()} != ${expected.toNumber()}`,
         );
@@ -171,7 +171,7 @@ describe("Amounts", () => {
           sellTokenDecimals,
           buyTokenDecimals,
         );
-        assert(essentiallyEqual(output, expected));
+        assert.isTrue(essentiallyEqual(output, expected));
       });
     }
   });
@@ -241,8 +241,8 @@ describe("Amounts", () => {
           sellTokenDecimals,
           buyTokenDecimals,
         );
-        assert(essentiallyEqual(quote, expectedQuoteAmount));
-        assert(essentiallyEqual(base, expectedbaseAmount));
+        assert.isTrue(essentiallyEqual(quote, expectedQuoteAmount));
+        assert.isTrue(essentiallyEqual(base, expectedbaseAmount));
       });
     }
   });


### PR DESCRIPTION
importing chai as a main project dependency was overkill for such simple assertions in `amounts.ts` Hopefully this works for those exported functions in integrated projects.