### PR TITLE
[Easy] bump project version v0.4.3 to v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gnosis.pm/dex-contracts",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Contracts for dFusion multi-token batch auction exchange",
   "main": "build/common/src/index.js",
   "types": "build/common/src/index.d.ts",


### PR DESCRIPTION
New release version will have the following info

## Title

Updated migration script for integration

## Description

This version introduced one breaking change to the migration script used by projects which integrate with BatchExchange contracts. Observe now that `migrateBatchExchange` function now takes the BatchExchange contract as an input parameter.

- Update BatchExchange migration script (#1022)
- Vendor dex-js token list for script (#992)

Several dependency version bumps

- Bump eslint-config-prettier from 6.12.0 to 6.13.0 (#1021)
- Bump mocha from 8.1.3 to 8.2.0 (#1020)
- Bump @types/chai from 4.2.13 to 4.2.14 (#1019)
- Bump solhint from 3.2.1 to 3.2.2 (#1018)
- Bump yargs from 16.0.3 to 16.1.0 (#1017)
- Bump truffle from 5.1.48 to 5.1.49 (#1016)
- Bump @truffle/contract from 4.2.25 to 4.2.26 (#1015)
- Bump eth-gas-reporter from 0.2.17 to 0.2.18 (#1014)
- [Easy] Fix broken version bump in solidity-bytes–utils (#1013)
- Bump ganache-cli from 6.11.0 to 6.12.0 (#1012)
- Bump eslint from 7.10.0 to 7.11.0 (#1011)
- Bump truffle from 5.1.47 to 5.1.48 (#1010)
- Bump @truffle/contract from 4.2.24 to 4.2.25 (#1009)
- Bump solidity-coverage from 0.7.10 to 0.7.11 (#1008)
- Bump prettier-plugin-solidity from 1.0.0-alpha.58 to 1.0.0-alpha.59 (#1007)
- Bump @types/chai from 4.2.12 to 4.2.13 (#1006)
- Bump typechain from 2.0.0 to 2.0.1 (#1005)
- Bump @truffle/contract from 4.2.23 to 4.2.24 (#1004)
- Bump truffle from 5.1.46 to 5.1.47 (#1003)
- Bump ganache-cli from 6.10.2 to 6.11.0 (#1000)
- Bump bignumber.js from 9.0.0 to 9.0.1 (#999)
- Bump prettier-plugin-solidity from 1.0.0-alpha.57 to 1.0.0-alpha.58 (#998)
- Bump eslint from 7.9.0 to 7.10.0 (#997)
- Bump truffle from 5.1.44 to 5.1.46 (#996)
- Bump @truffle/contract from 4.2.22 to 4.2.23 (#995)
- Bump eslint-config-prettier from 6.11.0 to 6.12.0 (#994)
- Bump solhint from 3.2.0 to 3.2.1 (#993)
- Bump typescript from 4.0.2 to 4.0.3 (#984)
- Bump web3-eth-contract from 1.2.11 to 1.3.0 (#981)
- Bump prettier from 2.1.1 to 2.1.2 (#980)
- Bump web3 from 1.2.11 to 1.3.0 (#982)
- Bump web3-core from 1.2.11 to 1.3.0 (#978)
- Bump eslint from 7.8.1 to 7.9.0 (#977)
- Bump cross-fetch from 3.0.5 to 3.0.6 (#976)
- Bump truffle from 5.1.43 to 5.1.44 (#975)
- Bump @truffle/contract from 4.2.21 to 4.2.22 (#974)
