### PR TITLE
Exporting BatchExchange contract for external projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "build/common/src/index.js",
   "types": "build/common/src/index.d.ts",
@@ -54,7 +54,10 @@
     "build/common",
     "build/esm",
     "networks.json",
-    "src"
+    "src",
+    "contracts/BatchExchange.sol",
+    "contracts/EpochTokenLocker.sol",
+    "contracts/libraries/TokenConservation.sol"
   ],
   "keywords": [
     "decentralized",

--- a/src/migration/PoC_dfusion.js
+++ b/src/migration/PoC_dfusion.js
@@ -1,4 +1,4 @@
-const { isDevelopmentNetwork, getArtifactFromNpmImport, getArtifactFromBuildFolderOrImport } = require("./utilities.js")
+const { isDevelopmentNetwork, getArtifactFromNpmImport } = require("./utilities.js")
 const deployOwl = require("@gnosis.pm/owl-token/src/migrations-truffle-5/3_deploy_OWL")
 
 async function migrate({ artifacts, deployer, network, account, web3, maxTokens = 2 ** 16 - 1 }) {
@@ -34,13 +34,7 @@ async function migrate({ artifacts, deployer, network, account, web3, maxTokens 
     await IterableAppendOnlySet.deployed()
   }
 
-  const BatchExchange = getArtifactFromBuildFolderOrImport(
-    artifacts,
-    network,
-    deployer,
-    account,
-    "@gnosis.pm/dex-contracts/build/contracts/BatchExchange"
-  )
+  const BatchExchange = artifacts.require("BatchExchange")
   //linking libraries
   await deployer.link(BiMap, BatchExchange)
   await deployer.link(IterableAppendOnlySet, BatchExchange)

--- a/src/migration/utilities.js
+++ b/src/migration/utilities.js
@@ -11,26 +11,11 @@ function getArtifactFromNpmImport(path, deployer, account) {
   return contract
 }
 
-function getArtifactFromBuildFolderOrImport(artifacts, network, deployer, account, path) {
-  let contract
-  // If this migration script is used from the repository dex-contracts, the contract
-  // data is received via the artificats.require.
-  // If this migration script is used from an external project, the first try statement
-  // will fail and it will get the contracts from the function initializeContract.
-  try {
-    contract = artifacts.require(path.split("/").pop())
-  } catch (error) {
-    contract = getArtifactFromNpmImport(path, deployer, account)
-  }
-  return contract
-}
-
 function isDevelopmentNetwork(network) {
   return network === "development" || network === "coverage" || network === "developmentdocker"
 }
 
 module.exports = {
-  getArtifactFromBuildFolderOrImport,
   isDevelopmentNetwork,
   getArtifactFromNpmImport,
 }


### PR DESCRIPTION
This PR publishes BatchExchange contract in the npm package, so that other projects can depend better on the exchange.
Please note that this change would actually require the lift of these dev-dependencies into dependencies:
```
 "@gnosis.pm/solidity-data-structures/contracts/libraries/IdToAddressBiMap.sol";
 "@gnosis.pm/solidity-data-structures/contracts/libraries/IterableAppendOnlySet.sol";
"@gnosis.pm/owl-token/contracts/TokenOWL.sol";
 "openzeppelin-solidity/contracts/utils/SafeCast.sol";
"solidity-bytes-utils/contracts/BytesLib.sol";
```
But I did not do it, as this would boost the npm package significantly in size and some of you are concerned about the size. Personally, I would do it, to have it cleaner.

Please be aware that this is a short term solution, as long term we will have one mono-repo with several npm packages for the different use cases.


Why I needed to export the BatchExchange contract:
In the current version of dex-liquidity-provision a usual migration against ganache does not store the network addresses. Hence, we can not run and tests any scripts against ganache, as we are losing the network-address information, besides the usual testing framework offered by truffle. While there are workarounds, like storing the addresses during migration and then copy them by hand into the artifacts existing in the dex-contracts npm package, this is not a clean solution.

This PR is the basis for the other [PR here.](https://github.com/gnosis/dex-liquidity-provision/pull/409), demonstrating how to depend on the project.

Testplan:

```
checkout this PR
yarn link
cd ../dex-liquidity-provision
[checkout other PR.](https://github.com/gnosis/dex-liquidity-provision/pull/409)
yarn link @gnosis.pm/dex-contracts
rm -rf build
yarn compile
npx truffle migrate
```
