### PR TITLE
[Easy] update OWL token dependency

### DIFF
--- a/contracts/BatchExchange.sol
+++ b/contracts/BatchExchange.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.0;
 import "./EpochTokenLocker.sol";
 import "@gnosis.pm/solidity-data-structures/contracts/libraries/IdToAddressBiMap.sol";
 import "@gnosis.pm/solidity-data-structures/contracts/libraries/IterableAppendOnlySet.sol";
-import "@gnosis.pm/owl-token/contracts/TokenOWL.sol";
+import "@gnosis.pm/owl-token/contracts/5/TokenOWL.sol";
 import "@openzeppelin/contracts/utils/SafeCast.sol";
 import "solidity-bytes-utils/contracts/BytesLib.sol";
 import "./libraries/TokenConservation.sol";

--- a/contracts/DevDependencies.sol
+++ b/contracts/DevDependencies.sol
@@ -5,6 +5,6 @@ pragma solidity ^0.5.0;
 //  contracts during development.
 //
 //  For other environments, only use compiled contracts from the NPM package.
-import "@gnosis.pm/owl-token/contracts/TokenOWLProxy.sol";
+import "@gnosis.pm/owl-token/contracts/5/TokenOWLProxy.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20Detailed.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20Mintable.sol";

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@gnosis.pm/mock-contract": "^3.0.8",
-    "@gnosis.pm/owl-token": "^3.2.0",
+    "@gnosis.pm/owl-token": "^4.0.0",
     "@gnosis.pm/solidity-data-structures": "1.3.5",
     "@gnosis.pm/util-contracts": "2.0.7",
     "@openzeppelin/contracts": "=2.5.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@gnosis.pm/mock-contract": "^3.0.8",
-    "@gnosis.pm/owl-token": "^3.1.0",
+    "@gnosis.pm/owl-token": "^3.2.0",
     "@gnosis.pm/solidity-data-structures": "1.3.5",
     "@gnosis.pm/util-contracts": "2.0.7",
     "@openzeppelin/contracts": "=2.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,13 +278,14 @@
   dependencies:
     ethereumjs-abi "^0.6.5"
 
-"@gnosis.pm/owl-token@^3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/owl-token/-/owl-token-3.1.0.tgz#f7da8c43cd6bbcc8c871a44eaef767c86ac23458"
-  integrity sha512-DxM22gk/PRY24Y4FXPfvr+F5rNB6JDPkd0NAEBE9sjLICfn5VK0X4kRc33obUP9mG1nyUFroWUPSeqHQQ7iXAQ==
+"@gnosis.pm/owl-token@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/owl-token/-/owl-token-3.2.0.tgz#1226ac55ca8a8cb2cdbd2f293ae2ae10b689881e"
+  integrity sha512-dK4+dMlHmYewG284zPFhggEfTh+PYqaoPREQg+2k3HwkhwqWr/ZXEz98MQf1IhZoFnGKD0mrCqsye3RBm7fRsw==
   dependencies:
     "@gnosis.pm/gno-token" "^2.0.0"
     "@gnosis.pm/util-contracts" "^2.0.0"
+    openzeppelin-solidity "1.12.0"
     verify-on-etherscan "^1.1.1"
 
 "@gnosis.pm/solidity-data-structures@1.3.5":
@@ -6909,6 +6910,11 @@ onetime@^2.0.0:
   integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
   dependencies:
     mimic-fn "^1.0.0"
+
+openzeppelin-solidity@1.12.0:
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/openzeppelin-solidity/-/openzeppelin-solidity-1.12.0.tgz#7b9c55975e73370d4541e3442b30cb3d91ac973a"
+  integrity sha512-WlorzMXIIurugiSdw121RVD5qA3EfSI7GybTn+/Du0mPNgairjt29NpVTAaH8eLjAeAwlw46y7uQKy0NYem/gA==
 
 optionator@^0.8.1, optionator@^0.8.2:
   version "0.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,10 +278,10 @@
   dependencies:
     ethereumjs-abi "^0.6.5"
 
-"@gnosis.pm/owl-token@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@gnosis.pm/owl-token/-/owl-token-3.2.0.tgz#1226ac55ca8a8cb2cdbd2f293ae2ae10b689881e"
-  integrity sha512-dK4+dMlHmYewG284zPFhggEfTh+PYqaoPREQg+2k3HwkhwqWr/ZXEz98MQf1IhZoFnGKD0mrCqsye3RBm7fRsw==
+"@gnosis.pm/owl-token@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@gnosis.pm/owl-token/-/owl-token-4.0.0.tgz#228be5dbd6cbc06616bcced1fa6791050af6ee4a"
+  integrity sha512-Ia+3BwEqcywlGbg1s3EU8l40ZkP/hiKDr8A8lQb705iIE2pSqakG1NhwswExuNYMnwAK5AvplVRa5Fs0K5UFZA==
   dependencies:
     "@gnosis.pm/gno-token" "^2.0.0"
     "@gnosis.pm/util-contracts" "^2.0.0"


### PR DESCRIPTION
The most recent release of OWL token changed the directory structure of the contracts folder (splitting the different solidity versions). Thus we had to adjust our import statements