### PR TITLE
[Trivial] Trim whitespace from comma separated script arguments

### DIFF
--- a/scripts/cancel_order.ts
+++ b/scripts/cancel_order.ts
@@ -10,7 +10,7 @@ const argv = require("yargs")
     type: "string",
     describe: "Order IDs to be canceled",
     coerce: (str: string) => {
-      return str.split(",").map((o) => parseInt(o));
+      return str.split(",").map((o) => parseInt(o.trim()));
     },
   })
   .demand(["accountId", "orderIds"])

--- a/scripts/place_spread_orders.ts
+++ b/scripts/place_spread_orders.ts
@@ -33,7 +33,7 @@ const argv = require("yargs")
     type: "string",
     describe: "Collection of trusted tokenIds",
     coerce: (str: string) => {
-      return str.split(",").map((t) => parseInt(t));
+      return str.split(",").map((t) => parseInt(t.trim()));
     },
   })
   .option("accountId", {

--- a/src/onchain_reading.ts
+++ b/src/onchain_reading.ts
@@ -34,7 +34,7 @@ export async function* getOpenOrdersPaginated(
     const elements = decodeIndexedOrders(page.elements);
     yield elements;
 
-    //Update page info
+    // Update page info
     hasNextPage = page.hasNextPage;
     nextPageUser = page.nextPageUser;
     nextPageUserOffset = page.nextPageUserOffset;


### PR DESCRIPTION
Just a little improvement, that might save someone some careful planning someday in the future.

Previously our scripts would only accept arguments like `--tokenIds` with no spaces like `1,2,3`, but now it will handle `1, 2, 3`  just the same.