### PR TITLE
[Trivial] Remove undefiend solhint preferences

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,17 +1,22 @@
 {
   "extends": "solhint:default",
-  "plugins": ["prettier"],
+  "plugins": [
+    "prettier"
+  ],
   "rules": {
-    "indent": ["error", 4],
-    "quotes": ["error", "double"],
-    "max-line-length": ["error", 129],
-    "max-states-count": ["error", 18],
+    "quotes": [
+      "error",
+      "double"
+    ],
+    "max-line-length": [
+      "error",
+      129
+    ],
+    "max-states-count": [
+      "error",
+      18
+    ],
     "not-rely-on-time": "error",
-    "compiler-fixed": true,
-    "no-simple-event-func-name": true,
-    "two-lines-top-level-separator": "off",
-    "separate-by-one-line-in-contract": "warn",
-    "bracket-align": "warn",
     "prettier/prettier": "error"
   }
 }


### PR DESCRIPTION
We had been seeing these unknown solidity linting preferences

```
➜  dex-contracts git:(solidity_lint_warnings) yarn lint
yarn run v1.22.4
$ yarn run lint:solidity && yarn run lint:ts
$ solhint "contracts/**/*.sol"
[solhint] Warning: Rule 'indent' doesn't exist
[solhint] Warning: Rule 'compiler-fixed' doesn't exist
[solhint] Warning: Rule 'no-simple-event-func-name' doesn't exist
[solhint] Warning: Rule 'two-lines-top-level-separator' doesn't exist
[solhint] Warning: Rule 'separate-by-one-line-in-contract' doesn't exist
[solhint] Warning: Rule 'bracket-align' doesn't exist

$ eslint . --ext .js,.ts
✨  Done in 11.21s.
```

and now they are gone!