### PR TITLE
[Travis] Use newest Ubuntu version in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
+dist: focal
 node_js:
   - 12
 cache: yarn


### PR DESCRIPTION
We are still seeing a lot of sporadic failures in [travis](https://travis-ci.com/github/gnosis/dex-contracts/builds) which seem related to ganache-cli crashing on our large test instance. I already tried reverting the latest ganache release (since this bump coincided with the start of the issues), but it still seems to be happening.

@nlordell suggested on slack that @e00E fixed a similar issue in ethcontracts by bumping the ubuntu version of travis to a more recent one. This is what this PR does for dex-contracts

### Test Plan

🤞 that travis starts looking more ☀️ 