### PR TITLE
bump contracts to version 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "build/common/src/index.js",
   "types": "build/common/src/index.d.ts",


### PR DESCRIPTION
It has been over a month since last publish and we have migrated everything in to typescript. This calls for a middle number bump.

Also, I need this version explicitly for the `fetchTokenInfo` function that is now exposed from src