### PR TITLE
Allow specfiying an arbitrary fee token for deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ If you are building for a local development network, ganache has to be running l
 yarn run ganache # start a development network (blocking)
 ```
 
+If you want to deploy the contracts with an already existing fee token (tokenId 0), you can set the env variable
+
+```
+export FEE_TOKEN_ADDRESS=...
+```
+
+before running the migration script.
+
 3. Verify the contracts for some cool Etherscan.io goodies (see below for more help)
 
 ```sh

--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -445,7 +445,7 @@ contract BatchExchange is EpochTokenLocker {
      * @return encoded packed bytes of user addresses
      */
     function getUsersPaginated(address previousPageUser, uint16 pageSize) public view returns (bytes memory users) {
-        if (allUsers.size() == 0) {
+        if (allUsers.size == 0) {
             return users;
         }
         uint16 count = 0;
@@ -482,7 +482,7 @@ contract BatchExchange is EpochTokenLocker {
         uint16 previousPageUserOffset,
         uint16 pageSize
     ) public view returns (bytes memory elements) {
-        if (allUsers.size() == 0) {
+        if (allUsers.size == 0) {
             return elements;
         }
         uint16 currentOffset = previousPageUserOffset;
@@ -510,7 +510,7 @@ contract BatchExchange is EpochTokenLocker {
      * @return encoded bytes representing all orders ordered by (user, index)
      */
     function getEncodedOrders() public view returns (bytes memory elements) {
-        if (allUsers.size() > 0) {
+        if (allUsers.size > 0) {
             address user = allUsers.first();
             bool stop = false;
             while (!stop) {

--- a/migrations/2_batch_exchange.js
+++ b/migrations/2_batch_exchange.js
@@ -8,5 +8,6 @@ module.exports = async function (deployer, network, accounts, web3) {
     account: accounts[0],
     web3,
     forceRedeploy: true,
+    feeTokenAddress: process.env.FEE_TOKEN_ADDRESS,
   })
 }

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
   "devDependencies": {
     "@gnosis.pm/mock-contract": "^3.0.8",
     "@gnosis.pm/owl-token": "^3.1.0",
-    "@gnosis.pm/solidity-data-structures": "=1.2.4",
+    "@gnosis.pm/solidity-data-structures": "1.3.5",
     "@gnosis.pm/util-contracts": "^2.0.6",
     "@openzeppelin/contracts": "=2.5.1",
     "@truffle/contract": "^4.2.19",

--- a/src/migration/PoC_dfusion.js
+++ b/src/migration/PoC_dfusion.js
@@ -39,7 +39,7 @@ async function migrate({
     await IterableAppendOnlySet.deployed()
   }
 
-  if (feeTokenAddress === null) {
+  if (feeTokenAddress == null) {
     const TokenOWLProxy = getArtifactFromBuildFolderOrImport(
       artifacts,
       deployer,

--- a/src/migration/utilities.js
+++ b/src/migration/utilities.js
@@ -11,7 +11,7 @@ function getArtifactFromNpmImport(path, deployer, account) {
   return contract
 }
 
-function getArtifactFromBuildFolderOrImport(artifacts, network, deployer, account, path) {
+function getArtifactFromBuildFolderOrImport(artifacts, deployer, account, path) {
   let contract
   // If this migration script is used from the repository dex-contracts, the contract
   // data is received via the artificats.require.

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,10 +286,10 @@
     "@gnosis.pm/util-contracts" "^2.0.0"
     verify-on-etherscan "^1.1.1"
 
-"@gnosis.pm/solidity-data-structures@=1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/solidity-data-structures/-/solidity-data-structures-1.2.4.tgz#e7e0a2e4c3460a0166e7b985e7851e3a54e86607"
-  integrity sha512-s5AV1cTf1ERYPCWdC8+Zgx0oZDJTClpkbtXs8RcBFnuhADLd0QTwBowlS8iDsnQtfLNhcF0bDB1rzokJOSUGhg==
+"@gnosis.pm/solidity-data-structures@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/solidity-data-structures/-/solidity-data-structures-1.3.5.tgz#a38cab984a5a4c7d379454d5e82a2ac2f1a6b65e"
+  integrity sha512-qU32sUlH1cE26uhSSTbCYpskYzMm4KBXaIZdpu9v2xsO6jjedgfg9rKxJcor1V4ZRBp4EQyFqWzPx7fPTTPoUQ==
   dependencies:
     "@gnosis.pm/util-contracts" "^2.0.4"
     ethereumjs-util "^6.1.0"


### PR DESCRIPTION
This PR is another requirement for xDAI deployment. On xDAI we don't want to redeploy a mintable OWL token. instead we want to use the existing [TokenBridge](https://docs.tokenbridge.net/eth-xdai-amb-bridge/multi-token-extension/the-bridged-tokens-list) for it.

This PR makes it so that we can deploy the BatchExchange contracts with a fixed fee token address (specified via command line arg)

### Test Plan

xDAI deployment uses the previously set address (https://blockscout.com/poa/xdai/tokens/0x750eCf8c11867Ce5Dbc556592c5bb1E0C6d16538/token_transfers)

```sh
export FEE_TOKEN_ADDRESS=0x750eCf8c11867Ce5Dbc556592c5bb1E0C6d16538
yarn truffle migrate --network xdai
```