### PR TITLE
[Easy] Fix broken version bump in solidity-bytes–utils

### DIFF
--- a/contracts/BatchExchangeViewer.sol
+++ b/contracts/BatchExchangeViewer.sol
@@ -293,7 +293,7 @@ contract BatchExchangeViewer {
 
     function getSellTokenBalance(bytes memory element) public pure returns (uint256) {
         bytes memory slice = element.slice(ADDRESS_WIDTH, 52);
-        return slice.toUint(0);
+        return slice.toUint256(0);
     }
 
     function updateSellTokenBalance(bytes memory element, uint256 amount) public pure returns (bytes memory) {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "rimraf": "^3.0.2",
     "solhint": "^3.2.1",
     "solhint-plugin-prettier": "0.0.5",
-    "solidity-bytes-utils": "0.0.9",
+    "solidity-bytes-utils": "0.1.1",
     "solidity-coverage": "^0.7.11",
     "solium": "^1.2.5",
     "truffle": "^5.1.48",

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,23 +513,7 @@
   resolved "https://registry.yarnpkg.com/@truffle/error/-/error-0.0.7.tgz#e9db39885575647ef08bf624b0c13fe46d41a209"
   integrity sha512-UIfVKsXSXocKnn5+RNklUXNoGd/JVj7V8KmC48TQzmjU33HQI86PX0JDS7SpHMHasI3w9X//1q7Lu7nZtj3Zzg==
 
-"@truffle/hdwallet-provider@^1.0.27", "@truffle/hdwallet-provider@latest":
-  version "1.0.37"
-  resolved "https://registry.yarnpkg.com/@truffle/hdwallet-provider/-/hdwallet-provider-1.0.37.tgz#ff514ab0c17aea91505207b5faa23fe602333794"
-  integrity sha512-LPsMNaBxwpCpDrTgvMGvNtk4c/pDDpZ5AXLrugzK1lVT3SW/DCpjPDgcUckOCNNAx8ktG0PzJbiVFM6Ami92nQ==
-  dependencies:
-    "@trufflesuite/web3-provider-engine" "14.0.7"
-    any-promise "^1.3.0"
-    bindings "^1.5.0"
-    bip39 "^2.4.2"
-    ethereum-protocol "^1.0.1"
-    ethereumjs-tx "^1.0.0"
-    ethereumjs-util "^6.1.0"
-    ethereumjs-wallet "^0.6.3"
-    source-map-support "^0.5.19"
-    web3 "1.2.1"
-
-"@truffle/hdwallet-provider@^1.0.42":
+"@truffle/hdwallet-provider@^1.0.27", "@truffle/hdwallet-provider@^1.0.42":
   version "1.0.42"
   resolved "https://registry.yarnpkg.com/@truffle/hdwallet-provider/-/hdwallet-provider-1.0.42.tgz#0c906b67f0950ce8b85aaa50e5bf02418c517e82"
   integrity sha512-Q6+Pn6x9oLE0lTk72xC4V7il/UoI2i6dy8kSfh4xjYkE585SO9sc7ndXqX5K+epPolr7UAndEe7Lv6mHjiPmsQ==
@@ -544,6 +528,22 @@
     ethereumjs-util "^6.1.0"
     ethereumjs-wallet "^0.6.3"
     source-map-support "^0.5.19"
+
+"@truffle/hdwallet-provider@latest":
+  version "1.0.37"
+  resolved "https://registry.yarnpkg.com/@truffle/hdwallet-provider/-/hdwallet-provider-1.0.37.tgz#ff514ab0c17aea91505207b5faa23fe602333794"
+  integrity sha512-LPsMNaBxwpCpDrTgvMGvNtk4c/pDDpZ5AXLrugzK1lVT3SW/DCpjPDgcUckOCNNAx8ktG0PzJbiVFM6Ami92nQ==
+  dependencies:
+    "@trufflesuite/web3-provider-engine" "14.0.7"
+    any-promise "^1.3.0"
+    bindings "^1.5.0"
+    bip39 "^2.4.2"
+    ethereum-protocol "^1.0.1"
+    ethereumjs-tx "^1.0.0"
+    ethereumjs-util "^6.1.0"
+    ethereumjs-wallet "^0.6.3"
+    source-map-support "^0.5.19"
+    web3 "1.2.1"
 
 "@truffle/interface-adapter@^0.3.0":
   version "0.3.3"
@@ -8234,10 +8234,10 @@ solhint@^3.2.1:
   optionalDependencies:
     prettier "^1.14.3"
 
-solidity-bytes-utils@0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/solidity-bytes-utils/-/solidity-bytes-utils-0.0.9.tgz#c37ff4abb338d71443859b3eca3382c113383a81"
-  integrity sha512-ApGN/l2XlK8hL4JxkCg3ilwTMPh+PB7CN33imDMpsZoJyhTdXV3tUWCbAKYoa69Zd1mc5oIyYdTRGwsqGRW3bQ==
+solidity-bytes-utils@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/solidity-bytes-utils/-/solidity-bytes-utils-0.1.1.tgz#6cf66d03a79dac9412167ff12623b99caca9c667"
+  integrity sha512-SHL05zPsc5LVDNi8Jd9YkMf+5L2ZM0DVfLaN/3DsliEsz7RCBqzaOJbMBG7UEofB7x7hv7ogQtUKLBsBx4Le2Q==
   dependencies:
     "@truffle/hdwallet-provider" latest
 


### PR DESCRIPTION
This change fixes the broken build introduced by dependabot when attempting to bump our dependency on solidity-byte-utils. That is, a breaking change was introduced on their smart contract we had to make a one line change in `BatchExchange.sol` in order to continue.

Breaking change was introduced here:

https://github.com/GNSPS/solidity-bytes-utils/pull/31

when they changed `toUint` to `toUint256`