### PR TITLE
[JS->TS] Migrate invokeViewFunction.js

### DIFF
--- a/scripts/invokeViewFunction.js
+++ b/scripts/invokeViewFunction.js
@@ -1,6 +1,0 @@
-const BatchExchange = artifacts.require("BatchExchange")
-const { invokeViewFunction } = require("./utilities.js")
-
-module.exports = async (callback) => {
-  await invokeViewFunction(BatchExchange, callback)
-}

--- a/scripts/invoke_view_function.ts
+++ b/scripts/invoke_view_function.ts
@@ -1,6 +1,4 @@
 import { parseArgs, getBatchExchange } from "./util";
-import { factory } from "../src/logging";
-const log = factory.getLogger("scripts.invoke_view_function");
 
 module.exports = async (callback: Truffle.ScriptCallback) => {
   try {
@@ -12,8 +10,14 @@ module.exports = async (callback: Truffle.ScriptCallback) => {
     }
     const [functionName, ...arg] = args;
     const exchange = await getBatchExchange(artifacts);
-    const info = await (exchange as any)[functionName].call(...arg);
-    log.info(info);
+    const info: unknown = await exchange.contract.methods[functionName](
+      ...arg,
+    ).call();
+    // Note that this script is intended to be used for bash scripting and
+    // one would usually grep for the results of this execution. Thus,
+    // the raw output is printed rather than include irrelevant log details.
+    // eslint-disable-next-line no-console
+    console.log(info);
     callback();
   } catch (error) {
     callback(error);

--- a/scripts/invoke_view_function.ts
+++ b/scripts/invoke_view_function.ts
@@ -1,0 +1,21 @@
+import { parseArgs, getBatchExchange } from "./util";
+import { factory } from "../src/logging";
+const log = factory.getLogger("scripts.invoke_view_function");
+
+module.exports = async (callback: Truffle.ScriptCallback) => {
+  try {
+    const args = parseArgs();
+    if (args.length < 1) {
+      callback(
+        "Error: This script requires arguments - <functionName> [..args]",
+      );
+    }
+    const [functionName, ...arg] = args;
+    const exchange = await getBatchExchange(artifacts);
+    const info = await (exchange as any)[functionName].call(...arg);
+    log.info(info);
+    callback();
+  } catch (error) {
+    callback(error);
+  }
+};

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -88,3 +88,12 @@ export async function addTokens(
   // Return token information
   return tokens;
 }
+
+export function parseArgs(): string[] {
+  const args = process.argv.slice(4);
+  const index = args.indexOf("--network");
+  if (index > -1) {
+    args.splice(index, 2);
+  }
+  return args;
+}

--- a/scripts/utilities.js
+++ b/scripts/utilities.js
@@ -1,14 +1,5 @@
 import { setAllowance } from "./util"
 
-const getArgumentsHelper = function () {
-  const args = process.argv.slice(4)
-  const index = args.indexOf("--network")
-  if (index > -1) {
-    args.splice(index, 2)
-  }
-  return args
-}
-
 const getOrderData = async function (instance, callback, web3, argv) {
   const minBuy = web3.utils.toWei(String(argv.minBuy))
   const maxSell = web3.utils.toWei(String(argv.maxSell))
@@ -29,24 +20,6 @@ const getOrderData = async function (instance, callback, web3, argv) {
   }
 
   return [argv.buyToken, argv.sellToken, minBuy, maxSell, sender]
-}
-
-const invokeViewFunction = async function (contract, callback) {
-  try {
-    const args = getArgumentsHelper()
-    if (args.length < 1) {
-      callback("Error: This script requires arguments - <functionName> [..args]")
-    }
-    const [functionName, ...arg] = args
-
-    const instance = await contract.deployed()
-    const info = await instance[functionName].call(...arg)
-
-    console.log(info)
-    callback()
-  } catch (error) {
-    callback(error)
-  }
 }
 
 async function createMintableToken(artifacts) {
@@ -128,9 +101,7 @@ async function mintOwl({ users, minter, amount, owl }) {
 }
 
 module.exports = {
-  getArgumentsHelper,
   getOrderData,
-  invokeViewFunction,
   mintOwl,
   deleteOrders,
   setAllowances,

--- a/scripts/wait_seconds.js
+++ b/scripts/wait_seconds.js
@@ -1,9 +1,9 @@
 const { waitForNSeconds } = require("../build/common/test/utilities")
-const { getArgumentsHelper } = require("./script_utilities.js")
+const { parseArgs } = require("../build/common/scripts/util")
 
 module.exports = async (callback) => {
   try {
-    const args = getArgumentsHelper()
+    const args = parseArgs()
     if (args.length != 1) {
       callback("Error: This script requires arguments - <seconds>")
     }


### PR DESCRIPTION
Partially fulfills #330. Unfortunately, I have not been able to get expected values returned from this script just yet. This snippet is the closest example in the current code base

https://github.com/gnosis/dex-contracts/blob/7cabfe1fb34f49bde972d2b423edd9fabd6f34c8/src/onchain_reading.ts#L89-L91

I can verify that logging `contract.methods` does indeed contain the methods as strings.

**Test Plan**

```sh
npx truffle exec build/common/scripts/invoke_view_function.js --network mainnet getCurrentBatchId
```
Currently getting back `undefined`.

```
Using network 'mainnet'.

2020-05-28 17:39:53,393 INFO [scripts.invoke_view_function] undefined
```