### PR TITLE
[Easy] Bump to NodeJS LTS (v12)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
 language: node_js
 node_js:
-  - 10
+  - 12
 cache: yarn
-env: NODE_OPTIONS=--max_old_space_size=4096
+env:
+  global:
+    NODE_OPTIONS=--max_old_space_size=4096
 before_install:
   - rm -rf build
   - npm install -g yarn@latest
   - yarn --version
 before_script:
-  - yarn run ganache > /dev/null &
+  - yarn ganache > /dev/null &
 script:
   - yarn lint
   - yarn build


### PR DESCRIPTION
This PR bumps NodeJS version to 12 (the current LTS version) in the Travis file.

### Test Plan

CI! That is what we are updating :smile:
