### PR TITLE
Vendor dex-js token list for script

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "bignumber.js": "^9.0.0",
     "chai": "^4.2.0",
     "coveralls": "^3.1.0",
-    "cross-fetch": "^3.0.6",
     "dotenv": "^8.2.0",
     "eslint": "^7.9.0",
     "eslint-config-prettier": "^6.11.0",

--- a/scripts/add_token_list.ts
+++ b/scripts/add_token_list.ts
@@ -1,13 +1,13 @@
-import { addTokens, getBatchExchange, getOwl } from "./util";
-import fetch from "cross-fetch";
+import { promises as fs } from "fs";
 import { factory } from "../src/logging";
+import { addTokens, getBatchExchange, getOwl } from "./util";
+import DefaultTokenList from "./data/tokenList.json";
 const log = factory.getLogger("scripts.add_token_list");
 
 const argv = require("yargs")
-  .option("token_list_url", {
-    describe: "A url which can be fetched with cross-fetch",
-    default:
-      "https://raw.githubusercontent.com/gnosis/dex-js/master/src/tokenList.json",
+  .option("token_list", {
+    describe:
+      "A path to a token list, a default list will be used if not specified",
   })
   .help(false)
   .version(false).argv;
@@ -25,9 +25,16 @@ interface TokenObject {
 
 module.exports = async function (callback: Truffle.ScriptCallback) {
   try {
-    const tokenList: TokenObject[] = await (
-      await fetch(argv.token_list_url)
-    ).json();
+    let tokenList: TokenObject[];
+    if (argv.token_list) {
+      log.info(`Reading token list from '${argv.token_list}'`);
+      const json = await fs.readFile(argv.token_list, "utf-8");
+      tokenList = JSON.parse(json);
+    } else {
+      log.info("Using default token list");
+      tokenList = DefaultTokenList as TokenObject[];
+    }
+
     const networkId = String(await web3.eth.net.getId());
     const tokenAddresses = [];
     for (const token of tokenList) {

--- a/scripts/add_token_list.ts
+++ b/scripts/add_token_list.ts
@@ -36,6 +36,10 @@ module.exports = async function (callback: Truffle.ScriptCallback) {
     }
 
     const networkId = String(await web3.eth.net.getId());
+    log.info(
+      `Token list with ${tokenList.length} tokens, filtering for network '${networkId}'`,
+    );
+
     const tokenAddresses = [];
     for (const token of tokenList) {
       const address = token.addressByNetwork[networkId];

--- a/scripts/data/tokenList.json
+++ b/scripts/data/tokenList.json
@@ -1,0 +1,218 @@
+[
+  {
+    "id": 1,
+    "name": "Wrapped Ether",
+    "symbol": "WETH",
+    "decimals": 18,
+    "addressByNetwork": {
+      "1": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "4": "0xc778417E063141139Fce010982780140Aa0cD5Ab"
+    },
+    "website": "https://weth.io",
+    "description": "Wrapper of Ether to make it ERC-20 compliant",
+    "rinkeby_faucet": "https://faucet.rinkeby.io/"
+  },
+  {
+    "id": 2,
+    "name": "Tether USD",
+    "symbol": "USDT",
+    "decimals": 6,
+    "addressByNetwork": {
+      "1": "0xdAC17F958D2ee523a2206206994597C13D831ec7",
+      "4": "0xa9881E6459CA05d7D7C95374463928369cD7a90C"
+    },
+    "website": "https://tether.to/",
+    "description": "Fiat enabled collateralized stable coin, that is backed by the most popular fiat currency, USD (US Dollar) in a 1:1 ratio",
+    "rinkeby_faucet": "mint using Team's shared account 0xf85D1a0E1b71e72013Db51139f285C6d5356B712"
+  },
+  {
+    "id": 3,
+    "name": "TrueUSD",
+    "symbol": "TUSD",
+    "decimals": 18,
+    "addressByNetwork": {
+      "1": "0x0000000000085d4780B73119b644AE5ecd22b376",
+      "4": "0x0000000000085d4780B73119b644AE5ecd22b376"
+    },
+    "website": "https://www.trusttoken.com/trueusd",
+    "description": "US Dollar backed stable coin which is totally fiat-collateralized",
+    "rinkeby_faucet": "https://github.com/trusttoken/true-currencies#getting-testnet-tokens"
+  },
+  {
+    "id": 4,
+    "name": "USD Coin",
+    "symbol": "USDC",
+    "decimals": 6,
+    "addressByNetwork": {
+      "1": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "4": "0x4DBCdF9B62e891a7cec5A2568C3F4FAF9E8Abe2b"
+    },
+    "website": "https://www.circle.com/en/usdc",
+    "description": "legitimate built on open standards using Grant Thornton for verifying Circle’s US dollar reserves launched by cryptocurrency finance firm circle Internet financial Ltd and the CENTRE open source consortium launched ",
+    "rinkeby_faucet": "https://app.compound.finance/asset/cUSDC"
+  },
+  {
+    "id": 5,
+    "name": "Paxos Standard",
+    "symbol": "PAX",
+    "decimals": 18,
+    "addressByNetwork": {
+      "1": "0x8E870D67F660D95d5be530380D0eC0bd388289E1",
+      "4": "0xBD6A9921504fae42EaD2024F43305A8ED3890F6f"
+    },
+    "website": "https://www.paxos.com/standard",
+    "description": "Regulated stable coin. PAX is backed by US Dollar in equivalent 1:1. Launched by Paxos Trust Company. Approved by the New York State Department of Financial Services",
+    "rinkeby_faucet": "mint using Team's shared account 0xf85D1a0E1b71e72013Db51139f285C6d5356B712"
+  },
+  {
+    "id": 6,
+    "name": "Gemini dollar",
+    "symbol": "GUSD",
+    "decimals": 2,
+    "addressByNetwork": {
+      "1": "0x056Fd409E1d7A124BD7017459dFEa2F387b6d5Cd",
+      "4": "0x784B46A4331f5c7C495F296AE700652265ab2fC6"
+    },
+    "website": "https://gemini.com/dollar/",
+    "description": "Regulated by the New York State Department of Financial Services launched same day as PAX by Gemini Trust Company. backed by USD",
+    "rinkeby_faucet": "mint using Team's shared account 0xf85D1a0E1b71e72013Db51139f285C6d5356B712. Using ERC20Impl (0x8d54C3af182A5ef4f74e7eCC07aB6182153797bB) contract, call `requestPrint(address, amount). On same contract, use the `lockId` returned from previous call and execute `confirmPrint(lockId)`."
+  },
+  {
+    "id": 7,
+    "name": "DAI Stablecoin",
+    "symbol": "DAI",
+    "decimals": 18,
+    "addressByNetwork": {
+      "1": "0x6B175474E89094C44Da98b954EedeAC495271d0F",
+      "4": "0x5592EC0cfb4dbc12D3aB100b257153436a1f0FEa"
+    },
+    "website": "https://makerdao.com/",
+    "description": "crypto-collateralized cryptocurrency: stable coin which is pegged to USD",
+    "rinkeby_faucet": "https://app.compound.finance/asset/cDAI"
+  },
+  {
+    "id": 8,
+    "name": "Synth sETH",
+    "symbol": "sETH",
+    "decimals": 18,
+    "addressByNetwork": {
+      "1": "0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb",
+      "4": "0x0647b2c7a2a818276154b0fc79557f512b165bc1"
+    },
+    "website": "https://www.synthetix.io",
+    "description": "Tracks the price of Ether (ETH) through price feeds supplied by an oracle",
+    "rinkeby_faucet": null
+  },
+  {
+    "id": 9,
+    "name": "Synth sUSD",
+    "symbol": "sUSD",
+    "decimals": 18,
+    "addressByNetwork": {
+      "1": "0x57Ab1E02fEE23774580C119740129eAC7081e9D3",
+      "4": "0x1b642a124cdfa1e5835276a6ddaa6cfc4b35d52c"
+    },
+    "website": "https://www.synthetix.io/ ",
+    "description": "Tracks the price of a single US Dollar (USD). This Synth always remains constant at 1.",
+    "rinkeby_faucet": "https://rinkeby.etherscan.io/address/0xDFd3CAde426Fc6A014fd2e0E1Cb3158F972A1A0D. Instructions: https://github.com/Synthetixio/synthetix/issues/382#issuecomment-579518740"
+  },
+  {
+    "id": 10,
+    "name": "Synth sBTC",
+    "symbol": "sBTC",
+    "decimals": 18,
+    "addressByNetwork": {
+      "1": "0xfE18be6b3Bd88A2D2A7f928d00292E7a9963CfC6"
+    },
+    "website": "https://www.synthetix.io",
+    "description": "Tracks the price of Bitcoin (BTC) through price feeds supplied by an oracle.",
+    "rinkeby_faucet": null
+  },
+  {
+    "id": 11,
+    "name": "Wrapped BTC",
+    "symbol": "WBTC",
+    "decimals": 8,
+    "addressByNetwork": {
+      "1": "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
+    },
+    "website": "https://www.wbtc.network",
+    "description": "ERC20 token backed 1:1 with Bitcoin",
+    "rinkeby_faucet": null
+  },
+  {
+    "id": 13,
+    "name": "Compound Dai",
+    "symbol": "cDAI",
+    "decimals": 8,
+    "addressByNetwork": {
+      "1": "0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643"
+    },
+    "website": "https://compound.finance/",
+    "description": "Money market protocol to earn interest",
+    "rinkeby_faucet": null
+  },
+  {
+    "id": 15,
+    "name": "Synthetix Network",
+    "symbol": "SNX",
+    "decimals": 18,
+    "addressByNetwork": {
+      "1": "0xC011A72400E58ecD99Ee497CF89E3775d4bd732F",
+      "4": "0x322A3346bf24363f451164d96A5b5cd5A7F4c337"
+    },
+    "website": "https://www.synthetix.io",
+    "description": "The Synthetix Network Token (SNX) gets staked as collateral to back Synths and entitles stakers to receive fees generated by Synth trades on Synthetix.Exchange",
+    "rinkeby_faucet": "https://rinkeby.etherscan.io/address/0xDFd3CAde426Fc6A014fd2e0E1Cb3158F972A1A0D. Instructions: https://github.com/Synthetixio/synthetix/issues/382#issuecomment-579518740"
+  },
+  {
+    "id": 16,
+    "name": "Chai",
+    "symbol": "CHAI",
+    "decimals": 18,
+    "addressByNetwork": {
+      "1": "0x06AF07097C9Eeb7fD685c692751D5C66dB49c215"
+    },
+    "website": "https://chai.money/",
+    "description": "ERC20 wrapper over the Dai Savings Rate",
+    "rinkeby_faucet": null
+  },
+  {
+    "id": 18,
+    "name": "Gnosis Token",
+    "symbol": "GNO",
+    "decimals": 18,
+    "addressByNetwork": {
+      "1": "0x6810e776880C02933D47DB1b9fc05908e5386b96",
+      "4": "0xd0Dab4E640D95E9E8A47545598c33e31bDb53C7c"
+    },
+    "website": "https://gnosis.io",
+    "description": "Native token of the Gnosis ecosystem primary used for generating OWL",
+    "rinkeby_faucet": null
+  },
+  {
+    "id": 19,
+    "name": "Panvala pan",
+    "symbol": "PAN",
+    "decimals": 18,
+    "addressByNetwork": {
+      "1": "0xD56daC73A4d6766464b38ec6D91eB45Ce7457c44"
+    },
+    "website": "https://panvala.com",
+    "description": "Allows to subsidize public goods",
+    "rinkeby_faucet": null
+  },
+  {
+    "id": 0,
+    "name": "OWL",
+    "symbol": "OWL",
+    "decimals": 18,
+    "addressByNetwork": {
+      "1": "0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4",
+      "4": "0xa7D1C04fAF998F9161fC9F800a99A809b84cfc9D"
+    },
+    "website": "https://gnosis.io/tokens",
+    "description": "OWL can be used to pay 1 USD in fees on Gnosis platforms",
+    "rinkeby_faucet": null
+  }
+]


### PR DESCRIPTION
This PR vendors the `dex-js` token list and modifies the script to read token lists from the local file system.

### Test Plan

Run the script and see that it works with and without a specified token list:
```
$ yarn truffle-exec scripts/add_token_list.ts
yarn run v1.21.1
$ sh -c 'npx truffle exec build/common/${0%.*}.js $@' scripts/add_token_list.ts
Using network 'development'.

2020-09-24 20:34:19,506 INFO [scripts.add_token_list] Using default token list
2020-09-24 20:34:19,510 INFO [scripts.add_token_list] Token list with 17 tokens, filtering for network '1600971633613'
2020-09-24 20:34:20,865 INFO [scripts.add_token_list] Attempting to register 0 tokens
Done in 4.61s.
$ yarn truffle-exec scripts/add_token_list.ts --token_list scripts/data/tokenList.json
yarn run v1.21.1
$ sh -c 'npx truffle exec build/common/${0%.*}.js $@' scripts/add_token_list.ts --token_list scripts/data/tokenList.json
> Warning: possible unsupported (undocumented in help) command line option: --token_list
Using network 'development'.

2020-09-24 20:34:27,963 INFO [scripts.add_token_list] Reading token list from 'scripts/data/tokenList.json'
2020-09-24 20:34:27,971 INFO [scripts.add_token_list] Token list with 17 tokens, filtering for network '1600971633613'
2020-09-24 20:34:29,292 INFO [scripts.add_token_list] Attempting to register 0 tokens
Done in 4.47s.
```

Note that no tokens are registered as the token list does not contain any test-net tokens.