### PR TITLE
Update package publication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ script:
   - yarn test-contracts --grep @skip-on-coverage
   - yarn test-ts
 before_deploy:
+  - export PACKAGE_NAME=$(jq -r '.name' package.json)
   - export PACKAGE_VERSION=$(jq -r '.version' package.json)
   - test "v$PACKAGE_VERSION" = "$TRAVIS_TAG"
   - mkdir -p deploy
@@ -31,12 +32,15 @@ deploy:
   local_dir: deploy
   skip_cleanup: true
   region: $AWS_REGION
+  upload-dir: dex-contracts
   on:
     tags: true
 after_deploy:
   - >
-    curl -X POST
-    -F "token=$GITLAB_TOKEN"
-    -F "ref=master"
-    -F "variables[PACKAGE_VERSION]=$PACKAGE_VERSION"
-    https://gitlab.gnosisdev.com/api/v4/projects/$GITLAB_PROJECT/trigger/pipeline
+    curl --silent --request POST
+         --form-string "token=$GITLAB_TRIGGER_TOKEN"
+         --form-string "ref=master"
+         --form-string "variables[PROJECT]=$PACKAGE_NAME"
+         --form-string "variables[VERSION]=$PACKAGE_VERSION"
+         --form-string "variables[TOKEN]=$GITLAB_TRIGGER_TOKEN"
+         "$PUBLISH_SERVER"


### PR DESCRIPTION
The GitLab service that publishes to NPM has been changed to accommodate publishing other packages (for example [gp-v2](https://github.com/gnosis/gp-v2-contracts/pull/468)).
This PR updates the publish mechanism of this repo to use the updated version.

I already made the following changes to the environment in Travis:
- deleted `GITLAB_TOKEN`, `GITLAB_PROJECT` 
- added `GITLAB_TRIGGER_TOKEN`, `PUBLISH_SERVER`
- updated `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` (the old ones were expired)

DevOps confirm that they the credentials can be used to write to the existing folder `dex-contracts`.

The changes are untested.