### PR TITLE
Update solidity-data-structures package

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -445,7 +445,7 @@ contract BatchExchange is EpochTokenLocker {
      * @return encoded packed bytes of user addresses
      */
     function getUsersPaginated(address previousPageUser, uint16 pageSize) public view returns (bytes memory users) {
-        if (allUsers.size() == 0) {
+        if (allUsers.size == 0) {
             return users;
         }
         uint16 count = 0;
@@ -482,7 +482,7 @@ contract BatchExchange is EpochTokenLocker {
         uint16 previousPageUserOffset,
         uint16 pageSize
     ) public view returns (bytes memory elements) {
-        if (allUsers.size() == 0) {
+        if (allUsers.size == 0) {
             return elements;
         }
         uint16 currentOffset = previousPageUserOffset;
@@ -510,7 +510,7 @@ contract BatchExchange is EpochTokenLocker {
      * @return encoded bytes representing all orders ordered by (user, index)
      */
     function getEncodedOrders() public view returns (bytes memory elements) {
-        if (allUsers.size() > 0) {
+        if (allUsers.size > 0) {
             address user = allUsers.first();
             bool stop = false;
             while (!stop) {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "@gnosis.pm/mock-contract": "^3.0.8",
     "@gnosis.pm/owl-token": "^3.1.0",
-    "@gnosis.pm/solidity-data-structures": "=1.2.4",
+    "@gnosis.pm/solidity-data-structures": "1.3.5",
     "@gnosis.pm/util-contracts": "^2.0.6",
     "@openzeppelin/contracts": "=2.5.1",
     "@truffle/contract": "^4.2.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,10 +286,10 @@
     "@gnosis.pm/util-contracts" "^2.0.0"
     verify-on-etherscan "^1.1.1"
 
-"@gnosis.pm/solidity-data-structures@=1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/solidity-data-structures/-/solidity-data-structures-1.2.4.tgz#e7e0a2e4c3460a0166e7b985e7851e3a54e86607"
-  integrity sha512-s5AV1cTf1ERYPCWdC8+Zgx0oZDJTClpkbtXs8RcBFnuhADLd0QTwBowlS8iDsnQtfLNhcF0bDB1rzokJOSUGhg==
+"@gnosis.pm/solidity-data-structures@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/solidity-data-structures/-/solidity-data-structures-1.3.5.tgz#a38cab984a5a4c7d379454d5e82a2ac2f1a6b65e"
+  integrity sha512-qU32sUlH1cE26uhSSTbCYpskYzMm4KBXaIZdpu9v2xsO6jjedgfg9rKxJcor1V4ZRBp4EQyFqWzPx7fPTTPoUQ==
   dependencies:
     "@gnosis.pm/util-contracts" "^2.0.4"
     ethereumjs-util "^6.1.0"


### PR DESCRIPTION
In order to deploy the exchange on xDai, we need to use the newest version of the solidity-data-structures package. There was a breaking change in the way that size gets computed (https://github.com/gnosis/solidity-data-structures/pull/21) which requires small adjustments in the smart contract code.

### Test Plan

CI