### PR TITLE
[Trivial] Bump web3-util to 1.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "web3": "^1.2.9",
     "web3-core": "^1.2.9",
     "web3-eth-contract": "^1.2.8",
-    "web3-utils": "^1.2.8",
+    "web3-utils": "^1.2.9",
     "yargs": "^15.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9230,7 +9230,7 @@ web3-core@1.2.8:
     web3-core-requestmanager "1.2.8"
     web3-utils "1.2.8"
 
-web3-core@^1.2.9:
+web3-core@1.2.9, web3-core@^1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.2.9.tgz#2cba57aa259b6409db532d21bdf57db8d504fd3e"
   integrity sha512-fSYv21IP658Ty2wAuU9iqmW7V+75DOYMVZsDH/c14jcF/1VXnedOcxzxSj3vArsCvXZNe6XC5/wAuGZyQwR9RA==
@@ -9960,7 +9960,7 @@ web3-utils@1.2.8:
     underscore "1.9.1"
     utf8 "3.0.0"
 
-web3-utils@1.2.9, web3-utils@^1.2.8:
+web3-utils@1.2.9, web3-utils@^1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.2.9.tgz#abe11735221627da943971ef1a630868fb9c61f3"
   integrity sha512-9hcpuis3n/LxFzEVjwnVgvJzTirS2S9/MiNAa7l4WOEoywY+BSNwnRX4MuHnjkh9NY25B6QOjuNG6FNnSjTw1w==
@@ -10048,17 +10048,6 @@ web3@^1.0.0-beta.34, web3@^1.2.1, web3@^1.2.9:
     web3-net "1.2.9"
     web3-shh "1.2.9"
     web3-utils "1.2.9"
-
-websocket@^1.0.31:
-  version "1.0.31"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.31.tgz#e5d0f16c3340ed87670e489ecae6144c79358730"
-  integrity sha512-VAouplvGKPiKFDTeCCO65vYHsyay8DqoBSlzIO3fayrfOgU94lQN5a1uWVnFrMLceTJw/+fQXR5PGbUVRaHshQ==
-  dependencies:
-    debug "^2.2.0"
-    es5-ext "^0.10.50"
-    nan "^2.14.0"
-    typedarray-to-buffer "^3.1.5"
-    yaeti "^0.0.6"
 
 websocket@^1.0.31:
   version "1.0.31"


### PR DESCRIPTION
Dependabot missed this one as it was updated as a transient dependency of another dependency, and so it was up to date in the lock file.

This PR just updates it in `package.json` as well.

### Test Plan

CI - note that only the requested versions in the `yarn.lock` file were updated. So the resolved dependencies didn't really change.