### PR TITLE
Add solution reversion to graph data script

### DIFF
--- a/scripts/ganache/setup_thegraph_data.ts
+++ b/scripts/ganache/setup_thegraph_data.ts
@@ -99,7 +99,20 @@ module.exports = async function (callback: Truffle.ScriptCallback) {
       from: user1Address,
     });
 
-    // Submit solution
+    // Submit suboptimal solution
+    await submitSolution(
+      "Partial solution",
+      batchId,
+      solutionSubmissionParams(
+        basicTrade.solutions[1],
+        userAddresses,
+        orderIds,
+      ),
+      solverAddress,
+      exchange,
+    );
+
+    // Submit optimal solution
     await submitSolution(
       "Full solution",
       batchId,

--- a/scripts/util.ts
+++ b/scripts/util.ts
@@ -140,7 +140,7 @@ export async function submitSolution(
   - Token ids for prices: ${solution.tokenIdsForPrice.join(", ")}`);
   const objectiveValue = await exchange.submitSolution(
     batchId,
-    1,
+    solution.objectiveValue,
     solution.owners,
     solution.touchedorderIds,
     solution.volumes,


### PR DESCRIPTION
This PR adds a competitive solution submission (suboptimal replaced by optimal solution) to our graph data script, so that we can use it for e2e tests in https://github.com/gnosis/dex-subgraph/pull/119

### Test Plan

Make sure script runs without errors against ganache.